### PR TITLE
Hybrid LoRA: adapt CPU + GPU layers in HybridTransformerModel (#82)

### DIFF
--- a/src/DotLLM.Cli/Commands/RunCommand.cs
+++ b/src/DotLLM.Cli/Commands/RunCommand.cs
@@ -262,15 +262,6 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
                 throw new InvalidOperationException($"LoRA adapter at '{settings.LoraPath}' is incompatible with this base model.");
         }
 
-        // HybridTransformerModel does not thread the adapter through its Forward path (neither GPU
-        // nor CPU layers); warn rather than silently producing base output.
-        if (loraAdapter is not null && model is DotLLM.Cuda.HybridTransformerModel)
-        {
-            const string hybridLoraWarning = "WARNING: --lora is not applied in hybrid mode; neither GPU-offloaded nor CPU-resident layers are adapted. Use --device cpu or --device gpu (full GPU) for full adapter application.";
-            if (settings.Json) Console.Error.WriteLine(hybridLoraWarning);
-            else AnsiConsole.MarkupLine($"[yellow]{Markup.Escape(hybridLoraWarning)}[/]");
-        }
-
         var threadingInfo = new ThreadingConfig(settings.Threads, settings.DecodeThreads, settings.NumaPin, settings.PCoreOnly);
 
         // Parse tool definitions and format prompt via chat template when tools are provided

--- a/src/DotLLM.Cuda/HybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/HybridTransformerModel.cs
@@ -642,6 +642,15 @@ public sealed unsafe class HybridTransformerModel : IModel
                 var rl = repackedLayers?[layer];
                 int cpuCacheLayer = layer; // HybridKvCache handles remapping
 
+                // When a LoRA adapter is active the F32 LoRA delta reads the normed
+                // projection input (normOut for Q/K/V and gate/up). The fused
+                // RmsNormQuantize decode fast-path skips materialising normOut (it
+                // writes only the quantised bytes), so force the unfused (prefill-
+                // style) path in both the attention and FFN blocks below — exactly
+                // as TransformerModel does. Adapter-less path keeps the fused fast
+                // path → byte-identical to the 4-arg Forward.
+                bool adapterActive = _currentAdapter is not null;
+
                 // a. Copy hiddenState → residual
                 new Span<float>(hidden, seqLen * hiddenSize)
                     .CopyTo(new Span<float>(residual, seqLen * hiddenSize));
@@ -649,7 +658,7 @@ public sealed unsafe class HybridTransformerModel : IModel
                 // b. RMSNorm + Pre-quantize + Q/K/V projections
                 byte* inputQ8Scratch = (byte*)_cpuState.InputQ8Scratch;
 
-                if (seqLen == 1 && _threadPool != null)
+                if (seqLen == 1 && _threadPool != null && !adapterActive)
                 {
                     // Decode path: try fused RmsNorm+Quantize
                     byte* preQuantNorm = null;
@@ -699,6 +708,17 @@ public sealed unsafe class HybridTransformerModel : IModel
                 AddBias(lw.QBias, q, lw.QOutputDim, seqLen);
                 AddBias(lw.KBias, k, lw.KOutputDim, seqLen);
                 AddBias(lw.VBias, v, lw.VOutputDim, seqLen);
+
+                // LoRA delta (q/k/v): y += scale · (normOut · B) · A. Applied AFTER
+                // bias and BEFORE QK-norm / RoPE — mirrors TransformerModel and the
+                // GPU phase. x = normOut (F32, materialised by the !adapterActive
+                // gate above), y = q/k/v. `layer` is the absolute (global) index.
+                if (_currentAdapter is not null)
+                {
+                    ApplyLoraDeltaCpu(layer, "q_proj", normOut, q, seqLen, lw.QInputDim, lw.QOutputDim);
+                    ApplyLoraDeltaCpu(layer, "k_proj", normOut, k, seqLen, lw.KInputDim, lw.KOutputDim);
+                    ApplyLoraDeltaCpu(layer, "v_proj", normOut, v, seqLen, lw.VInputDim, lw.VOutputDim);
+                }
 
                 // Optional QK-norms
                 if (lw.QNormWeight is not null)
@@ -753,6 +773,13 @@ public sealed unsafe class HybridTransformerModel : IModel
                     preQuantAttn, in rwO);
                 AddBias(lw.OBias, normOut, lw.OOutputDim, seqLen);
 
