### PR TITLE
Cross-device offload M2: configurable split + HybridVulkanCudaKvCache (#55)

### DIFF
--- a/src/DotLLM.Cuda/CudaWeights.cs
+++ b/src/DotLLM.Cuda/CudaWeights.cs
@@ -155,14 +155,24 @@ internal sealed class CudaWeights : IDisposable
     /// <param name="numGpuLayers">Number of layers to upload. -1 = all layers.
     /// When less than total layers (hybrid mode), output norm and LM head are skipped
     /// since the CPU handles final projection.</param>
+    /// <param name="firstLayer">
+    /// First layer index (0-based) in <paramref name="cpuWeights"/> to upload.
+    /// Layers <c>firstLayer..(firstLayer+layerCount-1)</c> are uploaded.
+    /// The resulting <see cref="Layers"/> array is always 0-based regardless of
+    /// <paramref name="firstLayer"/>. Used by the Vulkan+CUDA split to avoid uploading
+    /// the Vulkan-resident layers to CUDA VRAM. Default 0 = upload from the beginning.
+    /// </param>
     public static CudaWeights LoadFromGguf(TransformerWeights cpuWeights, ModelConfig config,
                                               CudaKernels kernels, nint stream,
-                                              int numGpuLayers = -1)
+                                              int numGpuLayers = -1, int firstLayer = 0)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(firstLayer);
         int layerCount = numGpuLayers < 0
-            ? config.NumLayers
-            : Math.Min(numGpuLayers, config.NumLayers);
-        bool isHybrid = layerCount < config.NumLayers;
+            ? config.NumLayers - firstLayer
+            : Math.Min(numGpuLayers, config.NumLayers - firstLayer);
+        // isHybrid: the CUDA upload covers only a contiguous slice of the full model,
+        // so it does NOT own the output norm + LM head (caller owns them separately).
+        bool isHybrid = (firstLayer + layerCount) < config.NumLayers;
 
         var allocs = new List<nint>();
 
@@ -229,7 +239,8 @@ internal sealed class CudaWeights : IDisposable
 
         for (int i = 0; i < layerCount; i++)
         {
-            ref readonly var lw = ref cpuWeights.Layers[i];
+            // cpuWeights.Layers is indexed globally; layers array is 0-based (local to this CUDA slice).
+            ref readonly var lw = ref cpuWeights.Layers[firstLayer + i];
 
             // MLA layers do NOT carry GQA Q/K/V tensors — those slots are zero on
             // the CPU side. Skip the GQA upload path entirely; CudaMlaWeightsLoader

--- a/src/DotLLM.Cuda/HybridVulkanCudaKvCache.cs
+++ b/src/DotLLM.Cuda/HybridVulkanCudaKvCache.cs
@@ -14,7 +14,7 @@ namespace DotLLM.Cuda;
 /// <see cref="VulkanCache"/> directly; CUDA layers via
 /// <see cref="CudaCache"/> using 0-based (per-cache) layer indices.
 /// </summary>
-public sealed class VulkanCudaKvCache : IKvCache
+public sealed class HybridVulkanCudaKvCache : IKvCache
 {
     private readonly int _numVulkanLayers;
 
@@ -47,7 +47,7 @@ public sealed class VulkanCudaKvCache : IKvCache
     /// <param name="vulkanCache">Vulkan cache for the first <paramref name="numVulkanLayers"/> layers.</param>
     /// <param name="cudaCache">CUDA cache for the remaining layers.</param>
     /// <param name="numVulkanLayers">Number of layers handled by the Vulkan cache.</param>
-    public VulkanCudaKvCache(VulkanKvCache vulkanCache, CudaKvCache cudaCache, int numVulkanLayers)
+    public HybridVulkanCudaKvCache(VulkanKvCache vulkanCache, CudaKvCache cudaCache, int numVulkanLayers)
     {
         ArgumentNullException.ThrowIfNull(vulkanCache);
         ArgumentNullException.ThrowIfNull(cudaCache);
@@ -73,7 +73,7 @@ public sealed class VulkanCudaKvCache : IKvCache
         // CudaKvCache.Update(ITensor) is the IKvCache host-copy path — not available
         // for device-side CudaKvCache; callers must use UpdateDevice. Surface a clear error.
         throw new NotSupportedException(
-            "Use CudaCache.UpdateDevice() for CUDA layers in a VulkanCudaKvCache.");
+            "Use CudaCache.UpdateDevice() for CUDA layers in a HybridVulkanCudaKvCache.");
     }
 
     /// <inheritdoc/>
@@ -84,7 +84,7 @@ public sealed class VulkanCudaKvCache : IKvCache
                 $"Layer {layerIndex} is a Vulkan layer — use VulkanCache directly.");
 
         throw new NotSupportedException(
-            "Use CudaCache.UpdateDevice() for CUDA layers in a VulkanCudaKvCache.");
+            "Use CudaCache.UpdateDevice() for CUDA layers in a HybridVulkanCudaKvCache.");
     }
 
     /// <inheritdoc/>
