### PR TITLE
Fix hybrid + BitNet (I2_S): FP32 residual + I2_S dispatch (#83)

### DIFF
--- a/src/DotLLM.Cuda/HybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/HybridTransformerModel.cs
@@ -164,10 +164,13 @@ public sealed unsafe class HybridTransformerModel : IModel
             }
         }
 
-        // 5. GPU scratch buffers
+        // 5. GPU scratch buffers. BitNet's residual stream exceeds FP16 range in deep
+        //    layers, so it carries the residual in FP32 (overflow→NaN otherwise). Mirrors
+        //    CudaTransformerModel.LoadFromGguf.
         var gpuState = new CudaForwardState(
             config.HiddenSize, config.NumAttentionHeads, config.NumKvHeads,
-            config.HeadDim, config.IntermediateSize, config.VocabSize);
+            config.HeadDim, config.IntermediateSize, config.VocabSize,
+            useFp32Residual: config.Architecture == DotLLM.Core.Configuration.Architecture.BitNet);
 
         // 6. CPU scratch buffers (with RoPE tables)
         int ropeDim = config.RoPEConfig?.DimensionCount ?? config.HeadDim;
@@ -274,10 +277,13 @@ public sealed unsafe class HybridTransformerModel : IModel
         // 4. Skip the VRAM-pressure warning — synthetic fixtures are tiny and
         //    the cuMemGetInfo probe would just clutter the test output.
 
-        // 5. GPU scratch buffers
+        // 5. GPU scratch buffers. BitNet's residual stream exceeds FP16 range in deep
+        //    layers, so it carries the residual in FP32 (overflow→NaN otherwise). Mirrors
+        //    CudaTransformerModel.LoadFromGguf / the production LoadFromGguf above.
         var gpuState = new CudaForwardState(
             config.HiddenSize, config.NumAttentionHeads, config.NumKvHeads,
-            config.HeadDim, config.IntermediateSize, config.VocabSize);
+            config.HeadDim, config.IntermediateSize, config.VocabSize,
+            useFp32Residual: config.Architecture == DotLLM.Core.Configuration.Architecture.BitNet);
 
         // 6. CPU scratch buffers (with RoPE tables)
         int ropeDim = config.RoPEConfig?.DimensionCount ?? config.HeadDim;
@@ -419,6 +425,12 @@ public sealed unsafe class HybridTransformerModel : IModel
         nint s = _stream.Handle;
         nint cublasH = _cublas.Handle;
 
+        // BitNet's residual stream exceeds FP16's ~65504 ceiling in deep layers, so it
+        // carries the residual in FP32 (overflow→NaN/zero logits otherwise). Mirrors
+        // CudaTransformerModel.Forward. ResidualF32 is always allocated, so isBitNet gates.
+        bool isBitNet = Config.Architecture == DotLLM.Core.Configuration.Architecture.BitNet;
+        bool fp32Res = _gpuState.ResidualF32 != 0 && isBitNet;
+
         _gpuState.EnsureCapacity(seqLen);
 
         // 1. Upload tokenIds + positions
