### PR TITLE
refactor(lora): share dtype-aware CPU delta; hybrid CPU LoRA supports F16/BF16/Q8_0

### DIFF
--- a/src/DotLLM.Cuda/HybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/HybridTransformerModel.cs
@@ -1075,40 +1075,21 @@ public sealed unsafe class HybridTransformerModel : IModel
 
     /// <summary>
     /// Applies the CPU-phase LoRA delta for one projection: <c>y += scale · (x · B) · A</c>,
-    /// using the shared F32 <see cref="LoraDelta.Apply(float*, float*, float*, float*, int, int, int, int, float, nint)"/>
-    /// kernel. Mirrors <c>TransformerModel.ApplyLoraDelta</c>'s structure but is scoped to F32
-    /// adapter weights only — the Q8_0 / outer-product / pre-quantised-X fast paths that
-    /// <c>TransformerModel.ApplyLoraDelta</c> dispatches into are out of scope for the hybrid CPU
-    /// phase (the synthetic / parity adapters are F32). Early-returns when no adapter is staged or
-    /// the adapter does not target <paramref name="proj"/> at this layer. <paramref name="layer"/>
-    /// is the absolute (global) layer index.
+    /// delegating to the shared full dtype-aware <see cref="LoraProjection.Apply"/>. This gives the
+    /// hybrid CPU-resident layers identical adapter-dtype support to the full-CPU
+    /// <c>TransformerModel</c> path — F32 / F16 / BF16 / Q8_0 adapter weights plus the Phase-4d.6
+    /// outer-product stage-2 fast path. Early-returns (inside the shared helper) when no adapter is
+    /// staged or the adapter does not target <paramref name="proj"/> at this layer.
+    /// The hybrid CPU loop does not pre-quantise x for the LoRA path, so <c>preQuantX</c> is null
+    /// (the dequant-once F32 fallback handles every dtype). <paramref name="layer"/> is the
+    /// absolute (global) layer index.
     /// </summary>
     private void ApplyLoraDeltaCpu(int layer, string proj, float* x, float* y,
                                    int seqLen, int inputDim, int outputDim)
     {
-        var adapter = _currentAdapter;
-        if (adapter is null)
-            return;
-
-        var lora = adapter.GetLayerWeights(layer, proj);
-        if (lora is not { } w)
-            return; // untargeted projection — no-op
-
-        if (w.InputDim != inputDim || w.OutputDim != outputDim)
-            throw new InvalidOperationException(
-                $"LoRA adapter shape mismatch at layer {layer} proj {proj}: " +
-                $"adapter [{w.InputDim}->{w.OutputDim}] vs projection [{inputDim}->{outputDim}].");
-
-        if (w.WeightDType != LoraWeightDType.F32)
-            throw new NotSupportedException(
-                $"Hybrid CPU LoRA currently supports F32 adapter weights only (proj={proj} is {w.WeightDType}); " +
-                "use --device cpu for other dtypes.");
-
-        // y += (adapter.Alpha / adapter.Rank) · (x · B) · A. Legacy stage-2 path
-        // (aTransposedHandle: 0) — the outer-product fast path is out of scope here.
-        LoraDelta.Apply(x, (float*)w.BHandle, (float*)w.AHandle, y,
-                        seqLen, inputDim, outputDim, adapter.Rank,
-                        adapter.Alpha / adapter.Rank);
+        LoraProjection.Apply(_currentAdapter!, layer, proj, x, y,
+                             seqLen, inputDim, outputDim, _threadPool,
+                             preQuantX: null, preQuantXType: QuantizationType.F32);
     }
 
     // ═══════════════════════════════════════════════════

