### PR TITLE
Cross-device offload M0: VulkanBackend : IBackend + VulkanTensor (#53)

### DIFF
--- a/src/DotLLM.Vulkan/VulkanBackend.cs
+++ b/src/DotLLM.Vulkan/VulkanBackend.cs
@@ -1,0 +1,209 @@
+using DotLLM.Core.Backends;
+using DotLLM.Core.Tensors;
+using DotLLM.Vulkan.Interop;
+
+namespace DotLLM.Vulkan;
+
+/// <summary>
+/// GPU backend using Vulkan compute via raw P/Invoke. Supports single-device
+/// operations against the first available (or
+/// <c>DOTLLM_VULKAN_DEVICE_VENDOR</c>-targeted) Vulkan device.
+/// Multi-device operations (<see cref="AllReduce"/>, <see cref="Send"/>,
+/// <see cref="Receive"/>) throw <see cref="NotSupportedException"/> — they are
+/// deferred to the async-pipelining milestone (M3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AllocateOnDevice"/> produces a <see cref="VulkanTensor"/> backed
+/// by a device-local <c>VkBuffer</c>. The returned tensor's
+/// <see cref="VulkanTensor.DataPointer"/> is the opaque <c>VkBuffer</c> handle;
+/// it is NOT a host-accessible address.
+/// </para>
+/// <para>
+/// <see cref="CopyBetweenDevices"/> routes:
+/// <list type="bullet">
+///   <item>Host → Vulkan: alloc HOST_VISIBLE staging buffer, map + copy FP32 bytes,
+///     synchronous <c>vkCmdCopyBuffer</c> staging → device-local, dispose staging.
+///     This is the same path as <c>VulkanKvCache.IngestFromHost</c>.</item>
+///   <item>Vulkan → Host: synchronous <c>vkCmdCopyBuffer</c> device-local →
+///     HOST_VISIBLE staging, map + copy FP32 bytes out, dispose staging.</item>
+///   <item>Vulkan ↔ Vulkan (device 0 → device 0): not yet supported;
+///     throws <see cref="NotSupportedException"/>.</item>
+/// </list>
+/// All operations are synchronous (fence wait). Async pipelining via Vulkan
+/// timeline semaphores is M3 scope.
+/// </para>
+/// </remarks>
+public sealed class VulkanBackend : IBackend
+{
+    private readonly VulkanDevice _device;
+
+    /// <inheritdoc/>
+    /// <remarks>Always 1 — this backend binds to a single Vulkan physical device.</remarks>
+    public int DeviceCount => 1;
+
+    /// <summary>
+    /// Creates a Vulkan backend, initialising the Vulkan loader and selecting
+    /// the first available (or vendor-targeted) physical device.
+    /// </summary>
+    /// <exception cref="VulkanException">Thrown when no Vulkan device is available.</exception>
+    public VulkanBackend()
+    {
+        _device = VulkanDevice.Create();
+    }
+
+    /// <summary>
+    /// Creates a Vulkan backend that borrows an existing <see cref="VulkanDevice"/>.
+    /// The device is NOT disposed when this backend is disposed — the caller
+    /// retains ownership. Useful when the device is already held by a
+    /// <see cref="VulkanTransformerModel"/> that must outlive the backend reference.
+    /// </summary>
+    /// <param name="device">An already-created Vulkan device to borrow.</param>
+    public VulkanBackend(VulkanDevice device)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+        _device = device;
+        _ownsDevice = false;
+    }
+
+    private readonly bool _ownsDevice = true;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Allocates a device-local Vulkan buffer of the required byte size and
+    /// wraps it in a <see cref="VulkanTensor"/>. <paramref name="deviceId"/>
+    /// must be 0 (this backend has exactly one device).
+    /// </remarks>
+    public ITensor AllocateOnDevice(int deviceId, TensorShape shape, DType dtype)
+    {
+        if (deviceId != 0)
+            throw new ArgumentException(
+                $"VulkanBackend has DeviceCount=1 — only deviceId=0 is valid, got {deviceId}.",
+                nameof(deviceId));
+
+        return VulkanTensor.Allocate(_device, shape, dtype, deviceId: 0);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// Exactly one of <paramref name="source"/> and <paramref name="destination"/>
+    /// must be a <see cref="VulkanTensor"/> (deviceId=0); the other must be a
+    /// host tensor (deviceId=-1) with a valid <see cref="ITensor.DataPointer"/>.
+    /// </para>
+    /// <para>
+    /// Host → Vulkan: allocates a HOST_VISIBLE staging buffer, maps it and
+    /// copies from <c>source.DataPointer</c>, then issues a synchronous
+    /// <c>vkCmdCopyBuffer</c> staging → device-local.
+    /// </para>
+    /// <para>
+    /// Vulkan → Host: issues a synchronous <c>vkCmdCopyBuffer</c> device-local →
+    /// HOST_VISIBLE staging, maps the staging buffer and copies to
+    /// <c>destination.DataPointer</c>.
+    /// </para>
+    /// </remarks>
+    public unsafe void CopyBetweenDevices(ITensor source, ITensor destination)
+    {
+        if (source.ByteCount != destination.ByteCount)
+            throw new ArgumentException(
+                $"Source ({source.ByteCount} bytes) and destination ({destination.ByteCount} bytes) sizes differ.");
+
+        long bytes = source.ByteCount;
+
+        if (source.DeviceId == -1 && destination.DeviceId == 0)
+        {
+            // Host → Vulkan: staging copy, same pattern as VulkanKvCache.IngestFromHost
+            var dst = CastToVulkanTensor(destination, nameof(destination));
+            using var staging = _device.Allocate(bytes);
+            MapAndCopyIn(staging, source.DataPointer, bytes);
+            _device.CopyBufferRangeSynchronous(staging, dst.DeviceBuffer,
+                srcOffset: 0, dstOffset: 0, size: (ulong)bytes);
+        }
+        else if (source.DeviceId == 0 && destination.DeviceId == -1)
+        {
+            // Vulkan → Host: staging copy then map-read
+            var src = CastToVulkanTensor(source, nameof(source));
+            using var staging = _device.Allocate(bytes);
+            _device.CopyBufferRangeSynchronous(src.DeviceBuffer, staging,
+                srcOffset: 0, dstOffset: 0, size: (ulong)bytes);
+            MapAndCopyOut(staging, destination.DataPointer, bytes);
+        }
+        else
+        {
+            throw new NotSupportedException(
+                $"VulkanBackend.CopyBetweenDevices does not support {source.DeviceId}→{destination.DeviceId}. "
+                + "Supported: host(-1)→Vulkan(0) and Vulkan(0)→host(-1).");
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AllReduce(ReadOnlySpan<ITensor> tensors) =>
+        throw new NotSupportedException(
+            "VulkanBackend does not support AllReduce (requires multi-device + timeline semaphores, M3 scope).");
+
+    /// <inheritdoc/>
+    public void Send(ITensor tensor, int targetDevice) =>
+        throw new NotSupportedException(
+            "VulkanBackend does not support Send (requires multi-device + timeline semaphores, M3 scope).");
+
+    /// <inheritdoc/>
+    public ITensor Receive(int sourceDevice, TensorShape shape, DType dtype) =>
+        throw new NotSupportedException(
+            "VulkanBackend does not support Receive (requires multi-device + timeline semaphores, M3 scope).");
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_ownsDevice)
+            _device.Dispose();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static VulkanTensor CastToVulkanTensor(ITensor tensor, string paramName)
+    {
+        if (tensor is not VulkanTensor vt)
+            throw new ArgumentException(
+                $"Expected a VulkanTensor for deviceId=0 but got {tensor.GetType().Name}.",
+                paramName);
+        return vt;
+    }
+
+    /// <summary>
+    /// Maps <paramref name="staging"/> (HOST_VISIBLE) and copies
+    /// <paramref name="bytes"/> bytes FROM <paramref name="hostPtr"/> into it.
+    /// </summary>
+    private unsafe void MapAndCopyIn(VulkanDevice.Buffer staging, nint hostPtr, long bytes)
+    {
+        VulkanApi.vkMapMemory(_device.Handle, staging.Memory, 0, (ulong)bytes, 0, out nint mapped)
+            .ThrowOnError("vkMapMemory VulkanBackend H2D staging");
+        try
+        {
+            System.Buffer.MemoryCopy((void*)hostPtr, (void*)mapped, bytes, bytes);
+        }
+        finally
+        {
+            VulkanApi.vkUnmapMemory(_device.Handle, staging.Memory);
+        }
+    }
+
+    /// <summary>
+    /// Maps <paramref name="staging"/> (HOST_VISIBLE) and copies
+    /// <paramref name="bytes"/> bytes TO <paramref name="hostPtr"/> from it.
+    /// </summary>
+    private unsafe void MapAndCopyOut(VulkanDevice.Buffer staging, nint hostPtr, long bytes)
+    {
+        VulkanApi.vkMapMemory(_device.Handle, staging.Memory, 0, (ulong)bytes, 0, out nint mapped)
+            .ThrowOnError("vkMapMemory VulkanBackend D2H staging");
+        try
+        {
+            System.Buffer.MemoryCopy((void*)mapped, (void*)hostPtr, bytes, bytes);
+        }
+        finally
+        {
+            VulkanApi.vkUnmapMemory(_device.Handle, staging.Memory);
+        }
+    }
+}

--- a/src/DotLLM.Vulkan/VulkanDevice.cs
+++ b/src/DotLLM.Vulkan/VulkanDevice.cs
@@ -295,6 +295,21 @@ public sealed class VulkanDevice : IDisposable
         VulkanApi.vkEnumeratePhysicalDevices(instance, ref count, devices)
             .ThrowOnError("vkEnumeratePhysicalDevices");
 
+        // Manual override (testing / iGPU targeting): DOTLLM_VULKAN_DEVICE_INDEX picks a device by
+        // enumeration index; DOTLLM_VULKAN_DEVICE_VENDOR (hex, e.g. 0x8086) picks the first device of
+        // that PCI vendor. Either lets us force the integrated Intel Arc on a box where the scorer would
+        // otherwise pick the discrete NVIDIA. Falls through to scoring if unset/invalid.
+        nint forced = ResolveForcedDevice(devices);
+        if (forced != 0)
+        {
+            VulkanApi.vkGetPhysicalDeviceProperties(forced, out var fp);
+            name = ReadDeviceName(fp);
+            vendor = fp.vendorID;
+            type = fp.deviceType;
+            apiVersion = fp.apiVersion;
+            return forced;
+        }
+
         // Score every device. Prefer: discrete > integrated > other/CPU.
         // Within discrete, prefer AMD/NVIDIA over Intel (Intel rarely has dGPUs,
         // but if one is present it's often weaker than an AMD/NVIDIA dGPU).
@@ -327,6 +342,34 @@ public sealed class VulkanDevice : IDisposable
         type = bestType;
         apiVersion = bestApi;
         return bestDev;
+    }
+
+    /// <summary>
+    /// Resolves a manually-forced physical device from environment overrides, or 0 if none/invalid.
+    /// <c>DOTLLM_VULKAN_DEVICE_INDEX</c> selects by enumeration index; <c>DOTLLM_VULKAN_DEVICE_VENDOR</c>
+    /// (hex PCI vendor, e.g. 0x8086 for Intel) selects the first device of that vendor.
+    /// </summary>
+    private static nint ResolveForcedDevice(nint[] devices)
+    {
+        string? idxEnv = Environment.GetEnvironmentVariable("DOTLLM_VULKAN_DEVICE_INDEX");
+        if (int.TryParse(idxEnv, out int idx) && idx >= 0 && idx < devices.Length)
+            return devices[idx];
+
+        string? vendorEnv = Environment.GetEnvironmentVariable("DOTLLM_VULKAN_DEVICE_VENDOR");
+        if (!string.IsNullOrEmpty(vendorEnv))
+        {
+            string hex = vendorEnv.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? vendorEnv[2..] : vendorEnv;
+            if (uint.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out uint wantVendor))
+            {
+                foreach (var dev in devices)
+                {
+                    VulkanApi.vkGetPhysicalDeviceProperties(dev, out var props);
+                    if (props.vendorID == wantVendor)
+                        return dev;
+                }
+            }
+        }
+        return 0;
     }
 
     // Packed Vulkan API version helpers. Layout: variant(3) | major(7) | minor(10) | patch(12).