+                // LoRA delta (o_proj): y += scale · (attnOut · B) · A. x = attnOut,
+                // which holds the Sub-LN'd attention output (the optional Sub-LN above
+                // ran in-place into attnOut) — the exact O-projection input. y = normOut
+                // (the O output). Applied after the O bias and BEFORE the residual add.
+                if (_currentAdapter is not null)
+                    ApplyLoraDeltaCpu(layer, "o_proj", attnOut, normOut, seqLen, lw.OInputDim, lw.OOutputDim);
+
                 // Residual add
                 for (int t = 0; t < seqLen; t++)
                 {
@@ -766,8 +793,10 @@ public sealed unsafe class HybridTransformerModel : IModel
                 new Span<float>(hidden, seqLen * hiddenSize)
                     .CopyTo(new Span<float>(residual, seqLen * hiddenSize));
 
-                // FFN: RMSNorm + Pre-quantize + Gate/Up projections
-                if (seqLen == 1 && _threadPool != null)
+                // FFN: RMSNorm + Pre-quantize + Gate/Up projections.
+                // Force the unfused path when an adapter is active so normOut (F32)
+                // is materialised for the gate/up LoRA delta — same trap as Q/K/V.
+                if (seqLen == 1 && _threadPool != null && !adapterActive)
                 {
                     byte* preQuantFfn = null;
                     if (IsCompatiblePreQuant(lw.GateQuantType, lw.UpQuantType))
@@ -809,6 +838,16 @@ public sealed unsafe class HybridTransformerModel : IModel
                 AddBias(lw.GateBias, ffnGate, lw.GateOutputDim, seqLen);
                 AddBias(lw.UpBias, ffnUp, lw.UpOutputDim, seqLen);
 
+                // LoRA delta (gate/up): y += scale · (normOut · B) · A. x = normOut
+                // (FFN-normed input, F32, materialised by the !adapterActive gate
+                // above), y = ffnGate/ffnUp. Applied after biases and BEFORE the GLU
+                // activation below — mirrors TransformerModel and the GPU phase.
+                if (_currentAdapter is not null)
+                {
+                    ApplyLoraDeltaCpu(layer, "gate_proj", normOut, ffnGate, seqLen, lw.GateInputDim, lw.GateOutputDim);
+                    ApplyLoraDeltaCpu(layer, "up_proj", normOut, ffnUp, seqLen, lw.UpInputDim, lw.UpOutputDim);
+                }
+
                 // Gated activation: SwiGLU (default) or squared-ReLU GLU (BitNet b1.58).
                 bool useReluSquared = Config.ActivationFunction == ActivationFunction.ReluSquared;
                 for (int t = 0; t < seqLen; t++)
@@ -838,6 +877,12 @@ public sealed unsafe class HybridTransformerModel : IModel
                 GemmInterleaved(lw.DownWeight, lw.DownQuantType, siluOut, normOut, lw.DownOutputDim, lw.DownInputDim, seqLen,
                     preQuantSilu, in rwDown);
                 AddBias(lw.DownBias, normOut, lw.DownOutputDim, seqLen);
+
+                // LoRA delta (down_proj): y += scale · (siluOut · B) · A. x = siluOut
+                // (the post-GLU, possibly FFN-Sub-LN'd, down-projection input), y = normOut
+                // (down output). Applied after the down bias and BEFORE the FFN residual add.
+                if (_currentAdapter is not null)
+                    ApplyLoraDeltaCpu(layer, "down_proj", siluOut, normOut, seqLen, lw.DownInputDim, lw.DownOutputDim);
 
                 // Residual add
                 for (int t = 0; t < seqLen; t++)
@@ -936,7 +981,7 @@ public sealed unsafe class HybridTransformerModel : IModel
     /// <summary>
     /// Applies the GPU-phase LoRA delta for one projection: <c>y += scale · (x · B) · A</c>,
     /// using the staged FP16 factors (<c>B[rank, inputDim]</c>, <c>A[outputDim, rank]</c>) via
-    /// the shared <see cref="_gpuState.LoraTmp"/> scratch. Mirrors
+    /// the shared <c>_gpuState.LoraTmp</c> scratch. Mirrors
     /// <c>CudaTransformerModel.ApplyLoraDeltaDevice</c> (M2): decode (seqLen==1) uses two GEMVs,
     /// prefill (seqLen&gt;1) uses two batched GEMMs. Early-returns when no adapter is staged or
     /// the adapter does not target <paramref name="proj"/> at this layer.
@@ -977,6 +1022,44 @@ public sealed unsafe class HybridTransformerModel : IModel
             // Step 2: Y[seqLen, outputDim] += scale · tmp[seqLen, rank] × A^T
             CudaGemm.LinearF16Accum(cublasH, tmp, aF16, yDev, seqLen, rank, outputDim, scale, s);
         }
+    }
+
+    /// <summary>
+    /// Applies the CPU-phase LoRA delta for one projection: <c>y += scale · (x · B) · A</c>,
+    /// using the shared F32 <see cref="LoraDelta.Apply(float*, float*, float*, float*, int, int, int, int, float, nint)"/>
+    /// kernel. Mirrors <c>TransformerModel.ApplyLoraDelta</c>'s structure but is scoped to F32
+    /// adapter weights only — the Q8_0 / outer-product / pre-quantised-X fast paths that
+    /// <c>TransformerModel.ApplyLoraDelta</c> dispatches into are out of scope for the hybrid CPU
+    /// phase (the synthetic / parity adapters are F32). Early-returns when no adapter is staged or
+    /// the adapter does not target <paramref name="proj"/> at this layer. <paramref name="layer"/>
+    /// is the absolute (global) layer index.
+    /// </summary>
+    private void ApplyLoraDeltaCpu(int layer, string proj, float* x, float* y,
+                                   int seqLen, int inputDim, int outputDim)
+    {
+        var adapter = _currentAdapter;
+        if (adapter is null)
+            return;
+
+        var lora = adapter.GetLayerWeights(layer, proj);
+        if (lora is not { } w)
+            return; // untargeted projection — no-op
+
+        if (w.InputDim != inputDim || w.OutputDim != outputDim)
+            throw new InvalidOperationException(
+                $"LoRA adapter shape mismatch at layer {layer} proj {proj}: " +
+                $"adapter [{w.InputDim}->{w.OutputDim}] vs projection [{inputDim}->{outputDim}].");
+
+        if (w.WeightDType != LoraWeightDType.F32)
+            throw new NotSupportedException(
+                $"Hybrid CPU LoRA currently supports F32 adapter weights only (proj={proj} is {w.WeightDType}); " +
+                "use --device cpu for other dtypes.");
+
+        // y += (adapter.Alpha / adapter.Rank) · (x · B) · A. Legacy stage-2 path
+        // (aTransposedHandle: 0) — the outer-product fast path is out of scope here.
+        LoraDelta.Apply(x, (float*)w.BHandle, (float*)w.AHandle, y,
+                        seqLen, inputDim, outputDim, adapter.Rank,
+                        adapter.Alpha / adapter.Rank);
     }
 
     // ═══════════════════════════════════════════════════