--- a/src/DotLLM.Models/Architectures/LoraProjection.cs
+++ b/src/DotLLM.Models/Architectures/LoraProjection.cs
@@ -1,0 +1,99 @@
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Lora;
+using DotLLM.Cpu.Kernels;
+using DotLLM.Cpu.Threading;
+
+namespace DotLLM.Models.Architectures;
+
+/// <summary>
+/// Shared, full dtype-aware CPU LoRA delta projection. Extracted from
+/// <see cref="TransformerModel"/>'s former private <c>ApplyLoraDelta</c> so that
+/// both the full-CPU <see cref="TransformerModel"/> and the hybrid
+/// <c>HybridTransformerModel</c> (DotLLM.Cuda) route their CPU-resident layers
+/// through one implementation. Supports F32 / F16 / BF16 / Q8_0 adapter weights
+/// (via <see cref="LoraDelta.Apply(float*, void*, void*, float*, int, int, int, int, float, LoraWeightDType, LoraWeightDType, nint)"/>)
+/// and the Phase-4d.6 outer-product stage-2 fast path
+/// (<see cref="LoraStage2.EnsureATransposedF32"/>).
+/// </summary>
+public static unsafe class LoraProjection
+{
+    /// <summary>
+    /// Applies the LoRA delta for <paramref name="projName"/> at
+    /// <paramref name="layer"/> if <paramref name="adapter"/> targets that site:
+    /// <c>y += (alpha / rank) · (x · B) · A</c>. No-op when
+    /// <paramref name="adapter"/> is null or has no entry for this projection.
+    /// <para>
+    /// Phase 4d.5 / Gap 2 — when the caller has already quantised
+    /// <paramref name="x"/> for the base projection's GEMM and passes the
+    /// resulting buffer as <paramref name="preQuantX"/>, AND
+    /// <paramref name="preQuantXType"/> is <see cref="QuantizationType.Q8_0"/>,
+    /// AND the adapter's B factor is <see cref="LoraWeightDType.Q8_0"/>, the LoRA
+    /// stage-1 GEMM re-uses the pre-quantised buffer via
+    /// <see cref="LoraDelta.ApplyQ8_0BWithPreQuantX"/> instead of dequanting B to
+    /// F32 and running an F32 GEMM. This closes the residual −16% prefill
+    /// regression the Phase 4d.4 dequant-once path left on the table on a Q8_0
+    /// base (Strix Halo / Llama-3.2-1B). The default arguments give the legacy
+    /// F32 / dequant-once behaviour.
+    /// </para>
+    /// </summary>
+    public static void Apply(ILoraAdapter? adapter, int layer, string projName,
+                             float* x, float* y, int seqLen, int inputDim, int outputDim,
+                             ComputeThreadPool? threadPool,
+                             byte* preQuantX = null,
+                             QuantizationType preQuantXType = QuantizationType.F32)
+    {
+        if (adapter is null) return;
+        var lora = adapter.GetLayerWeights(layer, projName);
+        if (lora is not { } w) return;
+
+        // Defensive shape check — IsCompatible already validated dims, but
+        // we re-check at the call site so a bug in dim plumbing surfaces
+        // here rather than as a silent OOB into x/y buffers.
+        if (w.InputDim != inputDim || w.OutputDim != outputDim)
+            throw new InvalidOperationException(
+                $"LoRA adapter '{adapter.Name}' layer={layer} proj='{projName}' shape "
+                + $"({w.InputDim}x{w.OutputDim}) does not match base projection "
+                + $"({inputDim}x{outputDim}).");
+
+        float scale = adapter.Alpha / adapter.Rank;
+
+        // Phase 4d.6 — outer-product stage-2 fast path. At rank=16 with
+        // AVX-512 present, the per-token GEMV-then-MultiplyAdd stage 2
+        // (~outputDim short Dot calls per token, ~1M total at outputDim=2048
+        // / seqLen=512) is replaced by an outer-product kernel that
+        // collapses to ~seqLen × outputDim/16 tile FMAs (~3-4× faster on
+        // Strix Halo). The kernel consumes a [rank, outputDim] transposed-A
+        // buffer; we lazy-build + cache it on the adapter the first time we
+        // dispatch a (layer, proj) pair through this path. The cache also
+        // covers F16 / BF16 / Q8_0-B adapters — the dequant-and-transpose
+        // happens once at first use.
+        nint aTransposedHandle = LoraStage2.EnsureATransposedF32(
+            adapter as LoraAdapter, layer, projName, in w, adapter.Rank);
+
+        // Phase 4d.5 / Gap 2 — fast-path plumbing: when both base and adapter
+        // B are Q8_0 AND the caller pre-quantised x, we can route stage 1
+        // through `MatMul.GemmQ8_0(preQuantizedInput=preQuantX)` and skip the
+        // activation-quant cost. The original Phase 4d.5 spike gated this
+        // behind `DOTLLM_LORA_FORCE_Q8_PREQUANT=1` because kernel-level
+        // probing showed the Q8_0 GEMM at M=rank=16 was ~1.7× slower than
+        // the dequant-once F32 path. Phase 4d.6 keeps the env-var gate —
+        // independent of the stage-2 outer-product fix below — until a
+        // tiny-M Q8_0 stage-1 kernel can win at this geometry.
+        if (preQuantX is not null
+            && preQuantXType == QuantizationType.Q8_0
+            && w.WeightDType == LoraWeightDType.Q8_0
+            && (inputDim & 31) == 0
+            && Environment.GetEnvironmentVariable("DOTLLM_LORA_FORCE_Q8_PREQUANT") == "1")
+        {
+            LoraDelta.ApplyQ8_0BWithPreQuantX(
+                preQuantX, (byte*)w.BHandle, (void*)w.AHandle, y,
+                seqLen, inputDim, outputDim, adapter.Rank, scale,
+                w.ResolvedAWeightDType, threadPool, aTransposedHandle);
+            return;
+        }
+
+        LoraDelta.Apply((float*)x, (void*)w.BHandle, (void*)w.AHandle, (float*)y,
+                        seqLen, inputDim, outputDim, adapter.Rank, scale,
+                        w.WeightDType, w.ResolvedAWeightDType, aTransposedHandle);
+    }
+}