--- a/src/DotLLM.Vulkan/VulkanTensor.cs
+++ b/src/DotLLM.Vulkan/VulkanTensor.cs
@@ -1,0 +1,87 @@
+using DotLLM.Core.Tensors;
+
+namespace DotLLM.Vulkan;
+
+/// <summary>
+/// Tensor implementation backed by a device-local Vulkan buffer.
+/// The <see cref="DataPointer"/> holds the <c>VkBuffer</c> handle — it is
+/// an opaque GPU resource pointer and must NOT be dereferenced from C#.
+/// Use <see cref="VulkanBackend.CopyBetweenDevices"/> (which down-casts to this
+/// type to access <see cref="DeviceBuffer"/> directly) rather than reading or
+/// writing via <see cref="DataPointer"/>.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>CudaTensor</c>'s "opaque device pointer" convention: the Vulkan
+/// runtime owns the allocation; .NET code never touches the bytes directly.
+/// Disposal destroys the backing <c>VkBuffer</c> + <c>VkDeviceMemory</c>.
+/// </remarks>
+public sealed class VulkanTensor : ITensor
+{
+    private readonly VulkanDevice.Buffer _buffer;
+    private bool _disposed;
+
+    /// <inheritdoc/>
+    public TensorShape Shape { get; }
+
+    /// <inheritdoc/>
+    public DType DType { get; }
+
+    /// <inheritdoc/>
+    public int DeviceId { get; }
+
+    /// <summary>
+    /// The underlying Vulkan buffer. Use this (not <see cref="DataPointer"/>)
+    /// when issuing <c>vkCmd*</c> operations or staging copies.
+    /// </summary>
+    public VulkanDevice.Buffer DeviceBuffer => _buffer;
+
+    /// <summary>
+    /// Returns the <c>VkBuffer</c> handle as an opaque <see cref="nint"/>.
+    /// This is NOT a host-accessible memory address — do not dereference it.
+    /// </summary>
+    public nint DataPointer => _buffer.Handle;
+
+    /// <inheritdoc/>
+    public TensorMetadata Metadata => new(Shape, DType, DeviceId, DataPointer);
+
+    /// <inheritdoc/>
+    public long ElementCount { get; }
+
+    /// <inheritdoc/>
+    public long ByteCount { get; }
+
+    private VulkanTensor(VulkanDevice.Buffer buffer, TensorShape shape, DType dtype, int deviceId)
+    {
+        _buffer = buffer;
+        Shape = shape;
+        DType = dtype;
+        DeviceId = deviceId;
+        ElementCount = shape.ElementCount;
+        ByteCount = dtype.ComputeByteCount(ElementCount);
+    }
+
+    /// <summary>
+    /// Allocates a device-local Vulkan buffer of the correct size and wraps it
+    /// in a <see cref="VulkanTensor"/>. The buffer contents are uninitialised.
+    /// </summary>
+    /// <param name="device">The Vulkan device that owns the allocation.</param>
+    /// <param name="shape">Tensor shape.</param>
+    /// <param name="dtype">Element data type.</param>
+    /// <param name="deviceId">Logical device ID (typically 0 for the single Vulkan device).</param>
+    /// <returns>A newly allocated tensor. Caller owns disposal.</returns>
+    public static VulkanTensor Allocate(VulkanDevice device, TensorShape shape, DType dtype, int deviceId = 0)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+        long bytes = dtype.ComputeByteCount(shape.ElementCount);
+        var buffer = device.AllocateDeviceLocal(bytes);
+        return new VulkanTensor(buffer, shape, dtype, deviceId);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _buffer.Dispose();
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Vulkan/VulkanBackendTests.cs
+++ b/tests/DotLLM.Tests.Unit/Vulkan/VulkanBackendTests.cs
@@ -1,0 +1,174 @@
+using DotLLM.Core.Tensors;
+using DotLLM.Vulkan;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Vulkan;
+
+/// <summary>
+/// Tests for <see cref="VulkanBackend"/>: device availability, tensor allocation,
+/// and host↔device round-trip correctness.
+/// </summary>
+[Trait("Category", "GPU")]
+[Collection("VulkanKernels")]
+public class VulkanBackendTests
+{
+    // ─────────────────────────────────────────────────────────────────
+    // Construction and device identity
+    // ─────────────────────────────────────────────────────────────────
+
+    [SkippableFact]
+    public void DeviceCount_IsOne_WhenVulkanAvailable()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+
+        using var backend = new VulkanBackend();
+
+        Assert.Equal(1, backend.DeviceCount);
+    }
+
+    [SkippableFact]
+    public void AllocateOnDevice_ReturnsVulkanTensor_WithCorrectMetadata()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+
+        using var backend = new VulkanBackend();
+        var shape = new TensorShape(4, 8);
+
+        using var tensor = backend.AllocateOnDevice(deviceId: 0, shape, DType.Float32);
+
+        Assert.IsType<VulkanTensor>(tensor);
+        Assert.Equal(shape, tensor.Shape);
+        Assert.Equal(DType.Float32, tensor.DType);
+        Assert.Equal(0, tensor.DeviceId);
+        Assert.Equal(32L, tensor.ElementCount);   // 4 × 8
+        Assert.Equal(128L, tensor.ByteCount);      // 32 × 4 bytes
+    }
+
+    [SkippableFact]
+    public void AllocateOnDevice_DeviceIdNot0_Throws()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+
+        using var backend = new VulkanBackend();
+
+        Assert.Throws<ArgumentException>(
+            () => backend.AllocateOnDevice(deviceId: 1, new TensorShape(4), DType.Float32));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Round-trip: host → Vulkan → host, bit-exact
+    // ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <see cref="VulkanBackend.CopyBetweenDevices"/> correctly
+    /// transfers FP32 data host→device then device→host with bit-exact results.
+    /// This is a pure byte-copy path — any mismatch indicates a real bug.
+    /// </summary>
+    [SkippableFact]
+    public void CopyBetweenDevices_RoundTrip_BitExact()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+
+        const int elementCount = 256;
+        var shape = new TensorShape(elementCount);
+        var dtype = DType.Float32;
+
+        // Build deterministic source data.
+        float[] original = new float[elementCount];
+        for (int i = 0; i < elementCount; i++)
+            original[i] = (i % 37) * 0.01f - 0.5f;
+
+        using var backend = new VulkanBackend();
+
+        // Allocate host (CPU) source tensor.
+        using var hostSrc = UnmanagedTensor.Allocate(shape, dtype, deviceId: -1);
+        WriteFloats(hostSrc.DataPointer, original);
+
+        // Allocate device-local Vulkan tensor.
+        using var gpuTensor = backend.AllocateOnDevice(deviceId: 0, shape, dtype);
+
+        // Allocate host destination tensor (for the download).
+        using var hostDst = UnmanagedTensor.Allocate(shape, DType.Float32, deviceId: -1);
+
+        // Upload: host → Vulkan.
+        backend.CopyBetweenDevices(hostSrc, gpuTensor);
+
+        // Download: Vulkan → host.
+        backend.CopyBetweenDevices(gpuTensor, hostDst);
+
+        // Verify bit-exact equality — this is pure byte-copy, no conversion.
+        float[] result = ReadFloats(hostDst.DataPointer, elementCount);
+        for (int i = 0; i < elementCount; i++)
+        {
+            Assert.Equal(original[i], result[i]);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the Intel Arc iGPU (vendor 0x8086) is selected when
+    /// <c>DOTLLM_VULKAN_DEVICE_VENDOR=0x8086</c> is set in the environment.
+    /// This guards against tests silently running on the wrong GPU when
+    /// multiple Vulkan devices are present.
+    /// </summary>
+    [SkippableFact]
+    public void VulkanBackend_SelectsIntelArc_WhenVendorEnvSet()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+        Skip.If(
+            Environment.GetEnvironmentVariable("DOTLLM_VULKAN_DEVICE_VENDOR") != "0x8086",
+            "DOTLLM_VULKAN_DEVICE_VENDOR not set to 0x8086; skipping Intel Arc vendor check.");
+
+        // The env var is read by VulkanDevice.Create() -> ResolveForcedDevice().
+        // We need to probe the device directly to check the vendor ID.
+        using var device = VulkanDevice.Create();
+
+        Assert.Equal(0x8086u, device.VendorId);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Error cases
+    // ─────────────────────────────────────────────────────────────────
+
+    [SkippableFact]
+    public void CopyBetweenDevices_SizeMismatch_Throws()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+
+        using var backend = new VulkanBackend();
+        using var hostSrc = UnmanagedTensor.Allocate(new TensorShape(4), DType.Float32, deviceId: -1);
+        using var gpuDst = backend.AllocateOnDevice(deviceId: 0, new TensorShape(8), DType.Float32);
+
+        Assert.Throws<ArgumentException>(
+            () => backend.CopyBetweenDevices(hostSrc, gpuDst));
+    }
+
+    [SkippableFact]
+    public void CopyBetweenDevices_HostToHost_Throws()
+    {
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan device available.");
+
+        using var backend = new VulkanBackend();
+        using var hostA = UnmanagedTensor.Allocate(new TensorShape(4), DType.Float32, deviceId: -1);
+        using var hostB = UnmanagedTensor.Allocate(new TensorShape(4), DType.Float32, deviceId: -1);
+
+        Assert.Throws<NotSupportedException>(
+            () => backend.CopyBetweenDevices(hostA, hostB));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────
+
+    private static unsafe void WriteFloats(nint ptr, float[] values)
+    {
+        var span = new Span<float>((void*)ptr, values.Length);
+        values.CopyTo(span);
+    }
+
+    private static unsafe float[] ReadFloats(nint ptr, int count)
+    {
+        var result = new float[count];
+        new ReadOnlySpan<float>((void*)ptr, count).CopyTo(result);
+        return result;
+    }
+}