--- a/src/DotLLM.Cuda/HybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/HybridTransformerModel.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using DotLLM.Core.Attention;
 using DotLLM.Core.Configuration;
+using DotLLM.Core.Lora;
 using DotLLM.Core.Models;
 using DotLLM.Core.Tensors;
 using DotLLM.Cpu.Kernels;
@@ -54,6 +55,14 @@ public sealed unsafe class HybridTransformerModel : IModel
     private readonly int? _slidingWindowSize;
     private nint _fp16TransferBuffer;
     private int _fp16TransferCapacity; // in elements
+
+    // ── LoRA adapter staging (GPU phase) ──
+    // Set by the 5-arg Forward overload; read in the GPU layer loop to apply the
+    // per-projection device delta. Mirrors CudaTransformerModel's M2 fields. The CPU
+    // phase delta (Task 2) will read _currentAdapter separately. Null → adapter-less
+    // path is byte-identical to the 4-arg Forward.
+    private ILoraAdapter? _currentAdapter;
+    private CudaLoraWeights? _cudaLora;
 
     /// <inheritdoc/>
     public ModelConfig Config { get; }
@@ -327,6 +336,40 @@ public sealed unsafe class HybridTransformerModel : IModel
 
     /// <inheritdoc/>
     /// <remarks>