--- a/src/DotLLM.Models/Architectures/TransformerModel.cs
+++ b/src/DotLLM.Models/Architectures/TransformerModel.cs
@@ -2654,60 +2654,10 @@ public sealed unsafe class TransformerModel : IModel
                                 byte* preQuantX = null,
                                 QuantizationType preQuantXType = QuantizationType.F32)
     {
-        var adapter = _currentAdapter;
-        if (adapter is null) return;
-        var lora = adapter.GetLayerWeights(layer, projName);
-        if (lora is not { } w) return;
-
-        // Defensive shape check — IsCompatible already validated dims, but
-        // we re-check at the call site so a bug in dim plumbing surfaces
-        // here rather than as a silent OOB into x/y buffers.
-        if (w.InputDim != inputDim || w.OutputDim != outputDim)
-            throw new InvalidOperationException(
-                $"LoRA adapter '{adapter.Name}' layer={layer} proj='{projName}' shape "
-                + $"({w.InputDim}x{w.OutputDim}) does not match base projection "
-                + $"({inputDim}x{outputDim}).");
-
-        float scale = adapter.Alpha / adapter.Rank;
-
-        // Phase 4d.6 — outer-product stage-2 fast path. At rank=16 with
-        // AVX-512 present, the per-token GEMV-then-MultiplyAdd stage 2
-        // (~outputDim short Dot calls per token, ~1M total at outputDim=2048
-        // / seqLen=512) is replaced by an outer-product kernel that
-        // collapses to ~seqLen × outputDim/16 tile FMAs (~3-4× faster on
-        // Strix Halo). The kernel consumes a [rank, outputDim] transposed-A
-        // buffer; we lazy-build + cache it on the adapter the first time we
-        // dispatch a (layer, proj) pair through this path. The cache also
-        // covers F16 / BF16 / Q8_0-B adapters — the dequant-and-transpose
-        // happens once at first use.
-        nint aTransposedHandle = LoraStage2.EnsureATransposedF32(
-            adapter as LoraAdapter, layer, projName, in w, adapter.Rank);
-
-        // Phase 4d.5 / Gap 2 — fast-path plumbing: when both base and adapter
-        // B are Q8_0 AND the caller pre-quantised x, we can route stage 1
-        // through `MatMul.GemmQ8_0(preQuantizedInput=preQuantX)` and skip the
-        // activation-quant cost. The original Phase 4d.5 spike gated this
-        // behind `DOTLLM_LORA_FORCE_Q8_PREQUANT=1` because kernel-level
-        // probing showed the Q8_0 GEMM at M=rank=16 was ~1.7× slower than
-        // the dequant-once F32 path. Phase 4d.6 keeps the env-var gate —
-        // independent of the stage-2 outer-product fix below — until a
-        // tiny-M Q8_0 stage-1 kernel can win at this geometry.
-        if (preQuantX is not null
-            && preQuantXType == QuantizationType.Q8_0
-            && w.WeightDType == LoraWeightDType.Q8_0
-            && (inputDim & 31) == 0
-            && Environment.GetEnvironmentVariable("DOTLLM_LORA_FORCE_Q8_PREQUANT") == "1")
-        {
-            LoraDelta.ApplyQ8_0BWithPreQuantX(
-                preQuantX, (byte*)w.BHandle, (void*)w.AHandle, y,
-                seqLen, inputDim, outputDim, adapter.Rank, scale,
-                w.ResolvedAWeightDType, _threadPool, aTransposedHandle);
-            return;
-        }
-
-        LoraDelta.Apply((float*)x, (void*)w.BHandle, (void*)w.AHandle, (float*)y,
-                        seqLen, inputDim, outputDim, adapter.Rank, scale,
-                        w.WeightDType, w.ResolvedAWeightDType, aTransposedHandle);
+        if (_currentAdapter is null) return;
+        LoraProjection.Apply(_currentAdapter, layer, projName, x, y,
+                             seqLen, inputDim, outputDim, _threadPool,
+                             preQuantX, preQuantXType);
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #84. The hybrid CPU LoRA path threw `NotSupportedException` for any non-F32 adapter (most real PEFT adapters are F16/BF16). This shares the full-CPU model's existing dtype-aware delta so hybrid gets full coverage + the outer-product fast path, removing duplication.

- Extracted `TransformerModel.ApplyLoraDelta` **verbatim** into a shared `LoraProjection.Apply(...)` (`src/DotLLM.Models/Architectures/LoraProjection.cs`); only `_currentAdapter`→`adapter` and `_threadPool`→`threadPool` param renames.
- `TransformerModel.ApplyLoraDelta` now delegates (behavior-preserving; null guard kept).
- `HybridTransformerModel.ApplyLoraDeltaCpu` re-pointed to the shared helper; the F32-only `NotSupportedException` removed; 7 call sites + guards unchanged.

**Verify:** build 0/0; 650 `Lora|Engine` unit tests pass (exercise the full-CPU dtype/outer-product paths); SmolLM hybrid LoRA parity still passes on GPU. F16/BF16/Q8_0 now route through the byte-identical full-CPU code path. Review confirmed the extraction is verbatim.

Note: GPU adapter *staging* (`CudaLoraWeights`) remains F32-only — tracked separately (see linked issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)