@@ -95,7 +95,7 @@ public sealed class VulkanCudaKvCache : IKvCache
                 $"Layer {layerIndex} is a Vulkan layer — use VulkanCache.GetKeys().");
 
         throw new NotSupportedException(
-            "Use CudaCache.GetKeysPtr() for CUDA layers in a VulkanCudaKvCache.");
+            "Use CudaCache.GetKeysPtr() for CUDA layers in a HybridVulkanCudaKvCache.");
     }
 
     /// <inheritdoc/>
@@ -106,7 +106,7 @@ public sealed class VulkanCudaKvCache : IKvCache
                 $"Layer {layerIndex} is a Vulkan layer — use VulkanCache.GetValues().");
 
         throw new NotSupportedException(
-            "Use CudaCache.GetValuesPtr() for CUDA layers in a VulkanCudaKvCache.");
+            "Use CudaCache.GetValuesPtr() for CUDA layers in a HybridVulkanCudaKvCache.");
     }
 
     /// <inheritdoc/>

--- a/src/DotLLM.Cuda/HybridVulkanCudaTransformerModel.cs
+++ b/src/DotLLM.Cuda/HybridVulkanCudaTransformerModel.cs
@@ -185,10 +185,12 @@ public sealed unsafe class HybridVulkanCudaTransformerModel : IModel
         ptxDir ??= Path.Combine(AppContext.BaseDirectory, "ptx");
         var kernels = new CudaKernels(ptxDir);
 
-        // Upload full model weights to CUDA (norm + LM head required for Phase 3 final).
-        // numGpuLayers = -1 means all layers + output norm + LM head.
+        // Upload only the CUDA-resident layers to CUDA VRAM. Layers 0..numVulkanLayers-1
+        // are handled by Vulkan; no need to pay for them in CUDA VRAM.
+        // firstLayer skips the Vulkan slice; numGpuLayers = L-V covers the rest + output norm/LM head.
+        int numCudaOnlyLayers = config.NumLayers - numVulkanLayers;
         var cudaWeights = CudaWeights.LoadFromGguf(cpuWeights, config, kernels, stream.Handle,
-            numGpuLayers: -1);
+            numGpuLayers: numCudaOnlyLayers, firstLayer: numVulkanLayers);
 
         // CUDA scratch activations (same sizing as CudaTransformerModel).
         var cudaState = new CudaForwardState(
@@ -208,16 +210,16 @@ public sealed unsafe class HybridVulkanCudaTransformerModel : IModel
     }
 
     /// <summary>
-    /// Creates a <see cref="VulkanCudaKvCache"/> sized for this model's layer split.
+    /// Creates a <see cref="HybridVulkanCudaKvCache"/> sized for this model's layer split.
     /// The Vulkan cache holds <see cref="NumVulkanLayers"/> FP32 per-layer KV tables;
     /// the CUDA cache holds <c>Config.NumLayers - NumVulkanLayers</c> FP16 tables.
     /// </summary>
     /// <param name="maxSeqLen">Maximum sequence length for both sub-caches.</param>