+    /// Implements <see cref="IModel"/>'s default 5-arg overload. When
+    /// <paramref name="adapter"/> is null this delegates to the 4-arg
+    /// <see cref="Forward(ReadOnlySpan{int}, ReadOnlySpan{int}, int, IKvCache?)"/>,
+    /// reproducing the adapter-less forward byte-for-byte. Otherwise it stages the
+    /// adapter onto the GPU (identity-cached on <see cref="CudaLoraWeights.Source"/>),
+    /// then runs the 4-arg forward with <see cref="_currentAdapter"/> set so the GPU
+    /// layer loop applies the per-projection delta. The CPU-phase delta is added by a
+    /// separate task; the GPU-phase delta lands here.
+    /// </remarks>
+    public ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions,
+                           int deviceId, IKvCache? kvCache, ILoraAdapter? adapter)
+    {
+        if (adapter is null)
+            return Forward(tokenIds, positions, deviceId, kvCache); // byte-equivalent
+
+        if (!ReferenceEquals(_cudaLora?.Source, adapter))
+        {
+            _cudaLora?.Dispose();
+            _cudaLora = CudaLoraWeights.Stage(adapter, Config, _kernels, _stream.Handle);
+        }
+
+        _currentAdapter = adapter;
+        try
+        {
+            return Forward(tokenIds, positions, deviceId, kvCache);
+        }
+        finally
+        {
+            _currentAdapter = null;
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
     /// SYNC WARNING: The GPU phase (layers 0..N-1) replicates logic from
     /// CudaTransformerModel.Forward and the CPU phase (layers N..L-1) replicates logic
     /// from TransformerModel.Forward. Bug fixes to attention, FFN, or norm logic may
@@ -420,6 +463,18 @@ public sealed unsafe class HybridTransformerModel : IModel
             if (lw.KBias != 0) _kernels.LaunchBiasAdd(_gpuState.K, lw.KBias, lw.KOutputDim, seqLen, s);
             if (lw.VBias != 0) _kernels.LaunchBiasAdd(_gpuState.V, lw.VBias, lw.VOutputDim, seqLen, s);
 
+            // LoRA delta (q/k/v): y += scale · (NormOutput · B) · A. Applied AFTER bias and
+            // BEFORE QK-norm + RoPE — mirrors CudaTransformerModel.ApplyLoraDeltaDevice (M2)
+            // and the CPU oracle (TransformerModel.cs). x = NormOutput (projection input),
+            // y = Q/K/V. No-op for projections the adapter does not target (TryGet returns false).
+            // `layer` is the absolute index (GPU phase = global layers 0..gpuLayers-1).
+            if (_currentAdapter is not null)
+            {
+                ApplyLoraDeltaDeviceGpu(layer, "q_proj", _gpuState.NormOutput, _gpuState.Q, seqLen);
+                ApplyLoraDeltaDeviceGpu(layer, "k_proj", _gpuState.NormOutput, _gpuState.K, seqLen);
+                ApplyLoraDeltaDeviceGpu(layer, "v_proj", _gpuState.NormOutput, _gpuState.V, seqLen);
+            }
+
             if (lw.QNormWeight != 0)
                 _kernels.LaunchPerHeadRmsNorm(_gpuState.Q, lw.QNormWeight, eps, numHeads, headDim, seqLen, s);
             if (lw.KNormWeight != 0)
@@ -454,6 +509,13 @@ public sealed unsafe class HybridTransformerModel : IModel
                 lw.OOutputDim, lw.OInputDim, seqLen);
             if (lw.OBias != 0) _kernels.LaunchBiasAdd(_gpuState.NormOutput, lw.OBias, lw.OOutputDim, seqLen, s);
 
+            // LoRA delta (o_proj): y += scale · (AttnOutput · B) · A. x = _gpuState.AttnOutput,
+            // which holds the Sub-LN'd attention output when AttnSubNormWeight ran in place above —
+            // the exact O-projection input the CPU oracle uses. y = NormOutput (the O output).
+            // Applied after the O bias and BEFORE the fused residual add. Mirrors M2.
+            if (_currentAdapter is not null)
+                ApplyLoraDeltaDeviceGpu(layer, "o_proj", _gpuState.AttnOutput, _gpuState.NormOutput, seqLen);
+
             // ── FUSED: attention residual + FFN norm ──
             _kernels.LaunchFusedAddRmsNorm(_gpuState.Residual, _gpuState.NormOutput,
                 lw.FfnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
@@ -466,6 +528,15 @@ public sealed unsafe class HybridTransformerModel : IModel
 
             if (lw.GateBias != 0) _kernels.LaunchBiasAdd(_gpuState.FfnGate, lw.GateBias, lw.GateOutputDim, seqLen, s);
             if (lw.UpBias != 0) _kernels.LaunchBiasAdd(_gpuState.FfnUp, lw.UpBias, lw.UpOutputDim, seqLen, s);
+
+            // LoRA delta (gate/up): y += scale · (NormOutput · B) · A. x = NormOutput (FFN-normed
+            // input), y = FfnGate/FfnUp (raw projection outputs). Applied after biases and BEFORE
+            // the GLU activation below — mirrors M2 and the CPU oracle.
+            if (_currentAdapter is not null)
+            {
+                ApplyLoraDeltaDeviceGpu(layer, "gate_proj", _gpuState.NormOutput, _gpuState.FfnGate, seqLen);
+                ApplyLoraDeltaDeviceGpu(layer, "up_proj", _gpuState.NormOutput, _gpuState.FfnUp, seqLen);
+            }
 
             // BitNet's relu(gate)²·up intermediate overflows FP16; fuse activation + Sub-LN RMSNorm
             // (kept in FP32) when the Sub-LN weight is present. See CudaTransformerModel for rationale.
@@ -491,6 +562,12 @@ public sealed unsafe class HybridTransformerModel : IModel
             ProjectGpu(lw.DownQuant, lw.DownQuantType, lw.Down, _gpuState.SiluOutput, _gpuState.NormOutput,
                 lw.DownOutputDim, lw.DownInputDim, seqLen);
             if (lw.DownBias != 0) _kernels.LaunchBiasAdd(_gpuState.NormOutput, lw.DownBias, lw.DownOutputDim, seqLen, s);
+
+            // LoRA delta (down_proj): y += scale · (SiluOutput · B) · A. x = SiluOutput (the
+            // post-GLU, possibly FFN-Sub-LN'd, down-projection input), y = NormOutput (down
+            // output). Applied after the down bias and BEFORE the FFN residual add. Mirrors M2.
+            if (_currentAdapter is not null)
+                ApplyLoraDeltaDeviceGpu(layer, "down_proj", _gpuState.SiluOutput, _gpuState.NormOutput, seqLen);
 
             // ── FUSED: FFN residual + next layer setup ──
             if (layer < gpuLayers - 1)
@@ -856,6 +933,52 @@ public sealed unsafe class HybridTransformerModel : IModel
         }
     }
 