### PR DESCRIPTION
Closes #53

## Cross-device offload M0 — `VulkanBackend : IBackend`

Prerequisite zero for the iGPU(Vulkan)+eGPU(CUDA) offload track. Adds a concrete `IBackend` for Vulkan plus a `VulkanTensor` device-handle wrapper, and the device-vendor selection override needed to target the iGPU.

### Changes
- `src/DotLLM.Vulkan/VulkanBackend.cs` — `AllocateOnDevice`, `CopyBetweenDevices` (host↔Vulkan via HOST_VISIBLE staging), `DeviceCount = 1`; `Send`/`Receive`/`AllReduce` throw (single-device).
- `src/DotLLM.Vulkan/VulkanTensor.cs` — device-handle tensor metadata wrapper (`DataPointer` is an opaque VkBuffer handle, not a host address).
- `src/DotLLM.Vulkan/VulkanDevice.cs` — `DOTLLM_VULKAN_DEVICE_INDEX` / `DOTLLM_VULKAN_DEVICE_VENDOR` overrides in `SelectPhysicalDevice` (falls through to scoring if unset). Without this, the device scorer always picks discrete > integrated, so the iGPU can never be targeted on a box with a discrete GPU present — making the cross-device milestone unverifiable. (Self-contained block ported from local campaign tooling; the M0 vendor-identity guard test depends on it.)
- `tests/DotLLM.Tests.Unit/Vulkan/VulkanBackendTests.cs` — allocate + bit-exact round-trip copy tests, error cases, and a guard test asserting the selected device's vendorID is Intel (0x8086) when the env var is set.

### Stacking
**Base of a 3-PR stack** (M0 → M1 → M2), base branch `dev`. M1 (#54/#57) targets this branch; M2 (#55/#58) targets M1. Merge bottom-up.

### Build / test — local: Meteor Lake + Intel Arc iGPU + RTX 3060 eGPU
With `DOTLLM_VULKAN_DEVICE_VENDOR=0x8086` (forces Vulkan onto the Intel Arc):
```
VulkanBackendTests — Passed: 7, Failed: 0, Skipped: 0
  (incl. VulkanBackend_SelectsIntelArc_WhenVendorEnvSet — confirms vendorID 0x8086)
```
`DotLLM.Vulkan` + test project build clean (0 errors). Built with `-p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