@@ -440,8 +452,12 @@ public sealed unsafe class HybridTransformerModel : IModel
 
         if (gpuLayers > 0)
         {
-            CudaDriverApi.cuMemcpyDtoDAsync_v2(_gpuState.Residual, _gpuState.HiddenState,
-                (nuint)hiddenBytes, s).ThrowOnError();
+            // BitNet carries the residual in FP32 (widen the FP16 embedding into ResidualF32).
+            if (fp32Res)
+                _kernels.LaunchCopyF16ToF32(_gpuState.HiddenState, _gpuState.ResidualF32, seqLen * hiddenSize, s);
+            else
+                CudaDriverApi.cuMemcpyDtoDAsync_v2(_gpuState.Residual, _gpuState.HiddenState,
+                    (nuint)hiddenBytes, s).ThrowOnError();
             _kernels.LaunchRmsNorm(_gpuState.HiddenState, _gpuWeights.Layers[0].AttnNormWeight,
                 _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
         }
@@ -517,8 +533,13 @@ public sealed unsafe class HybridTransformerModel : IModel
                 ApplyLoraDeltaDeviceGpu(layer, "o_proj", _gpuState.AttnOutput, _gpuState.NormOutput, seqLen);
 
             // ── FUSED: attention residual + FFN norm ──
-            _kernels.LaunchFusedAddRmsNorm(_gpuState.Residual, _gpuState.NormOutput,
-                lw.FfnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
+            // BitNet carries the residual in FP32 to avoid FP16 overflow.
+            if (fp32Res)
+                _kernels.LaunchFusedAddRmsNormF32Res(_gpuState.ResidualF32, _gpuState.NormOutput,
+                    lw.FfnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
+            else
+                _kernels.LaunchFusedAddRmsNorm(_gpuState.Residual, _gpuState.NormOutput,
+                    lw.FfnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
 
             // ── FFN BLOCK ──
             ProjectGpu(lw.GateQuant, lw.GateQuantType, lw.Gate, _gpuState.NormOutput, _gpuState.FfnGate,
@@ -572,16 +593,28 @@ public sealed unsafe class HybridTransformerModel : IModel
             // ── FUSED: FFN residual + next layer setup ──
             if (layer < gpuLayers - 1)
             {
-                // Not last GPU layer: FusedAddRmsNorm for next GPU layer
+                // Not last GPU layer: FusedAddRmsNorm for next GPU layer.
+                // BitNet carries the residual in FP32 to avoid FP16 overflow.
                 ref readonly var nextLw = ref _gpuWeights.Layers[layer + 1];
-                _kernels.LaunchFusedAddRmsNorm(_gpuState.Residual, _gpuState.NormOutput,
-                    nextLw.AttnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
+                if (fp32Res)
+                    _kernels.LaunchFusedAddRmsNormF32Res(_gpuState.ResidualF32, _gpuState.NormOutput,
+                        nextLw.AttnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
+                else
+                    _kernels.LaunchFusedAddRmsNorm(_gpuState.Residual, _gpuState.NormOutput,
+                        nextLw.AttnNormWeight, _gpuState.NormOutput, hiddenSize, eps, seqLen, s);
             }
             else
             {
-                // Last GPU layer: plain Add → HiddenState (boundary transfer source)
-                _kernels.LaunchAdd(_gpuState.Residual, _gpuState.NormOutput, _gpuState.HiddenState,
-                    seqLen * hiddenSize, s);
+                // Last GPU layer: add residual + FFN output. For BitNet, accumulate into the
+                // FP32 residual (ResidualF32 holds the boundary-transfer source — the un-normed
+                // residual the CPU phase resumes from — never truncated to FP16). For non-BitNet
+                // the FP16 HiddenState is the boundary source (unchanged).
+                if (fp32Res)
+                    _kernels.LaunchAddF32F16(_gpuState.ResidualF32, _gpuState.NormOutput, _gpuState.ResidualF32,
+                        seqLen * hiddenSize, s);
+                else
+                    _kernels.LaunchAdd(_gpuState.Residual, _gpuState.NormOutput, _gpuState.HiddenState,
+                        seqLen * hiddenSize, s);
             }
         }
 
@@ -593,17 +626,26 @@ public sealed unsafe class HybridTransformerModel : IModel
         {
             _stream.Synchronize();
 
-            // D2H: HiddenState [seqLen, hiddenSize] as FP16
             int transferElements = seqLen * hiddenSize;
-            EnsureTransferCapacity(transferElements);
-
-            long transferBytes = (long)transferElements * h;
-            CudaDriverApi.cuMemcpyDtoH_v2(_fp16TransferBuffer, _gpuState.HiddenState,
-                (nuint)transferBytes).ThrowOnError();
-
-            // FP16 → FP32 conversion into CPU state
             _cpuState.EnsureCapacity(seqLen);
-            ConvertFp16ToFp32(_fp16TransferBuffer, _cpuState.HiddenState, transferElements);
+
+            if (fp32Res)
+            {
+                // BitNet: the un-normalized residual at the boundary overflows FP16, so the last
+                // GPU layer accumulated it into ResidualF32 (fix above). Transfer that FP32 buffer
+                // straight into the host-side CPU hidden state — skip the FP16 buffer + conversion.
+                CudaDriverApi.cuMemcpyDtoH_v2(_cpuState.HiddenState, _gpuState.ResidualF32,
+                    (nuint)((long)transferElements * sizeof(float))).ThrowOnError();
+            }
+            else
+            {
+                // D2H: HiddenState [seqLen, hiddenSize] as FP16, then widen to FP32 CPU state.
+                EnsureTransferCapacity(transferElements);
+                long transferBytes = (long)transferElements * h;
+                CudaDriverApi.cuMemcpyDtoH_v2(_fp16TransferBuffer, _gpuState.HiddenState,
+                    (nuint)transferBytes).ThrowOnError();
+                ConvertFp16ToFp32(_fp16TransferBuffer, _cpuState.HiddenState, transferElements);
+            }
         }
 
         // ═══════════════════════════════════════════════════
@@ -658,7 +700,11 @@ public sealed unsafe class HybridTransformerModel : IModel
                 // b. RMSNorm + Pre-quantize + Q/K/V projections
                 byte* inputQ8Scratch = (byte*)_cpuState.InputQ8Scratch;
 
-                if (seqLen == 1 && _threadPool != null && !adapterActive)
+                // The fused decode kernels don't support I2_S; route ternary weights through the
+                // standard (unfused) projection path, which dispatches to the I2_S GEMV. Mirrors
+                // TransformerModel.cs:1077 — without this guard I2_S decode throws in FusedQkvDecode.
+                if (seqLen == 1 && _threadPool != null && !adapterActive
+                    && lw.QQuantType != QuantizationType.I2_S)
                 {
                     // Decode path: try fused RmsNorm+Quantize
                     byte* preQuantNorm = null;
@@ -796,7 +842,10 @@ public sealed unsafe class HybridTransformerModel : IModel
                 // FFN: RMSNorm + Pre-quantize + Gate/Up projections.
                 // Force the unfused path when an adapter is active so normOut (F32)
                 // is materialised for the gate/up LoRA delta — same trap as Q/K/V.
-                if (seqLen == 1 && _threadPool != null && !adapterActive)
+                // I2_S (BitNet) is unsupported by the fused decode kernels — use the unfused
+                // path (which dispatches the I2_S GEMV). Mirrors TransformerModel.cs:1379.
+                if (seqLen == 1 && _threadPool != null && !adapterActive
+                    && lw.GateQuantType != QuantizationType.I2_S)
                 {
                     byte* preQuantFfn = null;
                     if (IsCompatiblePreQuant(lw.GateQuantType, lw.UpQuantType))
@@ -1083,6 +1132,11 @@ public sealed unsafe class HybridTransformerModel : IModel
             MatMul.GemvF32((float*)weights, x, y, m, k, _threadPool);
         else if (qt == QuantizationType.F16)
             MatMul.GemvF16(weights, x, y, m, k, _threadPool);
+        else if (qt == QuantizationType.I2_S)
+            // BitNet b1.58 ternary: per-tensor scale at the tensor tail (NOT per-row), so the
+            // generic per-row dequant fallback reads garbage. Dispatch the dedicated I2_S GEMV.
+            // Mirrors TransformerModel.cs:2772.
+            MatMul.GemvI2_S((byte*)weights, x, y, m, k, _threadPool);
         else
             GemvDequantFallback(weights, qt, x, y, m, k);
     }
@@ -1125,6 +1179,11 @@ public sealed unsafe class HybridTransformerModel : IModel
             MatMul.GemmF32((float*)weights, b, c, m, k, n, _threadPool);
         else if (qt == QuantizationType.F16)
             MatMul.GemmF16(weights, b, c, m, k, n, _threadPool);
+        else if (qt == QuantizationType.I2_S)
+            // BitNet b1.58 ternary: per-tensor scale at the tensor tail (NOT per-row), so the
+            // generic per-row dequant fallback reads garbage. Dispatch the dedicated I2_S GEMM.
+            // Mirrors TransformerModel.cs:2825.
+            MatMul.GemmI2_S((byte*)weights, b, c, m, k, n, _threadPool);
         else
             GemmDequantFallback(weights, qt, b, c, m, k, n);
     }

--- a/tests/DotLLM.Tests.Integration/Models/Lora/HybridBitNetParityTests.cs
+++ b/tests/DotLLM.Tests.Integration/Models/Lora/HybridBitNetParityTests.cs
@@ -1,0 +1,133 @@
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Tensors;
+using DotLLM.Cuda;
+using DotLLM.Models.Architectures;
+using DotLLM.Models.Gguf;
+using System.Numerics.Tensors;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Integration.Models.Lora;
+
+/// <summary>
+/// Hybrid CPU+GPU BASE-path parity vs full-CPU, on a BitNet b1.58 (I2_S) model (#83).
+/// Verifies that <see cref="HybridTransformerModel.Forward"/> with NO adapter produces
+/// logits numerically consistent with the full-CPU reference path for a BitNet (I2_S)
+/// model. With a half-layer split (numGpuLayers = cfg.NumLayers / 2) both GPU-resident
+/// and CPU-resident layers run in the same forward pass.
+/// Correctness criteria: argmax(hybrid) == argmax(cpu) AND cosine(hybrid, cpu) &gt; 0.999.
+/// </summary>
+/// <remarks>
+/// Plain [Fact] with early-return no-op when DOTLLM_BITNET_GGUF is unset/missing or when
+/// CUDA is unavailable — no SkippableFact dependency needed. This is the BASE path (no
+/// LoRA adapter): it pins the three hybrid+BitNet root causes (CPU decode I2_S guard,
+/// GPU-phase FP32 residual, FP32 boundary transfer). Kept in its own class to avoid
+/// cross-class GPU parallelism.
+/// </remarks>
+public sealed class HybridBitNetParityTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public HybridBitNetParityTests(ITestOutputHelper output) => _output = output;
+
+    private static string? ModelPath =>
+        Environment.GetEnvironmentVariable("DOTLLM_BITNET_GGUF");
+
+    [Fact]
+    public unsafe void HybridAndCpu_BitNetBaseLogits_AreNumericallyConsistent()
+    {
+        // ── Guard 1: model file must be present ──────────────────────────────────
+        if (ModelPath is null || !File.Exists(ModelPath))
+        {
+            _output.WriteLine("SKIP: BitNet GGUF not available (set DOTLLM_BITNET_GGUF).");
+            return;
+        }
+
+        // ── Guard 2: CUDA device must be available ────────────────────────────────
+        if (!CudaDevice.IsAvailable())
+        {
+            _output.WriteLine("SKIP: No CUDA device available.");
+            return;
+        }
+
+        // ── Setup ─────────────────────────────────────────────────────────────────
+        using var gguf = GgufFile.Open(ModelPath!);
+        var cfg = GgufModelConfigExtractor.Extract(gguf.Metadata);
+
+        int[] tok = [1, 2, 3];
+        int[] pos = [0, 1, 2];
+
+        // ── Hybrid model (system under test) — BASE path, no adapter ───────────────
+        // Half-split: ensures BOTH GPU layers and CPU layers are exercised.
+        int numGpuLayers = Math.Max(1, cfg.NumLayers / 2);
+        using var hybridModel = HybridTransformerModel.LoadFromGguf(
+            gguf, cfg, numGpuLayers, deviceId: 0, threading: new ThreadingConfig(0, 0));
+
+        using ITensor hybridLogits = hybridModel.Forward(tok, pos, deviceId: 0, kvCache: null);
+
+        int vocabSize = cfg.VocabSize;
+        // hybridLogits shape is [1, vocabSize] (last-token D2H).
+        float[] hybridVec = new float[vocabSize];
+        fixed (float* dst = hybridVec)
+        {
+            float* src = (float*)hybridLogits.DataPointer;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int hybridArgmax = ArgMax(hybridVec);
+
+        // ── Full-CPU forward (reference) ──────────────────────────────────────────
+        using var cpuModel = TransformerModel.LoadFromGguf(gguf, cfg, new ThreadingConfig(0, 0));
+        using ITensor cpuLogits = cpuModel.Forward(tok, pos, deviceId: -1, kvCache: null);
+
+        // cpuLogits shape is [seqLen, vocabSize]; take the last-token row.
+        long lastRowOffset = (long)(tok.Length - 1) * vocabSize;
+        float[] cpuVec = new float[vocabSize];
+        fixed (float* dst = cpuVec)
+        {
+            float* src = (float*)cpuLogits.DataPointer + lastRowOffset;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int cpuArgmax = ArgMax(cpuVec);
+
+        // ── Metrics ───────────────────────────────────────────────────────────────
+        double cosine = CosineSimilarity(hybridVec, cpuVec);
+
+        _output.WriteLine($"GPU layers: {numGpuLayers}/{cfg.NumLayers}  CPU layers: {cfg.NumLayers - numGpuLayers}");
+        _output.WriteLine($"Hybrid argmax: {hybridArgmax}  CPU argmax: {cpuArgmax}");
+        _output.WriteLine($"Hybrid top logit: {hybridVec[hybridArgmax]:F4}  CPU top logit: {cpuVec[cpuArgmax]:F4}");
+        _output.WriteLine($"Cosine(hybrid, cpu): {cosine:F6}");
+
+        // ── Assertions (the gate) ─────────────────────────────────────────────────
+        // 1. Argmax must match (hard correctness gate).
+        Assert.True(hybridArgmax == cpuArgmax,
+            $"Argmax mismatch: Hybrid={hybridArgmax} CPU={cpuArgmax}. " +
+            $"Cosine={cosine:F6}. " +
+            $"Hybrid top logit={hybridVec[hybridArgmax]:F4}  CPU top logit={cpuVec[cpuArgmax]:F4}. " +
+            $"This indicates the hybrid+BitNet (I2_S) base path is broken " +
+            $"(CPU decode I2_S guard, GPU-phase FP32 residual, or FP32 boundary transfer).");
+
+        // 2. Cosine similarity > 0.999 (FP16 GPU layers → FP16 tolerance).
+        Assert.True(cosine > 0.999,
+            $"Cosine similarity {cosine:F6} is below 0.999. " +
+            $"Hybrid argmax={hybridArgmax}  CPU argmax={cpuArgmax}. " +
+            $"This indicates significant numerical divergence between hybrid and CPU BitNet paths.");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    private static int ArgMax(float[] vec)
+        => TensorPrimitives.IndexOfMax(new ReadOnlySpan<float>(vec));
+
+    private static double CosineSimilarity(float[] a, float[] b)
+    {
+        double dot = 0, normA = 0, normB = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            normA += (double)a[i] * a[i];
+            normB += (double)b[i] * b[i];
+        }
+        double denom = Math.Sqrt(normA) * Math.Sqrt(normB);
+        return denom < 1e-12 ? 0.0 : dot / denom;
+    }
+}


### PR DESCRIPTION
Closes #83.

## Problem
Running a BitNet b1.58 (I2_S) GGUF in **hybrid** mode (partial GPU offload) produced NaN/zero logits (prefill) and threw `"Fused decode does not support I2_S"` (decode). BitNet worked on full `--device cpu` and full `--device gpu`; only the hybrid split was broken. Found while building the Hybrid LoRA parity test (#82), which was therefore re-pointed to a non-BitNet model.

## Root cause (systematic debugging — four causes)
`HybridTransformerModel` runs the GPU and CPU layer loops inline and was missing BitNet handling that the full-CPU/full-GPU models already have:
1. **CPU decode** conditions lacked the `&& QQuantType != I2_S` guard → `MatMul.FusedDecodeGemv3/2` throws for I2_S.
2. **GPU phase** used FP16 residual; BitNet's residual exceeds FP16's ~65504 ceiling (the full GPU model uses `useFp32Residual` for BitNet).
3. **GPU→CPU boundary transfer** went through an FP16 buffer → overflow.
4. **(found while debugging — dominant for prefill)** the hybrid **CPU prefill** `Gemm`/`Gemv` had no I2_S case, falling through to a per-row dequant fallback that is wrong for I2_S's per-tensor tail scale → activations ≈2.4e11 → NaN.

## Fix
Mirror the working `CudaTransformerModel` / `TransformerModel` BitNet paths into the hybrid loops:
- Build `_gpuState` with `useFp32Residual = (Architecture == BitNet)` (both `LoadFromGguf` paths); route the GPU residual junctions through FP32 (`LaunchCopyF16ToF32`, `LaunchFusedAddRmsNormF32Res` ×2, `LaunchAddF32F16`) when BitNet.
- For BitNet, transfer the boundary as a direct FP32 D2H of `ResidualF32` (skip the FP16 buffer).
- Add the I2_S decode guards (Q for attention, Gate for FFN).
- Dispatch `MatMul.GemmI2_S`/`GemvI2_S` in the CPU prefill path for I2_S weights.

All changes are gated on `isBitNet`/`fp32Res` — **non-BitNet hybrid is byte-equivalent** (the SmolLM Hybrid LoRA parity test still passes).

## Verification (RTX 3060, TDD)
- New `HybridBitNetParityTests` (hybrid base vs full-CPU base, BitNet-2B, 15/30 split): **RED** first (NaN, argmax 0≠5) → **GREEN** after fix (argmax 5==5, **cosine 0.999995**).
- SmolLM `HybridLoraParityTests` still passes (non-BitNet byte-equivalence).
- Full solution build 0 errors; 652 `Lora|Engine|I2S` unit tests pass.

Final review: ready to merge, no Critical/Important (two cosmetic minors inherited from the oracle pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)