### PR TITLE
fix(cuda): dtype-aware GPU LoRA adapter staging (F16) (#89)

### DIFF
--- a/src/DotLLM.Cuda/CudaLoraWeights.cs
+++ b/src/DotLLM.Cuda/CudaLoraWeights.cs
@@ -125,29 +125,24 @@ public sealed unsafe class CudaLoraWeights : IDisposable
                     if (maybeW is not { } w)
                         continue;
 
-                    long aF32Bytes = (long)w.OutputDim * rank * sizeof(float);
-                    long bF32Bytes = (long)rank * w.InputDim * sizeof(float);
-                    long aF16Bytes = (long)w.OutputDim * rank * sizeof(ushort);
-                    long bF16Bytes = (long)rank * w.InputDim * sizeof(ushort);
+                    int aElems = w.OutputDim * rank;
+                    int bElems = rank * w.InputDim;
+                    long aF16Bytes = (long)aElems * sizeof(ushort);
+                    long bF16Bytes = (long)bElems * sizeof(ushort);
 
-                    // Alloc F32 scratch, upload host data
-                    CudaDriverApi.cuMemAlloc_v2(out nint aF32Dev, (nuint)aF32Bytes).ThrowOnError();
-                    f32Scratch.Add(aF32Dev);
-                    CudaDriverApi.cuMemcpyHtoD_v2(aF32Dev, w.AHandle, (nuint)aF32Bytes).ThrowOnError();
-
-                    CudaDriverApi.cuMemAlloc_v2(out nint bF32Dev, (nuint)bF32Bytes).ThrowOnError();
-                    f32Scratch.Add(bF32Dev);
-                    CudaDriverApi.cuMemcpyHtoD_v2(bF32Dev, w.BHandle, (nuint)bF32Bytes).ThrowOnError();
-
-                    // Alloc persistent F16 buffers
+                    // Alloc persistent F16 device buffers (the inference target dtype).
+                    // Track in f16Allocs BEFORE any subsequent throw so error cleanup frees them.
                     CudaDriverApi.cuMemAlloc_v2(out nint aF16Dev, (nuint)aF16Bytes).ThrowOnError();
                     f16Allocs.Add(aF16Dev);
                     CudaDriverApi.cuMemAlloc_v2(out nint bF16Dev, (nuint)bF16Bytes).ThrowOnError();
                     f16Allocs.Add(bF16Dev);
 
-                    // Queue F32→F16 conversions
-                    kernels.LaunchConvertF32ToF16(aF32Dev, aF16Dev, w.OutputDim * rank, stream);
-                    kernels.LaunchConvertF32ToF16(bF32Dev, bF16Dev, rank * w.InputDim, stream);
+                    // Stage A (up-projection) per its resolved dtype.
+                    StageFactor(w.ResolvedAWeightDType, w.AHandle, aF16Dev, aElems,
+                                kernels, stream, f32Scratch, layer, proj);
+                    // Stage B (down-projection) per its dtype.
+                    StageFactor(w.WeightDType, w.BHandle, bF16Dev, bElems,
+                                kernels, stream, f32Scratch, layer, proj);
 
                     buffers[(layer, proj)] = (aF16Dev, bF16Dev, w.InputDim, w.OutputDim);
                 }
@@ -176,6 +171,57 @@ public sealed unsafe class CudaLoraWeights : IDisposable
         }
 
         return new CudaLoraWeights(adapter, rank, scale, buffers);