-    public VulkanCudaKvCache CreateKvCache(int maxSeqLen)
+    public HybridVulkanCudaKvCache CreateKvCache(int maxSeqLen)
     {
         _context.MakeCurrent();
         int numCudaLayers = Config.NumLayers - _numVulkanLayers;
-        return new VulkanCudaKvCache(
+        return new HybridVulkanCudaKvCache(
             _vulkanModel.CreateKvCache(maxSeqLen),
             new CudaKvCache(numCudaLayers, Config.NumKvHeads, Config.HeadDim, maxSeqLen),
             _numVulkanLayers);
@@ -247,7 +249,7 @@ public sealed unsafe class HybridVulkanCudaTransformerModel : IModel
     public ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions,
                            int deviceId, IKvCache? kvCache)
     {
-        var vulkanCudaCache = kvCache as VulkanCudaKvCache;
+        var vulkanCudaCache = kvCache as HybridVulkanCudaKvCache;
 
         int seqLen = tokenIds.Length;
         int hiddenSize = Config.HiddenSize;
@@ -310,20 +312,22 @@ public sealed unsafe class HybridVulkanCudaTransformerModel : IModel
             CudaDriverApi.cuMemcpyHtoD_v2(_cudaState.PositionsDevice, (nint)posPtr,
                 (nuint)(seqLen * sizeof(int))).ThrowOnError();
 
-        // Layer 0 of CUDA phase (= global layer _numVulkanLayers):
+        // Layer 0 of CUDA phase (= global layer _numVulkanLayers, local CUDA index 0):
         // copy hidden→residual, then RmsNorm into NormOutput.
+        // _cudaWeights.Layers is 0-based (CUDA-local), so index 0 = global layer _numVulkanLayers.
         CudaDriverApi.cuMemcpyDtoDAsync_v2(_cudaState.Residual, _cudaState.HiddenState,
             (nuint)hiddenFp16Bytes, s).ThrowOnError();
-        _kernels.LaunchRmsNorm(_cudaState.HiddenState, _cudaWeights.Layers[_numVulkanLayers].AttnNormWeight,
+        _kernels.LaunchRmsNorm(_cudaState.HiddenState, _cudaWeights.Layers[0].AttnNormWeight,
             _cudaState.NormOutput, hiddenSize, eps, seqLen, s);
 
-        // CUDA layer loop — standard GQA forward for layers _numVulkanLayers..totalLayers-1.
-        // KV-cache: CudaCache uses 0-based indices (global layer - _numVulkanLayers).
+        // CUDA layer loop — standard GQA forward for global layers _numVulkanLayers..totalLayers-1.
+        // _cudaWeights.Layers and CudaCache are both 0-based (local CUDA indices).
         var cudaKvCache = vulkanCudaCache?.CudaCache;
         for (int layer = _numVulkanLayers; layer < totalLayers; layer++)
         {
-            ref readonly var lw = ref _cudaWeights.Layers[layer];
-            int cacheLayer = layer - _numVulkanLayers; // 0-based index for CudaCache
+            int localLayer = layer - _numVulkanLayers; // 0-based index for both CudaWeights and CudaCache
+            ref readonly var lw = ref _cudaWeights.Layers[localLayer];
+            int cacheLayer = localLayer; // 0-based index for CudaCache (same remapping)
 
             // ── ATTENTION BLOCK ──
             Project(lw.QQuant, lw.QQuantType, lw.Q, _cudaState.NormOutput, _cudaState.Q,
@@ -388,8 +392,9 @@ public sealed unsafe class HybridVulkanCudaTransformerModel : IModel
             // Fused FFN residual + next-layer setup
             if (layer < totalLayers - 1)
             {
-                // Not last layer: FusedAddRmsNorm pre-applies next layer's AttnNorm
-                ref readonly var nextLw = ref _cudaWeights.Layers[layer + 1];
+                // Not last layer: FusedAddRmsNorm pre-applies next layer's AttnNorm.
+                // Next local index = localLayer + 1 (both arrays are 0-based within the CUDA slice).
+                ref readonly var nextLw = ref _cudaWeights.Layers[localLayer + 1];
                 _kernels.LaunchFusedAddRmsNorm(_cudaState.Residual, _cudaState.NormOutput,
                     nextLw.AttnNormWeight, _cudaState.NormOutput, hiddenSize, eps, seqLen, s);
             }

--- a/tests/DotLLM.Tests.Unit/Vulkan/HybridVulkanCudaParityTests.cs
+++ b/tests/DotLLM.Tests.Unit/Vulkan/HybridVulkanCudaParityTests.cs
@@ -21,14 +21,19 @@ namespace DotLLM.Tests.Unit.Vulkan;
 /// <remarks>
 /// <para>
 /// <b>Architecture.</b> A 4-layer synthetic dense GQA fixture (hidden=32,
-/// heads=2, KVheads=1, headDim=16, intermediate=32) is run three ways:
+/// heads=2, KVheads=1, headDim=16, intermediate=32) is parameterised over
+/// three split points:
 /// <list type="bullet">
-///   <item>Pure-CUDA (all 4 layers on CUDA) — the reference oracle.</item>
-///   <item>2-Vulkan + 2-CUDA (split at N=2) — exercises the handoff path.</item>
+///   <item>numVulkanLayers=1 (split at boundary 1/3) — catches off-by-one
+///   bugs where layer 0 ≡ global index ≡ local index, masking reindex errors.</item>
+///   <item>numVulkanLayers=2 (mid-stack) — original M1 split; exercises
+///   the two-independent-0-based-remap property (weights + KV cache).</item>
+///   <item>numVulkanLayers=3 (split at L-1) — only one CUDA layer; exercises
+///   the single-element edge case in the CUDA loop and firstLayer=3 offset
+///   in <see cref="CudaWeights.LoadFromGguf"/>.</item>
 /// </list>
-/// The split is at N=2 rather than N=1 so absolute layer-index versus
-/// cache-index bugs (which would only be hidden with N=1 where both
-/// coincide on the boundary layer) are discriminated cleanly.
+/// Both prefill and decode are run for each split so the three-way coverage
+/// catches both the activation handoff path and the KV-cache indexing path.
 /// </para>
 /// <para>
 /// <b>Tolerance band.</b> The hybrid path stacks two error sources on top of
@@ -40,13 +45,14 @@ namespace DotLLM.Tests.Unit.Vulkan;
 /// layer body.
 /// </para>
 /// <para>
-/// <b>What this test discriminates.</b>
-/// A wrong <c>cacheLayer = layer</c> (missing <c>- numVulkanLayers</c>
-/// offset) causes an out-of-bounds read in <see cref="CudaKvCache"/>
-/// (assert fails or silently reads stale data) — caught on decode step 2.
-/// A wrong positions upload (skipped) causes NaN/garbage logits — caught
-/// by the IsFinite assert. A wrong FP32→FP16 conversion direction
-/// (swapped src/dst) produces wildly off logits — caught by the tolerance.
+/// <b>What the split parameterisation discriminates.</b>
+/// Split=1: wrong <c>_cudaWeights.Layers[layer]</c> (missing firstLayer offset)
+/// reads layer 1 data for layer 0 — immediate OOB or silent garbage. Split=3:
+/// same bug surfaces on the first-CUDA-layer norm at local index 0 but global
+/// index 3. A wrong <c>cacheLayer = layer</c> (missing <c>- numVulkanLayers</c>
+/// offset) causes an out-of-bounds read in <see cref="HybridVulkanCudaKvCache"/>
+/// at decode step 2 — split=1 catches it because <c>cacheLayer=1</c> would
+/// read slot 1 from a 3-slot CUDA cache, while split=3 gives only 1 slot.
 /// </para>
 /// <para>
 /// <b>Skip behaviour.</b> Skips cleanly when either Vulkan or CUDA is
@@ -70,16 +76,20 @@ public sealed unsafe class HybridVulkanCudaParityTests
     private const int RopeDim = 16;
     private const int IntermediateSize = 32;
     private const int NumLayers = 4;
-    private const int NumVulkanLayers = 2; // First 2 of 4 layers on Vulkan (split at 2, not 1)
     private const int MaxSeqLen = 8;
+
+    // Three split points: 1 (min), 2 (mid), 3 (L-1 = max).
+    // Split at 1: numVulkanLayers=1, numCudaLayers=3, firstLayer=1
+    // Split at 2: numVulkanLayers=2, numCudaLayers=2, firstLayer=2  (original M1 point)
+    // Split at 3: numVulkanLayers=3, numCudaLayers=1, firstLayer=3
+    public static TheoryData<int> SplitPoints => new() { 1, 2, 3 };
 
     // Tolerance: Vulkan runs FP32 for layer bodies; CUDA runs FP16.
     // The FP32→FP16 conversion at the handoff introduces rounding at every
-    // hidden-state element. Over N=2 Vulkan layers + boundary + 2 CUDA
-    // layers this accumulates to ~1e-2 max|diff| on this tiny fixture.
-    // We use 5e-2 abs / 1e-1 rel — well above empirical noise but
-    // below the ~0.5 jump caused by a real boundary bug (mirroring the
-    // evidence in HybridTransformerModelSplitParityTests at ~600× gap).
+    // hidden-state element. Over N Vulkan layers + boundary + (L-N) CUDA
+    // layers this accumulates. We use 5e-2 abs / 1e-1 rel — well above
+    // empirical noise but below the ~0.5 jump caused by a real boundary bug
+    // (mirroring the evidence in HybridTransformerModelSplitParityTests at ~600×).
     private const float AbsTol = 5e-2f;
     private const float RelTol = 1e-1f;
 
@@ -132,12 +142,13 @@ public sealed unsafe class HybridVulkanCudaParityTests
     }
 
     /// <summary>
-    /// Prefill parity: 4-token sequence, NeoX RoPE.
-    /// Hybrid (2 Vulkan + 2 CUDA) logits must match pure-CUDA within the
-    /// tolerance band at the last-token position.
+    /// Prefill parity: 4-token sequence, NeoX RoPE, split point parameterised
+    /// over {1, 2, 3}. Hybrid logits must match pure-CUDA within the tolerance
+    /// band at the last-token position.
     /// </summary>
-    [SkippableFact]
-    public void HybridVulkanCuda_DenseNeoxRope_PrefillVsCuda_LastTokenLogitsMatch()
+    [SkippableTheory]
+    [MemberData(nameof(SplitPoints))]
+    public void HybridVulkanCuda_DenseNeoxRope_PrefillVsCuda_LastTokenLogitsMatch(int numVulkanLayers)
     {
         Skip.IfNot(IsBothAvailable(), "Both Vulkan and CUDA GPU must be available.");
         string? ptxDir = FindPtxDir();
@@ -151,18 +162,21 @@ public sealed unsafe class HybridVulkanCudaParityTests
         using var fixture = DenseFixture.Build(seed: 42, ropeType: RoPEType.NeoX);
 
         float[] cudaLast = RunCudaLastRow(fixture, tokenIds, positions, ptxDir!);
-        float[] hybridLast = RunHybridLastRow(fixture, tokenIds, positions, ptxDir!, spvDir!);
+        float[] hybridLast = RunHybridLastRow(fixture, tokenIds, positions, numVulkanLayers, ptxDir!, spvDir!);
 
-        AssertLogitsMatch(cudaLast, hybridLast, "NeoX-prefill");
+        AssertLogitsMatch(cudaLast, hybridLast, $"NeoX-prefill/split={numVulkanLayers}");
     }
 
     /// <summary>
-    /// Single-token decode parity: NeoX RoPE decode step (positions=[4]).
-    /// Exercises the KV-cache path — specifically that the CUDA cache uses
-    /// 0-based (per-cache) layer indices, not global layer indices.
+    /// Single-token decode parity: NeoX RoPE decode step (positions=[4]),
+    /// split point parameterised over {1, 2, 3}.
+    /// Exercises the KV-cache path — specifically that both the weight array
+    /// and <see cref="HybridVulkanCudaKvCache"/> use independently-0-based
+    /// (local) layer indices, not global layer indices.
     /// </summary>
-    [SkippableFact]
-    public void HybridVulkanCuda_DenseNeoxRope_DecodeVsCuda_LastTokenLogitsMatch()
+    [SkippableTheory]
+    [MemberData(nameof(SplitPoints))]
+    public void HybridVulkanCuda_DenseNeoxRope_DecodeVsCuda_LastTokenLogitsMatch(int numVulkanLayers)
     {
         Skip.IfNot(IsBothAvailable(), "Both Vulkan and CUDA GPU must be available.");
         string? ptxDir = FindPtxDir();
@@ -183,9 +197,9 @@ public sealed unsafe class HybridVulkanCudaParityTests
 
         // Run hybrid path with KV cache.
         float[] hybridLast = RunHybridDecodeLastRow(fixture, prefillIds, prefillPos, decodeIds, decodePos,
-            ptxDir!, spvDir!);
+            numVulkanLayers, ptxDir!, spvDir!);
 
-        AssertLogitsMatch(cudaLast, hybridLast, "NeoX-decode");
+        AssertLogitsMatch(cudaLast, hybridLast, $"NeoX-decode/split={numVulkanLayers}");
     }
 
     // ── Runner helpers ──────────────────────────────────────────────────────
@@ -203,11 +217,12 @@ public sealed unsafe class HybridVulkanCudaParityTests
     }
 
     private float[] RunHybridLastRow(
-        DenseFixture fixture, int[] tokenIds, int[] positions, string ptxDir, string spvDir)
+        DenseFixture fixture, int[] tokenIds, int[] positions,
+        int numVulkanLayers, string ptxDir, string spvDir)
     {
         using var device = VulkanDevice.Create();
         using var model = HybridVulkanCudaTransformerModel.BuildFromPrebuiltWeights(
-            fixture.Weights, fixture.Config, numVulkanLayers: NumVulkanLayers,
+            fixture.Weights, fixture.Config, numVulkanLayers: numVulkanLayers,
             vulkanDevice: device, cudaDeviceId: 0, spvDir: spvDir, ptxDir: ptxDir);
 
         using ITensor logits = model.Forward(tokenIds, positions, deviceId: -1);
@@ -238,11 +253,11 @@ public sealed unsafe class HybridVulkanCudaParityTests
     private float[] RunHybridDecodeLastRow(
         DenseFixture fixture,
         int[] prefillIds, int[] prefillPos, int[] decodeIds, int[] decodePos,
-        string ptxDir, string spvDir)
+        int numVulkanLayers, string ptxDir, string spvDir)
     {
         using var device = VulkanDevice.Create();
         using var model = HybridVulkanCudaTransformerModel.BuildFromPrebuiltWeights(
-            fixture.Weights, fixture.Config, numVulkanLayers: NumVulkanLayers,
+            fixture.Weights, fixture.Config, numVulkanLayers: numVulkanLayers,
             vulkanDevice: device, cudaDeviceId: 0, spvDir: spvDir, ptxDir: ptxDir);
         using var kvCache = model.CreateKvCache(MaxSeqLen);
 


### PR DESCRIPTION
Closes #55

## Cross-device offload M2 — configurable split point + HybridVulkanCudaKvCache

Generalises M1's fixed midpoint into a configurable `numVulkanLayers`, adds `HybridVulkanCudaKvCache`, and teaches `CudaWeights.LoadFromGguf` a `firstLayer` offset so the eGPU owns an arbitrary tail of the model.

### Changes
- `src/DotLLM.Cuda/HybridVulkanCudaKvCache.cs` — renamed/generalised from M1's `VulkanCudaKvCache`; routes any split boundary.
- `src/DotLLM.Cuda/CudaWeights.cs` — `LoadFromGguf` gains `firstLayer` offset (was always `0..N-1`).
- `src/DotLLM.Cuda/HybridVulkanCudaTransformerModel.cs` — arbitrary split-point wiring.
- `tests/.../HybridVulkanCudaParityTests.cs` — `SkippableTheory` over split points `{1, 2, 3}` (prefill + decode).

### Stacking
**PR 3 of 3.** Base branch `offload/m1-concept-proof` (#57) — review/merge **#56 → #57 → this** bottom-up.

### Build / test — local: Meteor Lake + Intel Arc iGPU + RTX 3060 eGPU
With `DOTLLM_VULKAN_DEVICE_VENDOR=0x8086`, Vulkan ran on the **Intel Arc iGPU** and CUDA on the **RTX 3060 eGPU** (genuine cross-device; M0 vendor guard confirms Arc selection). Parity tests **executed** (0 skipped):
```
HybridVulkanCuda_DenseNeoxRope_PrefillVsCuda_LastTokenLogitsMatch(numVulkanLayers: 1) — Passed
...PrefillVsCuda...(numVulkanLayers: 2) — Passed
...PrefillVsCuda...(numVulkanLayers: 3) — Passed
HybridVulkanCuda_DenseNeoxRope_DecodeVsCuda_LastTokenLogitsMatch(numVulkanLayers: 1) — Passed
...DecodeVsCuda...(numVulkanLayers: 2) — Passed
...DecodeVsCuda...(numVulkanLayers: 3) — Passed
Total: 6  Passed: 6  Skipped: 0
```
All offload projects + test project build clean. Built with `-p:EnableSourceControlManagerQueries=false -p:EnableSourceLink=false`.

### ⚠️ Manual-extraction note (M2 ↔ M3-probe stacking)
On the source branch `feature/offload-m2-m3`, this M2 work (commit `85606a0`) is followed by a single commit `261a06a` that bundles **two test-only files**:
- `tests/.../HybridVulkanCudaLatencyTests.cs` — M2/M3 latency baseline harness.
- `tests/.../HybridVulkanCudaM3SemaphoreProbeTests.cs` — M3 semaphore-interop probe.

`261a06a` is **deliberately excluded**: it is additive (no overlap with M2's modified files), it mixes M2-track and M3-track concerns in one commit, and the same commit also sits on the do-not-touch `feature/offload-m3` branch. The latency baseline belongs with M3 (async pipelining), not M2 correctness.

If the latency harness is wanted later, extract it file-by-file without dragging in the M3 probe:
```
git checkout 261a06a -- tests/DotLLM.Tests.Unit/Vulkan/HybridVulkanCudaLatencyTests.cs
```
The semaphore probe should stay with M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