+    /// <summary>
+    /// Applies the GPU-phase LoRA delta for one projection: <c>y += scale · (x · B) · A</c>,
+    /// using the staged FP16 factors (<c>B[rank, inputDim]</c>, <c>A[outputDim, rank]</c>) via
+    /// the shared <see cref="_gpuState.LoraTmp"/> scratch. Mirrors
+    /// <c>CudaTransformerModel.ApplyLoraDeltaDevice</c> (M2): decode (seqLen==1) uses two GEMVs,
+    /// prefill (seqLen&gt;1) uses two batched GEMMs. Early-returns when no adapter is staged or
+    /// the adapter does not target <paramref name="proj"/> at this layer.
+    /// </summary>
+    private void ApplyLoraDeltaDeviceGpu(int layer, string proj, nint xDev, nint yDev, int seqLen)
+    {
+        if (_cudaLora is null)
+            return;
+        if (!_cudaLora.TryGet(layer, proj, out nint aF16, out nint bF16, out int inputDim, out int outputDim))
+            return;
+
+        int rank = _cudaLora.Rank;
+        if (rank > CudaForwardState.MaxLoraRank)
+            throw new InvalidOperationException(
+                $"LoRA rank {rank} exceeds the device delta rank cap ({CudaForwardState.MaxLoraRank}). " +
+                $"Reduce adapter rank or rebuild with a higher MaxLoraRank.");
+
+        float scale = _cudaLora.Scale;
+        nint tmp = _gpuState.LoraTmp;  // [seqLen, MaxLoraRank] FP16
+        nint s = _stream.Handle;
+        nint cublasH = _cublas.Handle;
+
+        if (seqLen == 1)
+        {
+            // Decode path — two GEMVs.
+            // Step 1: tmp[rank] = B[rank, inputDim] · x[inputDim]  (overwrites tmp)
+            CudaGemm.GemvF16(cublasH, bF16, xDev, tmp, rank, inputDim, s);
+
+            // Step 2: y[outputDim] += scale · A[outputDim, rank] · tmp[rank]
+            CudaGemm.GemvF16Accum(cublasH, aF16, tmp, yDev, outputDim, rank, scale, s);
+        }
+        else
+        {
+            // Prefill path — two batched GEMMs.
+            // Step 1: tmp[seqLen, rank] = X[seqLen, inputDim] × B^T  (overwrites tmp)
+            CudaGemm.LinearF16(cublasH, xDev, bF16, tmp, seqLen, inputDim, rank, s);
+
+            // Step 2: Y[seqLen, outputDim] += scale · tmp[seqLen, rank] × A^T
+            CudaGemm.LinearF16Accum(cublasH, tmp, aF16, yDev, seqLen, rank, outputDim, scale, s);
+        }
+    }
+
     // ═══════════════════════════════════════════════════
     //  CPU helpers (same as TransformerModel private methods)
     // ═══════════════════════════════════════════════════