+    }
+
+    /// <summary>
+    /// Stages one A/B factor buffer from host into the pre-allocated F16 device
+    /// target, branching on the factor's source dtype. Host reads are sized by
+    /// the SOURCE dtype to avoid the F32-only over-read that triggered #89.
+    /// </summary>
+    private static void StageFactor(
+        LoraWeightDType dtype,
+        nint hostHandle,
+        nint f16Dev,
+        int elements,
+        CudaKernels kernels,
+        nint stream,
+        List<nint> f32Scratch,
+        int layer,
+        string proj)
+    {
+        switch (dtype)
+        {
+            case LoraWeightDType.F32:
+            {
+                // Legacy path: upload F32 host bytes to scratch, convert F32→F16.
+                // Byte-equivalent to the pre-#89 behaviour for F32 adapters.
+                long f32Bytes = (long)elements * sizeof(float);
+                CudaDriverApi.cuMemAlloc_v2(out nint f32Dev, (nuint)f32Bytes).ThrowOnError();
+                f32Scratch.Add(f32Dev);
+                CudaDriverApi.cuMemcpyHtoD_v2(f32Dev, hostHandle, (nuint)f32Bytes).ThrowOnError();
+                kernels.LaunchConvertF32ToF16(f32Dev, f16Dev, elements, stream);
+                break;
+            }
+
+            case LoraWeightDType.F16:
+            {
+                // Device target is already F16: upload host F16 bytes directly,
+                // no F32 scratch and no conversion. This is the #89 fix.
+                long f16Bytes = (long)elements * sizeof(ushort);
+                CudaDriverApi.cuMemcpyHtoD_v2(f16Dev, hostHandle, (nuint)f16Bytes).ThrowOnError();
+                break;
+            }
+
+            default:
+                // BF16 (no BF16→F16 kernel exists) and Q8_0 (GPU dequant out of
+                // scope) fail safely instead of silently over-reading the host
+                // buffer. The F16 device buffers are already tracked in f16Allocs,
+                // so the caller's catch frees them.
+                throw new NotSupportedException(
+                    $"GPU LoRA staging does not yet support {dtype} adapter weights " +
+                    $"(proj '{proj}', layer {layer}); use --device cpu, or an F32/F16 adapter. " +
+                    "Tracked in #89.");
+        }
     }
 
     /// <inheritdoc/>

