### PR TITLE
perf(vulkan): share Q8_1 activation-quant across same-input MMVQ decode projections

### DIFF
--- a/src/DotLLM.Vulkan/VulkanTransformerModel.cs
+++ b/src/DotLLM.Vulkan/VulkanTransformerModel.cs
@@ -156,6 +156,19 @@ public sealed class VulkanTransformerModel : IModel
     // conditions as _matmulQ8Mmvq; reuses _quantizeQ8_1 + the Q8_1Xq/Xds
     // activation scratch. RecordMatmul falls back to the F32-in Q4_K GEMV.
     private readonly MatMulQ4KMmvqKernel? _matmulQ4KMmvq;
+    // When true (default whenever the MMVQ decode path is wired),
+    // RecordSharedInputMmvqGroup quantizes the shared activation once for a group
+    // of same-input Q8_0 projections (Q/K/V share the post-attn-norm input;
+    // gate/up share the post-ffn-norm input) instead of re-running quantize_q8_1
+    // per projection. DOTLLM_VULKAN_MMVQ_NO_SHARE=1 forces the per-projection
+    // path (used by the share-vs-no-share bit-identical parity test).
+    private readonly bool _mmvqShareActivation = !IsMmvqShareDisabled();
+    // Reusable scratch for RecordSharedInputMmvqGroup's projection list — sized
+    // for the largest same-input group (Q/K/V = 3). Reused across layers and
+    // decode steps to keep command-buffer recording allocation-free (the element
+    // type holds a managed VulkanDevice.Buffer, so a Span collection-expression
+    // would heap-allocate per call). Recording is single-threaded per model.
+    private readonly MmvqGroupProjection[] _mmvqGroupScratch = new MmvqGroupProjection[3];
     // dp4a MMQ prefill path (issue #50) — both null when the device lacks
     // integer-dot-product support, the SPVs are missing, or the MMQ env-var
     // opt-out is set; RecordMatmul then falls back to the coopmat / scalar
@@ -974,6 +987,19 @@ public sealed class VulkanTransformerModel : IModel
 
     internal static bool IsMmvqDisabled() =>
         Environment.GetEnvironmentVariable(DisableMmvqEnvVar) == "1";
+
+    /// <summary>
+    /// Env-var opt-out for the shared-activation-quant optimisation on the MMVQ
+    /// decode path. Set <c>DOTLLM_VULKAN_MMVQ_NO_SHARE=1</c> to quantize the
+    /// activation per projection (the original per-call behaviour) instead of
+    /// once per same-input group (Q/K/V, gate/up). Used by the share-vs-no-share
+    /// bit-identical parity test and for A/B benchmarking. When unset, sharing is
+    /// on whenever the MMVQ decode path is wired.
+    /// </summary>
+    internal const string MmvqNoShareEnvVar = "DOTLLM_VULKAN_MMVQ_NO_SHARE";
+
+    internal static bool IsMmvqShareDisabled() =>
+        Environment.GetEnvironmentVariable(MmvqNoShareEnvVar) == "1";
 
     /// <summary>
     /// Env-var opt-out for the dp4a MMQ prefill path (issue #50). Set
@@ -2003,26 +2029,36 @@ public sealed class VulkanTransformerModel : IModel
             // shader writes BOTH the normalised hidden state (for K/V to
             // read) AND the Q matmul output. Falls back to the standalone
             // pair on prefill, non-Q8_0 weights, or oversized hidden.