@@ -1165,6 +1288,7 @@ public sealed unsafe class HybridTransformerModel : IModel
     /// <inheritdoc/>
     public void Dispose()
     {
+        _cudaLora?.Dispose();
         _gpuState.Dispose();
         _gpuWeights.Dispose();
         _kernels.Dispose();

--- a/tests/DotLLM.Tests.Integration/Models/Lora/HybridLoraParityTests.cs
+++ b/tests/DotLLM.Tests.Integration/Models/Lora/HybridLoraParityTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace DotLLM.Tests.Integration.Models.Lora;
 
 /// <summary>
-/// Hybrid CPU+GPU LoRA parity gate (#82).
+/// Hybrid CPU+GPU LoRA parity vs full-CPU, on SmolLM-135M (#82).
 /// Verifies that <see cref="HybridTransformerModel.Forward"/> with a synthetic LoRA adapter
 /// produces logits that are numerically consistent with the full-CPU reference path.
 /// With a half-layer split (numGpuLayers = cfg.NumLayers / 2) both GPU-resident and
@@ -19,8 +19,9 @@ namespace DotLLM.Tests.Integration.Models.Lora;
 /// Also asserts that hybrid+adapter ≠ hybrid-without-adapter (delta actually fires).
 /// </summary>
 /// <remarks>
-/// Plain [Fact] with early-return no-op when DOTLLM_BITNET_GGUF is unset/missing
+/// Plain [Fact] with early-return no-op when the SmolLM-135M Q8_0 GGUF is absent
 /// or when CUDA is unavailable — no SkippableFact dependency needed.
+/// Model path is hardcoded to the cached location; test skips gracefully if not present.
 /// Kept in its own class to avoid cross-class GPU parallelism.
 /// </remarks>
 public sealed class HybridLoraParityTests
@@ -29,16 +30,16 @@ public sealed class HybridLoraParityTests
 
     public HybridLoraParityTests(ITestOutputHelper output) => _output = output;
 
-    private static string? ModelPath =>
-        Environment.GetEnvironmentVariable("DOTLLM_BITNET_GGUF");
+    private static string ModelPath =>
+        @"C:/Users/james/.dotllm/models/QuantFactory/SmolLM-135M-GGUF/SmolLM-135M.Q8_0.gguf";
 
     [Fact]
     public unsafe void HybridAndCpu_LoraLogits_AreNumericallyConsistent()
     {
         // ── Guard 1: model file must be present ──────────────────────────────────
-        if (ModelPath is null || !File.Exists(ModelPath))
+        if (!File.Exists(ModelPath))
         {
-            _output.WriteLine("SKIP: BitNet GGUF not available (set DOTLLM_BITNET_GGUF).");
+            _output.WriteLine("SKIP: SmolLM-135M Q8_0 GGUF not found.");
             return;
         }
 
@@ -50,7 +51,7 @@ public sealed class HybridLoraParityTests
         }
 
         // ── Setup ─────────────────────────────────────────────────────────────────
-        using var gguf = GgufFile.Open(ModelPath!);
+        using var gguf = GgufFile.Open(ModelPath);
         var cfg = GgufModelConfigExtractor.Extract(gguf.Metadata);
 
         int[] tok = [1, 2, 3];
@@ -108,7 +109,7 @@ public sealed class HybridLoraParityTests
         double cosine = CosineSimilarity(hybridVec, cpuVec);
         bool adapterChangedHybrid = VectorsAreDifferent(hybridVec, hybridBaseVec, threshold: 1e-4f);
 
-        // Base-vs-base diagnostic (helps isolate pre-existing hybrid divergence from LoRA bugs)
+        // Base-vs-base sanity: hybrid-base should match cpu-base for SmolLM (non-BitNet model)
         using ITensor cpuBaseLogitsRaw = cpuModel.Forward(tok, pos, deviceId: -1, kvCache: null, adapter: null);
         float[] cpuBaseVec = new float[vocabSize];
         fixed (float* dst = cpuBaseVec)
@@ -133,7 +134,7 @@ public sealed class HybridLoraParityTests
         _output.WriteLine(cosineBaseVsBase > 0.999
             ? $"[Diagnostic] Base parity OK (cosine={cosineBaseVsBase:F6} > 0.999)"
             : $"[Diagnostic] Base parity WARN: hybrid-base diverges from cpu-base (cosine={cosineBaseVsBase:F6}). " +
-              $"Pre-existing hybrid-BitNet issue (out of scope for #82).");
+              $"Unexpected for SmolLM-135M — investigate hybrid forward-pass before attributing to LoRA wiring.");
 
         // GATE A: adapter delta must actually fire (hybrid+adapter ≠ hybrid-base).
         Assert.True(adapterChangedHybrid,

--- a/tests/DotLLM.Tests.Integration/Models/Lora/HybridLoraParityTests.cs
+++ b/tests/DotLLM.Tests.Integration/Models/Lora/HybridLoraParityTests.cs
@@ -1,0 +1,184 @@
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Tensors;
+using DotLLM.Cuda;
+using DotLLM.Models.Architectures;
+using DotLLM.Models.Gguf;
+using System.Numerics.Tensors;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Integration.Models.Lora;
+
+/// <summary>
+/// Hybrid CPU+GPU LoRA parity gate (#82).
+/// Verifies that <see cref="HybridTransformerModel.Forward"/> with a synthetic LoRA adapter
+/// produces logits that are numerically consistent with the full-CPU reference path.
+/// With a half-layer split (numGpuLayers = cfg.NumLayers / 2) both GPU-resident and
+/// CPU-resident layers are exercised in the same forward pass.
+/// Correctness criteria: argmax(hybrid) == argmax(cpu) AND cosine(hybrid, cpu) &gt; 0.999.
+/// Also asserts that hybrid+adapter ≠ hybrid-without-adapter (delta actually fires).
+/// </summary>
+/// <remarks>
+/// Plain [Fact] with early-return no-op when DOTLLM_BITNET_GGUF is unset/missing
+/// or when CUDA is unavailable — no SkippableFact dependency needed.
+/// Kept in its own class to avoid cross-class GPU parallelism.
+/// </remarks>
+public sealed class HybridLoraParityTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public HybridLoraParityTests(ITestOutputHelper output) => _output = output;
+
+    private static string? ModelPath =>
+        Environment.GetEnvironmentVariable("DOTLLM_BITNET_GGUF");
+
+    [Fact]
+    public unsafe void HybridAndCpu_LoraLogits_AreNumericallyConsistent()
+    {
+        // ── Guard 1: model file must be present ──────────────────────────────────
+        if (ModelPath is null || !File.Exists(ModelPath))
+        {
+            _output.WriteLine("SKIP: BitNet GGUF not available (set DOTLLM_BITNET_GGUF).");
+            return;
+        }
+
+        // ── Guard 2: CUDA device must be available ────────────────────────────────
+        if (!CudaDevice.IsAvailable())
+        {
+            _output.WriteLine("SKIP: No CUDA device available.");
+            return;
+        }
+
+        // ── Setup ─────────────────────────────────────────────────────────────────
+        using var gguf = GgufFile.Open(ModelPath!);
+        var cfg = GgufModelConfigExtractor.Extract(gguf.Metadata);
+
+        int[] tok = [1, 2, 3];
+        int[] pos = [0, 1, 2];
+
+        // Single adapter instance shared by both hybrid and CPU forward passes.
+        // SyntheticLoraAdapterFactory targets q_proj/v_proj on every layer with
+        // small deterministic deltas (±0.01, seed=42).
+        using var adapter = SyntheticLoraAdapterFactory.ForConfig(cfg, rank: 8, alpha: 16f, seed: 42);
+
+        // ── Hybrid model (system under test) ──────────────────────────────────────
+        // Half-split: ensures BOTH GPU layers and CPU layers are exercised.
+        int numGpuLayers = Math.Max(1, cfg.NumLayers / 2);
+        using var hybridModel = HybridTransformerModel.LoadFromGguf(
+            gguf, cfg, numGpuLayers, deviceId: 0, threading: new ThreadingConfig(0, 0));
+
+        // Hybrid + adapter (system under test)
+        using ITensor hybridLoraLogits = hybridModel.Forward(tok, pos, deviceId: 0, kvCache: null, adapter: adapter);
+
+        int vocabSize = cfg.VocabSize;
+        // hybridLoraLogits shape mirrors CudaTransformerModel: [1, vocabSize] (last-token D2H).
+        float[] hybridVec = new float[vocabSize];
+        fixed (float* dst = hybridVec)
+        {
+            float* src = (float*)hybridLoraLogits.DataPointer;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int hybridArgmax = ArgMax(hybridVec);
+
+        // Hybrid without adapter (sanity: delta must actually fire)
+        using ITensor hybridBaseLogits = hybridModel.Forward(tok, pos, deviceId: 0, kvCache: null, adapter: null);
+        float[] hybridBaseVec = new float[vocabSize];
+        fixed (float* dst = hybridBaseVec)
+        {
+            float* src = (float*)hybridBaseLogits.DataPointer;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int hybridBaseArgmax = ArgMax(hybridBaseVec);
+
+        // ── Full-CPU forward (reference) ──────────────────────────────────────────
+        using var cpuModel = TransformerModel.LoadFromGguf(gguf, cfg, new ThreadingConfig(0, 0));
+        using ITensor cpuLogits = cpuModel.Forward(tok, pos, deviceId: -1, kvCache: null, adapter: adapter);
+
+        // cpuLogits shape is [seqLen, vocabSize]; take the last-token row.
+        long lastRowOffset = (long)(tok.Length - 1) * vocabSize;
+        float[] cpuVec = new float[vocabSize];
+        fixed (float* dst = cpuVec)
+        {
+            float* src = (float*)cpuLogits.DataPointer + lastRowOffset;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int cpuArgmax = ArgMax(cpuVec);
+
+        // ── Metrics ───────────────────────────────────────────────────────────────
+        double cosine = CosineSimilarity(hybridVec, cpuVec);
+        bool adapterChangedHybrid = VectorsAreDifferent(hybridVec, hybridBaseVec, threshold: 1e-4f);
+
+        // Base-vs-base diagnostic (helps isolate pre-existing hybrid divergence from LoRA bugs)
+        using ITensor cpuBaseLogitsRaw = cpuModel.Forward(tok, pos, deviceId: -1, kvCache: null, adapter: null);
+        float[] cpuBaseVec = new float[vocabSize];
+        fixed (float* dst = cpuBaseVec)
+        {
+            float* src = (float*)cpuBaseLogitsRaw.DataPointer + lastRowOffset;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int cpuBaseArgmax = ArgMax(cpuBaseVec);
+        double cosineBaseVsBase = CosineSimilarity(hybridBaseVec, cpuBaseVec);
+
+        _output.WriteLine($"GPU layers: {numGpuLayers}/{cfg.NumLayers}  CPU layers: {cfg.NumLayers - numGpuLayers}");
+        _output.WriteLine($"Hybrid-adapted argmax: {hybridArgmax}  CPU-adapted argmax: {cpuArgmax}");
+        _output.WriteLine($"Cosine(hybrid_lora, cpu_lora): {cosine:F6}");
+        _output.WriteLine($"Hybrid+adapter differs from hybrid-base: {adapterChangedHybrid}");
+        _output.WriteLine($"[Diagnostic] Hybrid-base argmax: {hybridBaseArgmax}  CPU-base argmax: {cpuBaseArgmax}");
+        _output.WriteLine($"[Diagnostic] Cosine(hybrid_base, cpu_base): {cosineBaseVsBase:F6}");
+
+        // ── Assertions (the gate) ─────────────────────────────────────────────────
+
+        // Diagnostic: base-vs-base — helps isolate pre-existing hybrid divergence.
+        // Not the primary gate, but logged so failures can be attributed correctly.
+        _output.WriteLine(cosineBaseVsBase > 0.999
+            ? $"[Diagnostic] Base parity OK (cosine={cosineBaseVsBase:F6} > 0.999)"
+            : $"[Diagnostic] Base parity WARN: hybrid-base diverges from cpu-base (cosine={cosineBaseVsBase:F6}). " +
+              $"Pre-existing hybrid-BitNet issue (out of scope for #82).");
+
+        // GATE A: adapter delta must actually fire (hybrid+adapter ≠ hybrid-base).
+        Assert.True(adapterChangedHybrid,
+            "Hybrid+adapter logits are identical to hybrid-base logits. " +
+            "The LoRA delta did not fire on the hybrid path (no-op bug in GPU or CPU phase).");
+
+        // GATE B1: argmax must match (hard correctness gate).
+        Assert.True(hybridArgmax == cpuArgmax,
+            $"Argmax mismatch: Hybrid={hybridArgmax} CPU={cpuArgmax}. " +
+            $"Cosine={cosine:F6}. " +
+            $"Hybrid top logit={hybridVec[hybridArgmax]:F4}  CPU top logit={cpuVec[cpuArgmax]:F4}. " +
+            $"[Diagnostic] base cosine={cosineBaseVsBase:F6}. " +
+            $"This indicates a LoRA delta placement or layout bug in the hybrid path.");
+
+        // GATE B2: cosine similarity > 0.999 (FP16-vs-FP32 magnitude guard).
+        Assert.True(cosine > 0.999,
+            $"Cosine similarity {cosine:F6} is below 0.999. " +
+            $"Hybrid argmax={hybridArgmax}  CPU argmax={cpuArgmax}. " +
+            $"[Diagnostic] base cosine={cosineBaseVsBase:F6}. " +
+            $"This indicates significant numerical divergence between hybrid and CPU LoRA paths.");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    private static int ArgMax(float[] vec)
+        => TensorPrimitives.IndexOfMax(new ReadOnlySpan<float>(vec));
+
+    private static double CosineSimilarity(float[] a, float[] b)
+    {
+        double dot = 0, normA = 0, normB = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            normA += (double)a[i] * a[i];
+            normB += (double)b[i] * b[i];
+        }
+        double denom = Math.Sqrt(normA) * Math.Sqrt(normB);
+        return denom < 1e-12 ? 0.0 : dot / denom;
+    }
+
+    private static bool VectorsAreDifferent(float[] a, float[] b, float threshold)
+    {
+        for (int i = 0; i < a.Length; i++)
+            if (MathF.Abs(a[i] - b[i]) > threshold)
+                return true;
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #82.

## What & why
`HybridTransformerModel` (partial GPU offload) had no `ILoraAdapter` parameter, so in hybrid mode **neither** the GPU-resident **nor** the CPU-resident layers were LoRA-adapted (the CLI warned about it). M1 (#79, CPU) and M2 (#80, CUDA) added LoRA to the full-CPU and full-GPU models; this closes the remaining hybrid gap.

## How
`HybridTransformerModel` deliberately re-implements the forward pass inline (its own GPU loop + its own CPU loop — see its "SYNC WARNING"), so LoRA is mirrored into both:
- **5-arg `Forward(..., ILoraAdapter?)`** + adapter staging via the shared `CudaLoraWeights` (identity-cached, disposed-before-restage, freed in `Dispose`). Null adapter ⇒ delegates to the 4-arg path (byte-equivalent).
- **GPU phase:** a device delta helper mirroring M2's `ApplyLoraDeltaDevice` (`tmp=B·x` then `y+=scale·A·tmp`, two cuBLAS F16 GEMVs, shared `LoraTmp` scratch), applied at all 7 projection sites. Hybrid's GPU loop uses plain `ProjectGpu` (no fused I2_S kernels / no decode graph), so no fused-bypass needed.
- **CPU phase:** the shared `LoraDelta.Apply` (F32 path) at the same 7 sites in both the decode and prefill code paths. The fused `RmsNormQuantize` decode path skips materializing F32 `normOut` (which the delta needs as `x`), so — mirroring `TransformerModel` — the decode fast path is forced unfused when an adapter is active (`&& !adapterActive`) in both the attention and FFN blocks.
- **CLI:** the stale hybrid `--lora` warning is removed.

## Verification (RTX 3060)
- Full solution build: **0 errors**.
- **Parity gate PASSES** (`HybridLoraParityTests`, SmolLM-135M Q8_0, 15/30 GPU/CPU split): hybrid-adapted vs full-CPU-adapted **cosine 0.999739, argmax match**; delta fires; base-vs-base sanity 0.999819.
- 635 `Lora|Engine` unit tests pass.
- Adapter-less hybrid path is byte-equivalent (verified: `&& !adapterActive` collapses to the original condition; all delta calls are `if (_currentAdapter is not null)` no-ops).

## Scope notes
- **F32 adapter weights** for the CPU phase (throws `NotSupportedException` on other dtypes). dev's optimized Q8_0 / outer-product CPU fast paths for hybrid are a perf follow-up.
- The parity gate uses SmolLM-135M (not BitNet) because **hybrid + BitNet I2_S base is independently broken** (`"Fused decode does not support I2_S"`) — a pre-existing bug unrelated to LoRA, now tracked as **#83**. Hybrid works correctly for standard models (verified: Qwen3-4B hybrid base coherent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)