--- a/tests/DotLLM.Tests.Integration/Models/Lora/CudaLoraF16StagingParityTests.cs
+++ b/tests/DotLLM.Tests.Integration/Models/Lora/CudaLoraF16StagingParityTests.cs
@@ -1,0 +1,133 @@
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Tensors;
+using DotLLM.Cuda;
+using DotLLM.Models.Architectures;
+using DotLLM.Models.Gguf;
+using System.Numerics.Tensors;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Integration.Models.Lora;
+
+/// <summary>
+/// Regression gate for #89: GPU LoRA staging of an <b>F16</b> adapter.
+/// Before the fix, <see cref="CudaLoraWeights.Stage"/> assumed F32 host buffers
+/// and over-read F16 buffers (4 bytes/elem from a 2-byte/elem buffer) → access
+/// violation. This proves an F16 adapter now stages without an AV and matches a
+/// CPU run of the SAME F16 adapter.
+/// </summary>
+/// <remarks>
+/// Plain [Fact], env-gated on a cached GGUF + CUDA availability; no-op when
+/// absent. Mirrors <see cref="BitNetCudaLoraParityTests"/>.
+/// </remarks>
+public sealed class CudaLoraF16StagingParityTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CudaLoraF16StagingParityTests(ITestOutputHelper output) => _output = output;
+
+    private const string ModelPath =
+        @"C:\Users\james\.dotllm\models\QuantFactory\SmolLM-135M-GGUF\SmolLM-135M.Q8_0.gguf";
+
+    [Fact]
+    public unsafe void F16Adapter_StagesOnGpu_AndMatchesCpu()
+    {
+        if (!File.Exists(ModelPath))
+        {
+            _output.WriteLine($"SKIP: SmolLM-135M GGUF not found at {ModelPath}.");
+            return;
+        }
+
+        if (!CudaDevice.IsAvailable())
+        {
+            _output.WriteLine("SKIP: No CUDA device available.");
+            return;
+        }
+
+        using var gguf = GgufFile.Open(ModelPath);
+        var cfg = GgufModelConfigExtractor.Extract(gguf.Metadata);
+
+        int[] tok = [1, 2, 3];
+        int[] pos = [0, 1, 2];
+
+        // F16 adapter — host buffers are 2 bytes/elem. This is the buffer that
+        // crashed the GPU path before the #89 fix.
+        using var adapter = SyntheticLoraAdapterFactory.ForConfigF16(cfg, rank: 8, alpha: 16f, seed: 42);
+
+        // ── CPU forward (reference; handles F16 via shared LoraProjection.Apply) ──
+        using var cpuModel = TransformerModel.LoadFromGguf(gguf, cfg, new ThreadingConfig(0, 0));
+        using ITensor cpuLogits = cpuModel.Forward(tok, pos, deviceId: -1, kvCache: null, adapter: adapter);
+
+        int vocabSize = cfg.VocabSize;
+        long lastRowOffset = (long)(tok.Length - 1) * vocabSize;
+        float[] cpuVec = new float[vocabSize];
+        fixed (float* dst = cpuVec)
+        {
+            float* src = (float*)cpuLogits.DataPointer + lastRowOffset;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int cpuArgmax = ArgMax(cpuVec);
+
+        // ── GPU forward (system under test; calls CudaLoraWeights.Stage) ──────────
+        using var gpuModel = CudaTransformerModel.LoadFromGguf(gguf, cfg, deviceId: 0);
+
+        // (a) must not throw (previously AV'd inside Stage).
+        using ITensor gpuLoraLogits = gpuModel.Forward(tok, pos, deviceId: 0, kvCache: null, adapter: adapter);
+        float[] gpuVec = new float[vocabSize];
+        fixed (float* dst = gpuVec)
+        {
+            float* src = (float*)gpuLoraLogits.DataPointer;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+        int gpuArgmax = ArgMax(gpuVec);
+
+        using ITensor gpuBaseLogits = gpuModel.Forward(tok, pos, deviceId: 0, kvCache: null, adapter: null);
+        float[] gpuBaseVec = new float[vocabSize];
+        fixed (float* dst = gpuBaseVec)
+        {
+            float* src = (float*)gpuBaseLogits.DataPointer;
+            new ReadOnlySpan<float>(src, vocabSize).CopyTo(new Span<float>(dst, vocabSize));
+        }
+
+        double cosine = CosineSimilarity(cpuVec, gpuVec);
+        bool adapterChangedGpu = VectorsAreDifferent(gpuVec, gpuBaseVec, threshold: 1e-4f);
+
+        _output.WriteLine($"CPU argmax: {cpuArgmax}  GPU argmax: {gpuArgmax}");
+        _output.WriteLine($"Cosine(cpu_lora, gpu_lora): {cosine:F6}");
+        _output.WriteLine($"GPU+adapter differs from GPU-base: {adapterChangedGpu}");
+
+        // (b) delta fired on GPU.
+        Assert.True(adapterChangedGpu,
+            "GPU+F16-adapter logits are identical to GPU-base logits — the LoRA delta did not fire.");
+
+        // (c) GPU matches CPU run of the same F16 adapter.
+        Assert.True(cpuArgmax == gpuArgmax,
+            $"Argmax mismatch: CPU={cpuArgmax} GPU={gpuArgmax}, cosine={cosine:F6}.");
+        Assert.True(cosine > 0.999,
+            $"Cosine similarity {cosine:F6} is below 0.999 for the F16 staging path.");
+    }
+
+    private static int ArgMax(float[] vec)
+        => TensorPrimitives.IndexOfMax(new ReadOnlySpan<float>(vec));
+
+    private static double CosineSimilarity(float[] a, float[] b)
+    {
+        double dot = 0, normA = 0, normB = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            dot += (double)a[i] * b[i];
+            normA += (double)a[i] * a[i];
+            normB += (double)b[i] * b[i];
+        }
+        double denom = Math.Sqrt(normA) * Math.Sqrt(normB);
+        return denom < 1e-12 ? 0.0 : dot / denom;
+    }
+
+    private static bool VectorsAreDifferent(float[] a, float[] b, float threshold)
+    {
+        for (int i = 0; i < a.Length; i++)
+            if (MathF.Abs(a[i] - b[i]) > threshold)
+                return true;
+        return false;
+    }
+}