-            if (!TryRecordFusedRmsNormMatmul(cmdBuf,
+            if (TryRecordFusedRmsNormMatmul(cmdBuf,
                     _state.HiddenState, lw.AttnNormWeight,
                     lw.Q, lw.QDeviceQuantType,
                     _state.NormOutput, _state.Q,
                     lw.QOutputDim, lw.QInputDim, seqLen, eps))
             {
+                // Fused path wrote NormOutput + Q; K/V follow over the same input.
+                KernelSupport.ComputeToComputeBarrier(cmdBuf);
+                RecordMatmul(cmdBuf, lw.K, lw.KDeviceQuantType, _state.NormOutput, _state.K,
+                    lw.KOutputDim, lw.KInputDim, seqLen);
+                KernelSupport.ComputeToComputeBarrier(cmdBuf);
+                RecordMatmul(cmdBuf, lw.V, lw.VDeviceQuantType, _state.NormOutput, _state.V,
+                    lw.VOutputDim, lw.VInputDim, seqLen);
+            }
+            else
+            {
                 _rmsnorm.Record(cmdBuf, _state.HiddenState, lw.AttnNormWeight, _state.NormOutput,
                     rowCount: seqLen, n: hiddenSize, eps: eps);
                 KernelSupport.ComputeToComputeBarrier(cmdBuf);
-                RecordMatmul(cmdBuf, lw.Q, lw.QDeviceQuantType, _state.NormOutput, _state.Q,
-                    lw.QOutputDim, lw.QInputDim, seqLen);
-            }
-            KernelSupport.ComputeToComputeBarrier(cmdBuf);
 
-            // K/V projections — read the normalised hidden state written above.
-            RecordMatmul(cmdBuf, lw.K, lw.KDeviceQuantType, _state.NormOutput, _state.K,
-                lw.KOutputDim, lw.KInputDim, seqLen);
-            KernelSupport.ComputeToComputeBarrier(cmdBuf);
-            RecordMatmul(cmdBuf, lw.V, lw.VDeviceQuantType, _state.NormOutput, _state.V,
-                lw.VOutputDim, lw.VInputDim, seqLen);
+                // Q/K/V all read the post-attn-norm hidden state. On the MMVQ
+                // decode path this shares one Q8_1 activation-quant across the
+                // three GEMVs (issue #46 follow-up). Non-qualifying groups fall
+                // back to per-projection RecordMatmul with the same barriers.
+                _mmvqGroupScratch[0] = new(lw.Q, lw.QDeviceQuantType, _state.Q, lw.QOutputDim);
+                _mmvqGroupScratch[1] = new(lw.K, lw.KDeviceQuantType, _state.K, lw.KOutputDim);
+                _mmvqGroupScratch[2] = new(lw.V, lw.VDeviceQuantType, _state.V, lw.VOutputDim);
+                RecordSharedInputMmvqGroup(cmdBuf, _state.NormOutput, lw.QInputDim, seqLen,
+                    _mmvqGroupScratch.AsSpan(0, 3));
+            }
 
             // Optional QKV biases — kernel path keeps the whole forward in
             // one submit. Each bias add writes a different output buffer
@@ -2187,23 +2223,32 @@ public sealed class VulkanTransformerModel : IModel
             // FFN RMSNorm + Gate projection — fused when available
             // (mirrors the attn-norm + Q fusion above). Up reads the
             // normalised hidden state written by the fused dispatch.
-            if (!TryRecordFusedRmsNormMatmul(cmdBuf,
+            if (TryRecordFusedRmsNormMatmul(cmdBuf,
                     _state.HiddenState, lw.FfnNormWeight,
                     lw.Gate, lw.GateDeviceQuantType,
                     _state.NormOutput, _state.FfnGate,
                     lw.GateOutputDim, lw.GateInputDim, seqLen, eps))
             {
+                // Fused path wrote NormOutput + Gate; Up follows over the same input.
+                KernelSupport.ComputeToComputeBarrier(cmdBuf);
+                RecordMatmul(cmdBuf, lw.Up, lw.UpDeviceQuantType, _state.NormOutput, _state.FfnUp,
+                    lw.UpOutputDim, lw.UpInputDim, seqLen);
+            }
+            else
+            {
                 _rmsnorm.Record(cmdBuf, _state.HiddenState, lw.FfnNormWeight, _state.NormOutput,
                     rowCount: seqLen, n: hiddenSize, eps: eps);
                 KernelSupport.ComputeToComputeBarrier(cmdBuf);
-                RecordMatmul(cmdBuf, lw.Gate, lw.GateDeviceQuantType, _state.NormOutput, _state.FfnGate,
-                    lw.GateOutputDim, lw.GateInputDim, seqLen);
-            }
-            KernelSupport.ComputeToComputeBarrier(cmdBuf);
 
-            // Up projection — reads the normalised hidden state.
-            RecordMatmul(cmdBuf, lw.Up, lw.UpDeviceQuantType, _state.NormOutput, _state.FfnUp,
-                lw.UpOutputDim, lw.UpInputDim, seqLen);
+                // Gate/Up both read the post-ffn-norm hidden state. On the MMVQ
+                // decode path this shares one Q8_1 activation-quant across the two
+                // GEMVs. Non-qualifying groups fall back to per-projection
+                // RecordMatmul with the same barriers.
+                _mmvqGroupScratch[0] = new(lw.Gate, lw.GateDeviceQuantType, _state.FfnGate, lw.GateOutputDim);
+                _mmvqGroupScratch[1] = new(lw.Up, lw.UpDeviceQuantType, _state.FfnUp, lw.UpOutputDim);
+                RecordSharedInputMmvqGroup(cmdBuf, _state.NormOutput, lw.GateInputDim, seqLen,
+                    _mmvqGroupScratch.AsSpan(0, 2));
+            }
 
             KernelSupport.ComputeToComputeBarrier(cmdBuf);
             if (lw.GateBias is not null) _biasAdd.Record(cmdBuf, _state.FfnGate, lw.GateBias, seqLen, lw.GateOutputDim);
@@ -3869,6 +3914,105 @@ public sealed class VulkanTransformerModel : IModel
         };
         VulkanApi.vkCmdCopyBuffer(cmdBuf, deltaSum.Handle, y.Handle, 1, region);
         KernelSupport.TransferToComputeBarrier(cmdBuf);
+    }
+
+    /// <summary>
+    /// One projection in a same-input MMVQ group: the Q8_0 weight blob, its
+    /// device-side quant type, the output buffer, and the output dimension.
+    /// </summary>
+    private readonly record struct MmvqGroupProjection(
+        VulkanDevice.Buffer Weights, QuantType WeightQt,
+        VulkanDevice.Buffer Output, int OutputDim);
+
+    /// <summary>
+    /// Records a group of decode (<c>seqLen==1</c>) projections that all read the
+    /// same activation <paramref name="input"/> (e.g. Q/K/V over the post-attn-norm
+    /// hidden state, or gate/up over the post-ffn-norm hidden state), sharing one
+    /// Q8_1 activation-quant across the group's MMVQ GEMVs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When the MMVQ decode path is wired, sharing is enabled
+    /// (<see cref="_mmvqShareActivation"/>), and every projection is Q8_0 with a
+    /// qualifying shape, the activation is quantized to Q8_1 once into the shared
+    /// <c>_state.Q8_1Xq</c>/<c>_state.Q8_1Xds</c> scratch, then each projection's
+    /// integer-dot GEMV runs against that one quantized copy. Recording is:
+    /// <c>quantize → barrier → GEMV_0, GEMV_1, …</c> with NO barrier between the
+    /// GEMVs (they only read the shared scratch; their outputs are disjoint). The
+    /// caller is responsible for the barrier that precedes the next dispatch which
+    /// WRITES the shared scratch (e.g. the o-proj / down-proj quantize), exactly
+    /// as for a standalone <see cref="RecordMatmul"/>.
+    /// </para>
+    /// <para>
+    /// Results are bit-identical to the per-projection path
+    /// (<c>DOTLLM_VULKAN_MMVQ_NO_SHARE=1</c>): the same quantized activation feeds
+    /// every GEMV, so sharing only removes redundant quantize dispatches. When the
+    /// group does not qualify (sharing off, a non-Q8_0 member, an unsupported
+    /// shape, or scratch too small) each projection falls back to a standalone
+    /// <see cref="RecordMatmul"/> with a separating barrier — identical semantics
+    /// to recording them individually.
+    /// </para>
+    /// </remarks>
+    private void RecordSharedInputMmvqGroup(
+        nint cmdBuf, VulkanDevice.Buffer input, int inputDim, int seqLen,
+        ReadOnlySpan<MmvqGroupProjection> projections)
+    {
+        if (CanShareMmvqQuant(inputDim, seqLen, projections))
+        {
+            // One activation quant shared by every projection in the group.
+            _quantizeQ8_1!.Record(cmdBuf, input, _state.Q8_1Xq!, _state.Q8_1Xds!, inputDim);
+            KernelSupport.ComputeToComputeBarrier(cmdBuf);
+            foreach (var p in projections)
+            {
+                // No inter-GEMV barrier: all GEMVs only read the shared scratch
+                // and write disjoint outputs (read-after-write on the scratch is
+                // ordered by the single barrier above).
+                _matmulQ8Mmvq!.Record(cmdBuf, p.Weights, _state.Q8_1Xq!, _state.Q8_1Xds!, p.Output,
+                    m: p.OutputDim, k: inputDim);
+            }
+            return;
+        }
+
+        // Fallback: dispatch each projection independently, with a barrier between
+        // them, at the caller's real seqLen. RecordMatmul routes each to the
+        // appropriate kernel (decode MMVQ / prefill MMQ / coopmat / scalar). The
+        // barrier orders each projection's activation-quant after the prior GEMV's
+        // shared-scratch read (WAR on _state.Q8_1Xq); non-shared paths are
+        // order-independent anyway.
+        for (int i = 0; i < projections.Length; i++)
+        {
+            if (i > 0) KernelSupport.ComputeToComputeBarrier(cmdBuf);
+            var p = projections[i];
+            RecordMatmul(cmdBuf, p.Weights, p.WeightQt, input, p.Output,
+                p.OutputDim, inputDim, seqLen);
+        }
+    }
+
+    /// <summary>
+    /// Returns true when every projection in <paramref name="projections"/>
+    /// qualifies for the shared MMVQ activation-quant: decode step
+    /// (<paramref name="seqLen"/>==1), sharing enabled, the MMVQ decode path
+    /// wired, the shared scratch present and large enough for
+    /// <paramref name="inputDim"/>, and every member is Q8_0 with a 32-aligned
+    /// input. The group's input dim is identical for all members (they read the
+    /// same buffer) — asserted via the shared-scratch size check on
+    /// <paramref name="inputDim"/>. Prefill (seqLen&gt;1) never shares: the
+    /// quantize_q8_1 / MMVQ kernels are single-row decode kernels, so each
+    /// projection must fall back to the row-wise MMQ / GEMM path.
+    /// </summary>
+    private bool CanShareMmvqQuant(int inputDim, int seqLen, ReadOnlySpan<MmvqGroupProjection> projections)
+    {
+        if (seqLen != 1) return false;
+        if (!_mmvqShareActivation || projections.Length < 2) return false;
+        if (_matmulQ8Mmvq is null || _quantizeQ8_1 is null
+            || _state.Q8_1Xq is null || _state.Q8_1Xds is null)
+            return false;
+        if ((inputDim % QuantizeQ8_1Kernel.GroupSize) != 0) return false;
+        if (QuantizeQ8_1Kernel.PackedBytes(inputDim) > _state.Q8_1Xq.Size) return false;
+        if (QuantizeQ8_1Kernel.ScaleBytes(inputDim) > _state.Q8_1Xds.Size) return false;
+        foreach (var p in projections)
+            if (p.WeightQt != QuantType.Q8_0) return false;
+        return true;
     }
 
     private void RecordMatmul(

--- a/tests/DotLLM.Tests.Integration/Vulkan/VulkanMmvqSharedQuantParityTests.cs
+++ b/tests/DotLLM.Tests.Integration/Vulkan/VulkanMmvqSharedQuantParityTests.cs
@@ -1,0 +1,184 @@
+using DotLLM.Core.Tensors;
+using DotLLM.Models.Gguf;
+using DotLLM.Tests.Integration.Fixtures;
+using DotLLM.Tokenizers.Bpe;
+using DotLLM.Vulkan;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Integration.Vulkan;
+
+/// <summary>
+/// End-to-end parity for the MMVQ shared-activation-quant optimisation on the
+/// real SmolLM-135M.Q8_0 GGUF (dense GQA Llama-family, head_dim 64). Runs the
+/// full Vulkan decode forward through the restructured Q/K/V and gate/up call
+/// sites (<c>RecordSharedInputMmvqGroup</c>) TWICE — once with sharing on
+/// (default) and once with <c>DOTLLM_VULKAN_MMVQ_NO_SHARE=1</c> — and asserts
+/// the logits are BIT-IDENTICAL across prefill plus several decode steps.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the discriminating wiring test for the optimisation: sharing
+/// quantizes the activation once per same-input group instead of per
+/// projection, but the quantize is deterministic and every GEMV is identical,
+/// so the two paths must agree bit-for-bit. A wiring bug — wrong barrier order,
+/// a clobbered shared scratch, the fused-vs-share branch inverted, or a
+/// mismatched input dim — corrupts some projection's GEMV and breaks the
+/// equality. (The kernel-level invariant is covered by
+/// <c>VulkanMatMulQ8_0MmvqKernelTests.Mmvq_SharedQuant_BitIdenticalToPerProjection</c>;
+/// this test additionally exercises the production model wiring.)
+/// </para>
+/// <para>
+/// Q8_0 weights stay on device in their source byte layout
+/// (<c>VulkanWeights</c> default <c>dequantToFp32=false</c>), so the decode
+/// projections genuinely dispatch through the MMVQ path on integer-dot-capable
+/// devices. Skipped where MMVQ is unavailable (the shared and per-projection
+/// paths then collapse to the same F32-in GEMV and the test is vacuous).
+/// </para>
+/// </remarks>
+[Collection("SmallModel")]
+[Trait("Category", "GPU")]
+public sealed class VulkanMmvqSharedQuantParityTests
+{
+    private const int DecodeStepsToCheck = 6;
+
+    private readonly SmallModelFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public VulkanMmvqSharedQuantParityTests(SmallModelFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [SkippableFact]
+    public void SharedQuant_BitIdenticalToPerProjection_OnSmolLmDecode()
+    {
+        SkipVulkanOrMmvqUnavailable(out string spvDir);
+
+        int[] prompt;
+        using (var gguf = GgufFile.Open(_fixture.FilePath))
+        {
+            var tokenizer = GgufBpeTokenizerFactory.Load(gguf.Metadata);
+            prompt = tokenizer.Encode("The capital of France is").ToArray();
+        }
+        Assert.NotEmpty(prompt);
+
+        // SHARE = default (env unset). NO_SHARE = env set. The flag is read at
+        // model construction, so build each model under the desired setting.
+        float[][] shared = RunDecode(spvDir, prompt, noShare: false);
+        float[][] perProj = RunDecode(spvDir, prompt, noShare: true);
+
+        Assert.Equal(shared.Length, perProj.Length);
+        for (int step = 0; step < shared.Length; step++)
+        {
+            float[] a = shared[step];
+            float[] b = perProj[step];
+            Assert.Equal(a.Length, b.Length);
+            int mismatch = -1;
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (!a[i].Equals(b[i])) { mismatch = i; break; }
+            }
+            Assert.True(mismatch < 0,
+                $"step {step}: shared vs per-projection logits differ at index {mismatch} " +
+                $"(shared={(mismatch >= 0 ? a[mismatch] : 0):G9}, " +
+                $"perProj={(mismatch >= 0 ? b[mismatch] : 0):G9}). " +
+                "The restructured MMVQ group wiring is not bit-identical to per-projection quant.");
+            _output.WriteLine($"step {step}: bit-identical ({a.Length} logits)");
+        }
+    }
+
+    // Builds a fresh Vulkan model under the requested NO_SHARE setting and runs
+    // prefill + DecodeStepsToCheck single-token decodes, returning the last-row
+    // logits per step. The decode trajectory is driven by the SHARED run's
+    // argmax for both runs would require coupling; instead each run advances by
+    // its OWN argmax — which is fine because (a) both runs are deterministic and
+    // (b) if they ever diverge, the bit-identical assert fires at that step
+    // before the trajectories can drift apart.
+    private float[][] RunDecode(string spvDir, int[] prompt, bool noShare)
+    {
+        string? original = Environment.GetEnvironmentVariable(
+            VulkanTransformerModel.MmvqNoShareEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                VulkanTransformerModel.MmvqNoShareEnvVar, noShare ? "1" : null);
+
+            using var gguf = GgufFile.Open(_fixture.FilePath);
+            var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+            using var model = VulkanTransformerModel.LoadFromGguf(gguf, config, spvDir);
+            using var cache = model.CreateKvCache(maxSeqLen: 128);
+
+            var steps = new float[DecodeStepsToCheck + 1][];
+
+            int[] positions = new int[prompt.Length];
+            for (int i = 0; i < prompt.Length; i++) positions[i] = i;
+            steps[0] = LastRowLogits(model, prompt, positions, cache);
+
+            int nextToken = Argmax(steps[0]);
+            int nextPos = prompt.Length;
+            for (int step = 1; step <= DecodeStepsToCheck; step++)
+            {
+                steps[step] = LastRowLogits(model, new[] { nextToken }, new[] { nextPos }, cache);
+                nextToken = Argmax(steps[step]);
+                nextPos++;
+            }
+
+            return steps;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(VulkanTransformerModel.MmvqNoShareEnvVar, original);
+        }
+    }
+
+    private static unsafe float[] LastRowLogits(
+        VulkanTransformerModel model, int[] tokenIds, int[] positions, VulkanKvCache cache)
+    {
+        using ITensor logits = model.Forward(tokenIds, positions, deviceId: -1, cache);
+        int vocabSize = model.Config.VocabSize;
+        int seqLen = logits.Shape[0];
+        long lastRow = (long)(seqLen - 1) * vocabSize;
+        var span = new ReadOnlySpan<float>((void*)logits.DataPointer, (int)logits.ElementCount);
+        float[] result = new float[vocabSize];
+        span.Slice((int)lastRow, vocabSize).CopyTo(result);
+        return result;
+    }
+
+    private static int Argmax(float[] v)
+    {
+        int arg = 0;
+        for (int i = 1; i < v.Length; i++)
+            if (v[i] > v[arg]) arg = i;
+        return arg;
+    }
+
+    private static void SkipVulkanOrMmvqUnavailable(out string spvDir)
+    {
+        Skip.If(Environment.GetEnvironmentVariable("DOTLLM_SKIP_VULKAN") == "1", "DOTLLM_SKIP_VULKAN=1");
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan loader or physical device available on this host.");
+
+        using (var device = VulkanDevice.Create())
+            Skip.IfNot(device.HasIntegerDotProduct,
+                "Device lacks integer-dot-product — MMVQ path unavailable; share/no-share collapse to the same GEMV.");
+
+        string[] candidates =
+        {
+            Path.Combine(AppContext.BaseDirectory, "spv"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "vulkan", "spv"),
+        };
+        string? found = null;
+        foreach (var c in candidates)
+        {
+            string full = Path.GetFullPath(c);
+            if (Directory.Exists(full) && Directory.GetFiles(full, "*.spv").Length > 0)
+            {
+                found = full;
+                break;
+            }
+        }
+        Skip.If(found is null, "Compiled SPV shaders not found.");
+        spvDir = found!;
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Vulkan/VulkanMatMulQ8_0MmvqKernelTests.cs
+++ b/tests/DotLLM.Tests.Unit/Vulkan/VulkanMatMulQ8_0MmvqKernelTests.cs
@@ -108,6 +108,105 @@ public class VulkanMatMulQ8_0MmvqKernelTests
         AssertParity(expected, actual, m, k);
     }
 
+    /// <summary>
+    /// Bit-identical parity for the shared-activation-quant optimisation
+    /// (<c>RecordSharedInputMmvqGroup</c>): a group of same-input projections
+    /// (e.g. Q/K/V) must produce EXACTLY the same per-projection outputs whether
+    /// the activation is quantized once and shared across the group's GEMVs
+    /// (SHARE) or re-quantized per projection (NO_SHARE, the original per-call
+    /// form). The quantize is deterministic and the GEMVs are identical, so the
+    /// outputs are bit-for-bit equal — this discriminates a sharing
+    /// implementation that accidentally clobbers the shared scratch or mis-orders
+    /// the barrier (which would corrupt some GEMVs) from a correct one.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(2048, new[] { 2048, 512, 512 })]   // Q/K/V (GQA) over hidden=2048
+    [InlineData(2048, new[] { 8192, 8192 })]       // gate/up over hidden=2048
+    [InlineData(96, new[] { 64, 32, 160 })]        // odd blocksPerRow mix
+    public void Mmvq_SharedQuant_BitIdenticalToPerProjection(int k, int[] outDims)
+    {
+        VulkanMatMulF32KernelTests.SkipIfUnavailable(out string spvDir);
+
+        using var device = VulkanDevice.Create();
+        Skip.IfNot(device.HasIntegerDotProduct,
+            "Device does not advertise VK_KHR_shader_integer_dot_product — MMVQ path is unavailable here.");
+
+        using var quant = QuantizeQ8_1Kernel.TryCreate(device, spvDir)
+            ?? throw new Xunit.Sdk.XunitException("quantize_q8_1.spv missing.");
+        using var mmvq = MatMulQ8_0MmvqKernel.TryCreate(device, spvDir)
+            ?? throw new Xunit.Sdk.XunitException("matmul_q8_0_mmvq.spv missing or unsupported.");
+
+        var rng = new Random(0x5A + k);
+        float[] x = RandomFloats(rng, k, range: 1.0f);
+
+        using var bufX = device.Allocate((long)k * sizeof(float));
+        using var bufXq = device.Allocate(QuantizeQ8_1Kernel.PackedBytes(k));
+        using var bufXds = device.Allocate(QuantizeQ8_1Kernel.ScaleBytes(k));
+        device.Upload(x, bufX);
+
+        // Per-projection weights + output buffers (distinct, as in production).
+        var bufW = new VulkanDevice.Buffer[outDims.Length];
+        var sharedOut = new VulkanDevice.Buffer[outDims.Length];
+        var perProjOut = new VulkanDevice.Buffer[outDims.Length];
+        try
+        {
+            for (int p = 0; p < outDims.Length; p++)
+            {
+                int m = outDims[p];
+                byte[] wq = QuantizeRows(RandomFloats(rng, m * k, range: 0.1f), m, k);
+                long wbytes = ((long)wq.Length + 3) & ~3L;
+                bufW[p] = device.Allocate(wbytes);
+                sharedOut[p] = device.Allocate((long)m * sizeof(float));
+                perProjOut[p] = device.Allocate((long)m * sizeof(float));
+                device.Upload(new ReadOnlySpan<byte>(wq), bufW[p]);
+            }
+
+            // SHARE: one quantize, then one GEMV per projection (no inter-GEMV barrier).
+            using (var ctx = device.CreateSubmitContext())
+            {
+                ctx.Begin();
+                quant.Record(ctx.CommandBuffer, bufX, bufXq, bufXds, k);
+                DotLLM.Vulkan.Kernels.KernelSupport.ComputeToComputeBarrier(ctx.CommandBuffer);
+                for (int p = 0; p < outDims.Length; p++)
+                    mmvq.Record(ctx.CommandBuffer, bufW[p], bufXq, bufXds, sharedOut[p], outDims[p], k);
+                ctx.SubmitAndWait();
+            }
+
+            // NO_SHARE: re-quantize before each GEMV (per-call form), barriers between.
+            using (var ctx = device.CreateSubmitContext())
+            {
+                ctx.Begin();
+                for (int p = 0; p < outDims.Length; p++)
+                {
+                    if (p > 0) DotLLM.Vulkan.Kernels.KernelSupport.ComputeToComputeBarrier(ctx.CommandBuffer);
+                    quant.Record(ctx.CommandBuffer, bufX, bufXq, bufXds, k);
+                    DotLLM.Vulkan.Kernels.KernelSupport.ComputeToComputeBarrier(ctx.CommandBuffer);
+                    mmvq.Record(ctx.CommandBuffer, bufW[p], bufXq, bufXds, perProjOut[p], outDims[p], k);
+                }
+                ctx.SubmitAndWait();
+            }
+
+            for (int p = 0; p < outDims.Length; p++)
+            {
+                int m = outDims[p];
+                float[] s = new float[m];
+                float[] np = new float[m];
+                device.Download(sharedOut[p], s);
+                device.Download(perProjOut[p], np);
+                for (int i = 0; i < m; i++)
+                    Assert.True(s[i].Equals(np[i]),
+                        $"Shared vs per-projection mismatch at proj {p}, idx {i} (k={k}, m={m}): " +
+                        $"shared={s[i]:G9}, perProj={np[i]:G9}.");
+            }
+        }
+        finally
+        {
+            foreach (var b in bufW) b?.Dispose();
+            foreach (var b in sharedOut) b?.Dispose();
+            foreach (var b in perProjOut) b?.Dispose();
+        }
+    }
+
     // ─────────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────────

--- a/tests/DotLLM.Tests.Unit/Vulkan/VulkanMmvqSharedQuantBench.cs
+++ b/tests/DotLLM.Tests.Unit/Vulkan/VulkanMmvqSharedQuantBench.cs
@@ -1,0 +1,258 @@
+using System.Diagnostics;
+using System.Text;
+using DotLLM.Vulkan;
+using DotLLM.Vulkan.Kernels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Unit.Vulkan;
+
+/// <summary>
+/// Opt-in micro-benchmark for the MMVQ shared-activation-quant optimisation
+/// (<see cref="VulkanTransformerModel.MmvqNoShareEnvVar"/>). Times the two
+/// same-input decode projection groups — Q/K/V (post-attn-norm input) and
+/// gate/up (post-ffn-norm input) — recorded the production way:
+/// <c>quantize_q8_1 → barrier → GEMV per projection</c>, with a
+/// compute→compute barrier between dispatches. Buffers are host-visible
+/// (Arc/Xe-LPG is unified memory, so this is GPU-resident — same allocation the
+/// established VulkanGemvWorkgroupSweep / VulkanSubgroupMicroBench harnesses use).
+/// <para>
+/// SHARE records ONE quantize for the whole group; NO_SHARE records one
+/// quantize per projection (the original per-call <c>RecordMatmul</c> form).
+/// The delta is the redundant quantize dispatches + their barriers the
+/// optimisation removes. The bench also sums the full decode-step Q8_0 GEMV
+/// cost so the saving can be reported as a fraction of a realistic decode step
+/// (the denominator that decides "win vs marginal").
+/// </para>
+/// <para>
+/// Enable with <c>DOTLLM_VULKAN_MMVQ_SHARE_BENCH=1</c>. Arc only:
+/// <c>DOTLLM_VULKAN_DEVICE_VENDOR=0x8086</c>. Emits a Markdown table to stdout.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Not a BenchmarkDotNet harness — single-process walltime, batched-fence +
+/// paired-median, matching the project's existing Vulkan micro-benches. iGPU
+/// clocks vary run-to-run; the median over <see cref="Passes"/> passes is the
+/// load-bearing number, single samples are not.
+/// </remarks>
+[Trait("Category", "GPU")]
+[Collection("VulkanKernels")]
+public sealed class VulkanMmvqSharedQuantBench
+{
+    // Kept modest so a pass stays well under the GPU watchdog (TDR) window on
+    // the Arc iGPU — the lm_head-class shape is heavy and back-to-back launches
+    // accumulate. 16 * 4 = 64 timed groups per pass is plenty for a stable
+    // median of the dispatch+barrier delta.
+    private const int BatchSize = 16;       // launches per submit (amortise fence)
+    private const int BatchesPerPass = 4;   // 16 * 4 = 64 timed groups per pass
+    private const int WarmupPasses = 2;
+    private const int Passes = 7;
+
+    private readonly ITestOutputHelper _output;
+
+    public VulkanMmvqSharedQuantBench(ITestOutputHelper output) => _output = output;
+
+    // Decode (seqLen==1) projection groups at SmolLM/Llama-3.2-1B-class shapes
+    // (hidden=2048, GQA). Each group shares one activation row of length K.
+    // CountInStep weights the group's per-decode-step contribution.
+    private static readonly (string Tag, int K, int[] OutDims)[] Groups =
+    [
+        // Q/K/V over post-attn-norm hidden (K = hidden). GQA: Q=2048, K=V=512.
+        ("qkv (Q=2048,K=V=512)", 2048, [2048, 512, 512]),
+        // gate/up over post-ffn-norm hidden (K = hidden). Both = intermediate.
+        ("gate_up (8192,8192)", 2048, [8192, 8192]),
+    ];
+
+    // Singleton projections in a decode step that do NOT share input (for the
+    // full-step GEMV denominator): o_proj, down_proj, lm_head.
+    private static readonly (string Tag, int M, int K)[] Singletons =
+    [
+        ("o_proj",  2048, 2048),
+        ("down",    2048, 8192),
+        ("lm_head", 32000, 2048),
+    ];
+
+    // Heavy singletons (lm_head-class) get a small launch batch so a single
+    // submit stays well inside the GPU watchdog window.
+    private const int HeavyBatchSize = 4;
+
+    [SkippableFact]
+    public void Bench_SharedVsPerProjectionQuant()
+    {
+        Skip.IfNot(
+            Environment.GetEnvironmentVariable("DOTLLM_VULKAN_MMVQ_SHARE_BENCH") == "1",
+            "DOTLLM_VULKAN_MMVQ_SHARE_BENCH=1 to enable this benchmark.");
+        VulkanMatMulF32KernelTests.SkipIfUnavailable(out string spvDir);
+
+        using var device = VulkanDevice.Create();
+        Skip.IfNot(device.HasIntegerDotProduct,
+            "Device lacks integer-dot-product; MMVQ path unavailable.");
+
+        using var quant = QuantizeQ8_1Kernel.TryCreate(device, spvDir)!;
+        using var gemv = MatMulQ8_0MmvqKernel.TryCreate(device, spvDir)!;
+        Skip.If(quant is null || gemv is null, "MMVQ SPVs missing.");
+
+        var sb = new StringBuilder();
+        sb.AppendLine("| group | K | per-proj µs | shared µs | saved µs/group | speedup |");
+        sb.AppendLine("|---|---:|---:|---:|---:|---:|");
+
+        double totalSavedPerStep = 0;
+        foreach (var (tag, k, outDims) in Groups)
+        {
+            double perProj = TimeGroup(device, quant, gemv, k, outDims, share: false);
+            double shared = TimeGroup(device, quant, gemv, k, outDims, share: true);
+            double saved = perProj - shared;
+            totalSavedPerStep += saved; // one such group per layer
+            sb.AppendLine(
+                $"| {tag} | {k} | {perProj:F2} | {shared:F2} | {saved:F2} | {perProj / shared:F2}x |");
+        }
+
+        // Denominator: full decode-step Q8_0 GEMV cost = shared groups + singletons.
+        double stepGemv = 0;
+        foreach (var (_, k, outDims) in Groups)
+            stepGemv += TimeGroup(device, quant, gemv, k, outDims, share: true);
+        foreach (var (_, m, k) in Singletons)
+            stepGemv += TimeSingletonGemv(device, quant, gemv, m, k);
+
+        _output.WriteLine("Device: " + device.DeviceName);
+        _output.WriteLine($"IntegerDotProduct: {device.HasIntegerDotProduct}, SubgroupSize: {device.SubgroupSize}");
+        _output.WriteLine($"Schedule: {WarmupPasses} warmup + {Passes} timed passes,"
+            + $" {BatchesPerPass} batches × {BatchSize} groups per pass (median pass)");
+        _output.WriteLine(string.Empty);
+        _output.WriteLine(sb.ToString());
+        _output.WriteLine(string.Empty);
+        _output.WriteLine(
+            $"Saved per layer (Q/K/V + gate/up redundant quant): {totalSavedPerStep:F2} µs");
+        _output.WriteLine(
+            $"Full decode-step Q8_0 GEMV cost (1 layer's worth, shapes above): {stepGemv:F2} µs");
+        if (stepGemv > 0)
+            _output.WriteLine(
+                $"Saving as fraction of one layer's GEMV cost: {100.0 * totalSavedPerStep / stepGemv:F2}%");
+    }
+
+    // Records `share ? 1 : outDims.Length` quantize dispatches + one GEMV per
+    // outDim, with a compute→compute barrier after the/each quantize and between
+    // GEMVs — mirrors the production RecordSharedInputMmvqGroup vs per-call form.
+    private double TimeGroup(
+        VulkanDevice device, QuantizeQ8_1Kernel quant, MatMulQ8_0MmvqKernel gemv,
+        int k, int[] outDims, bool share)
+    {
+        int maxM = 0;
+        foreach (int m in outDims) maxM = Math.Max(maxM, m);
+
+        var rng = new Random(7);
+        using var bufX = device.Allocate((long)k * sizeof(float));
+        using var bufXq = device.Allocate(QuantizeQ8_1Kernel.PackedBytes(k));
+        using var bufXds = device.Allocate(QuantizeQ8_1Kernel.ScaleBytes(k));
+
+        // One weight blob + output per projection (distinct buffers, like prod).
+        var weights = new VulkanDevice.Buffer[outDims.Length];
+        var outputs = new VulkanDevice.Buffer[outDims.Length];
+        try
+        {
+            UploadRandom(device, bufX, k, rng);
+            for (int p = 0; p < outDims.Length; p++)
+            {
+                long rowBytes = (long)(k / 32) * 34;
+                weights[p] = device.Allocate((long)outDims[p] * rowBytes);
+                outputs[p] = device.Allocate((long)outDims[p] * sizeof(float));
+                UploadRandomBytes(device, weights[p], (long)outDims[p] * rowBytes, rng);
+            }
+
+            void Record(nint cmd)
+            {
+                if (share)
+                {
+                    quant.Record(cmd, bufX, bufXq, bufXds, k);
+                    KernelSupport.ComputeToComputeBarrier(cmd);
+                    for (int p = 0; p < outDims.Length; p++)
+                        gemv.Record(cmd, weights[p], bufXq, bufXds, outputs[p], outDims[p], k);
+                }
+                else
+                {
+                    for (int p = 0; p < outDims.Length; p++)
+                    {
+                        if (p > 0) KernelSupport.ComputeToComputeBarrier(cmd);
+                        quant.Record(cmd, bufX, bufXq, bufXds, k);
+                        KernelSupport.ComputeToComputeBarrier(cmd);
+                        gemv.Record(cmd, weights[p], bufXq, bufXds, outputs[p], outDims[p], k);
+                    }
+                }
+            }
+
+            return MeasureMedian(device, Record);
+        }
+        finally
+        {
+            foreach (var b in weights) b?.Dispose();
+            foreach (var b in outputs) b?.Dispose();
+        }
+    }
+
+    private double TimeSingletonGemv(
+        VulkanDevice device, QuantizeQ8_1Kernel quant, MatMulQ8_0MmvqKernel gemv,
+        int m, int k)
+    {
+        var rng = new Random(11);
+        long rowBytes = (long)(k / 32) * 34;
+        using var bufX = device.Allocate((long)k * sizeof(float));
+        using var bufXq = device.Allocate(QuantizeQ8_1Kernel.PackedBytes(k));
+        using var bufXds = device.Allocate(QuantizeQ8_1Kernel.ScaleBytes(k));
+        using var bufW = device.Allocate((long)m * rowBytes);
+        using var bufY = device.Allocate((long)m * sizeof(float));
+        UploadRandom(device, bufX, k, rng);
+        UploadRandomBytes(device, bufW, (long)m * rowBytes, rng);
+
+        void Record(nint cmd)
+        {
+            quant.Record(cmd, bufX, bufXq, bufXds, k);
+            KernelSupport.ComputeToComputeBarrier(cmd);
+            gemv.Record(cmd, bufW, bufXq, bufXds, bufY, m, k);
+        }
+
+        // Heavy shape (large M) → smaller launch batch to dodge the watchdog.
+        int batch = m >= 16384 ? HeavyBatchSize : BatchSize;
+        return MeasureMedian(device, Record, batch);
+    }
+
+    private static double MeasureMedian(VulkanDevice device, Action<nint> record, int batchSize = BatchSize)
+    {
+        for (int w = 0; w < WarmupPasses; w++) RunPass(device, record, batchSize);
+        var passUs = new double[Passes];
+        for (int p = 0; p < Passes; p++) passUs[p] = RunPass(device, record, batchSize);
+        Array.Sort(passUs);
+        return passUs[Passes / 2];
+    }
+
+    // One pass = BatchesPerPass submits, each recording batchSize groups behind a
+    // single fence. Returns mean µs per group over the pass.
+    private static double RunPass(VulkanDevice device, Action<nint> record, int batchSize)
+    {
+        using var ctx = device.CreateSubmitContext();
+        var sw = Stopwatch.StartNew();
+        for (int b = 0; b < BatchesPerPass; b++)
+        {
+            ctx.Begin();
+            for (int i = 0; i < batchSize; i++)
+                record(ctx.CommandBuffer);
+            ctx.SubmitAndWait();
+        }
+        sw.Stop();
+        long groups = (long)BatchesPerPass * batchSize;
+        return sw.Elapsed.TotalMicroseconds / groups;
+    }
+
+    private static void UploadRandom(VulkanDevice device, VulkanDevice.Buffer buf, int k, Random rng)
+    {
+        var x = new float[k];
+        for (int i = 0; i < k; i++) x[i] = (float)(rng.NextDouble() * 0.1 - 0.05);
+        device.Upload(x, buf);
+    }
+
+    private static void UploadRandomBytes(VulkanDevice device, VulkanDevice.Buffer buf, long bytes, Random rng)
+    {
+        var data = new byte[bytes];
+        rng.NextBytes(data);
+        device.Upload(data, buf);
+    }
+}


### PR DESCRIPTION
## Summary

On the dp4a **MMVQ** decode path (#46), **Q/K/V** all read the same post-attn-norm hidden state and **gate/up** both read the same post-ffn-norm hidden state — yet each projection re-ran `quantize_q8_1` on that *identical* activation before its GEMV. This folds the quant: a new `RecordSharedInputMmvqGroup` quantizes the shared activation **once per same-input group**, then dispatches the group's integer-dot GEMVs against the single quantized copy.

This is the genuine delta the superseded spike PR **#62** claimed over `dev` (the spike's `RecordSharedInputMatmulPair`), now folded into `dev`'s MMVQ kernels (#46/#50). The other thing #62 claimed — Intel/Arc default-on — is **already covered** on `dev` by the `HasIntegerDotProduct` gate.

## What changed

- **`RecordSharedInputMmvqGroup`**: `quantize → barrier → GEMV_Q, GEMV_K, GEMV_V` with **no inter-GEMV barrier** (GEMVs only read the shared scratch and write disjoint outputs). The existing post-group barrier still separates the group from the bias/next stage.
- **Default-on** whenever MMVQ is wired; `DOTLLM_VULKAN_MMVQ_NO_SHARE=1` forces the original per-projection path (used by the parity test / A-B bench).
- **Decode-only (`seqLen==1`)**: prefill, non-Q8_0 members, and unsupported shapes fall back to per-projection `RecordMatmul` at the caller's **real seqLen**, preserving the prefill MMQ/coopmat/scalar routing.
- The projection list uses a **reusable instance-field array** so command-buffer recording stays allocation-free (the project's zero-alloc-on-record rule).

## Measured (Intel Arc, Xe-LPG, Vulkan)

SmolLM / Llama-3.2-1B decode shapes, batched-fence + paired-median, integer-dot path:

| group | per-proj µs | shared µs | speedup |
|---|---:|---:|---:|
| Q/K/V (Q=2048, K=V=512) | 2651.9 | 1798.7 | **1.47x** |
| gate/up (8192, 8192) | 6911.0 | 4563.1 | **1.51x** |

≈ **7.5%** of one layer's Q8_0 decode-GEMV cost. (On an RTX 3060 the same delta is ~1.06x / ~2% — Arc's higher per-dispatch + barrier overhead makes collapsing the redundant quantize dispatches materially more valuable. This optimisation targets the iGPU/Vulkan decode profile.)

## Parity (all on Arc)

- **`Mmvq_SharedQuant_BitIdenticalToPerProjection`** (unit, kernel level): shared vs per-projection GEMV outputs are **bit-identical**.
- **`VulkanMmvqSharedQuantParityTests`** (integration): full Vulkan decode forward on the **real SmolLM-135M.Q8_0 GGUF** through the restructured Q/K/V + gate/up call sites is **bit-identical** with sharing on vs `DOTLLM_VULKAN_MMVQ_NO_SHARE=1`, across prefill + decode steps. (This is the discriminating *wiring* test — it caught a prefill seqLen-routing bug during development that the kernel-level invariant test could not.)
- Existing **CPU-vs-Vulkan SmolLM forward parity** and **MoE Q8_0 forward** tests still pass.

`VulkanMmvqSharedQuantBench` is an opt-in micro-bench (`DOTLLM_VULKAN_MMVQ_SHARE_BENCH=1`) for the share-vs-no-share decode delta.

## Notes / follow-ups

- The MoE shared-expert `W1`/`W3` pair also shares its input; folding it into a group is a natural follow-up, intentionally left out of scope here.
- Supersedes the shared-activation-quant portion of **#62**; closing **#62/#67/#73** as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)