--- a/tests/DotLLM.Tests.Integration/Models/Lora/SyntheticLoraAdapterFactory.cs
+++ b/tests/DotLLM.Tests.Integration/Models/Lora/SyntheticLoraAdapterFactory.cs
@@ -34,4 +34,42 @@ internal static unsafe class SyntheticLoraAdapterFactory
     {
         for (long i = 0; i < n; i++) p[i] = (float)(rng.NextDouble() * 0.02 - 0.01); // small deltas
     }
+
+    // F16 variant: identical structure/values to ForConfig, but A/B host buffers
+    // are stored as 16-bit halves with WeightDType=F16 (A implicitly F16).
+    public static LoraAdapter ForConfigF16(ModelConfig cfg, int rank, float alpha, int seed)
+    {
+        var adapter = new LoraAdapter("synthetic-f16", rank, alpha, new[] { "q_proj", "v_proj" });
+        int dModel = cfg.HiddenSize;
+        int qOut = cfg.NumAttentionHeads * cfg.HeadDim;
+        int vOut = cfg.NumKvHeads * cfg.HeadDim;
+        var rng = new Random(seed);
+        for (int layer = 0; layer < cfg.NumLayers; layer++)
+        {
+            AddProjF16(adapter, layer, "q_proj", dModel, qOut, rank, rng);
+            AddProjF16(adapter, layer, "v_proj", dModel, vOut, rank, rng);
+        }
+        return adapter;
+    }
+
+    private static void AddProjF16(LoraAdapter a, int layer, string proj, int dIn, int dOut, int r, Random rng)
+    {
+        long bN = (long)r * dIn;     // B: [r, dIn]
+        long aN = (long)dOut * r;    // A: [dOut, r]
+        nint bH = LoraAdapter.AllocAlignedBytes(bN * sizeof(ushort));
+        nint aH = LoraAdapter.AllocAlignedBytes(aN * sizeof(ushort));
+        FillF16((ushort*)bH, bN, rng);
+        FillF16((ushort*)aH, aN, rng);
+        a.AddLayerWeights(layer, proj,
+            new LoraLayerWeights(aH, bH, dIn, dOut, WeightDType: LoraWeightDType.F16));
+    }
+
+    private static void FillF16(ushort* p, long n, Random rng)
+    {
+        for (long i = 0; i < n; i++)
+        {
+            var h = (Half)(float)(rng.NextDouble() * 0.02 - 0.01);
+            p[i] = BitConverter.HalfToUInt16Bits(h);
+        }
+    }
 }


### PR DESCRIPTION
Closes #89.

`CudaLoraWeights.Stage` assumed F32 host A/B buffers and over-read F16/BF16 adapters → access violation on `--device gpu` with a non-F32 PEFT adapter. Now branches on `w.WeightDType`/`w.ResolvedAWeightDType` via a `StageFactor` helper:
- **F32** — unchanged (upload + `LaunchConvertF32ToF16`); byte-equivalent to before.
- **F16** — direct `cuMemcpyHtoD` into the F16 device buffer (no scratch/convert) — the fix.
- **BF16 / Q8_0** — clear `NotSupportedException` (no BF16→F16 kernel exists; Q8_0 GPU dequant out of scope) instead of a silent AV. CPU path already handles these via `LoraProjection.Apply`.

Leak-safety preserved (F16 device buffers tracked in `f16Allocs` before any throw).

**Verify:** build 0/0; new F16-staging GPU parity test passes (cosine>0.999, argmax match, delta fired, no AV); F32 regressions (`HybridLoraParity` + `BitNetCudaLoraParity`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)