### PR TITLE
lora: U2 results — train + serve + stack 3 Qwen adapters

### DIFF
--- a/scripts/lora/EVAL.md
+++ b/scripts/lora/EVAL.md
@@ -1,0 +1,45 @@
+# Task-LoRA — U2 results: train → serve → stack (Qwen3-4B)
+
+**Date:** 2026-06-25 · RTX 3060 (sm_86) · base `Qwen/Qwen3-4B-Instruct-2507` (served as `Qwen3-4B-Instruct-2507-Q4_K_M.gguf`).
+
+Three task LoRAs trained with `scripts/lora/train_task_lora.py` (QLoRA, **rank 16 / α 32 / dropout 0.05**, the 7 standard projections — identical sites so they stack), 2000 examples, 400 steps each, then served via dotLLM `--lora` and composed with the new repeatable `--lora` (stacking, PR #93).
+
+## Adapters
+| Adapter | Dataset | Final loss | Notes |
+|---|---|---:|---|
+| instruction | `HuggingFaceH4/no_robots` | 2.69 | diverse human prompts → higher steady loss |
+| tool-use | `NousResearch/hermes-function-calling-v1` (`glaive_func_calling`), template-rendered (#94) | 0.0003 | tool-call format is highly regular → very low loss |
+| coding | `iamtarun/python_code_instructions_18k_alpaca` | 0.31 | Python instruct→code |
+
+All exported as standard PEFT (`adapter_config.json` + `adapter_model.safetensors`), r=16/α=32/7 modules.
+
+## Swappable serving (base vs +adapter, greedy, GPU ~58 tok/s)
+- **Coding — clearest behavioral shift.** Base emits verbose markdown-fenced code with a docstring + prose; the **coding adapter emits terse, direct code** (no fence, no prose) — the CodeAlpaca style:
+  ```
+  base:    "Here's a Python function...\n```python\ndef is_prime(n):\n    \"\"\"...docstring...\"\"\"  ..."
+  +coding: "def is_prime(n):\n    if n < 2: return False\n    for i in range(2, n): ..."
+  ```
+- **Instruction — modest shift.** The base is already a strong instruct model; the adapter (no_robots) yields a slightly plainer, less-markdown style. Both answer well.
+- **Tool-use — both correct.** Qwen3-Instruct-2507 natively tool-calls, so base **and** adapter both emit the correct `<tool_call>{"name":"get_weather","arguments":{"city":"Tokyo"}}</tool_call>`. (A weaker base would show a larger adapter gain; here the base's strength masks it.)
+
+## Stacking (the headline) — `--lora instruction --lora tooluse --lora coding`
+The 3 adapters compose additively into one rank-48 adapter (`LoraComposer`); CPU/CUDA apply it through the unchanged single-adapter path. **No-regression confirmed — each skill survives the 3-way stack:**
+- **stack on the coding probe** → terse correct code, and notably uses the efficient `int(n**0.5)+1` sqrt bound (≥ the single coding adapter's `range(2,n)`):
+  ```
+  def is_prime(n):
+      if n < 2: return False
+      for i in range(2, int(n**0.5)+1):
+          if n % i == 0: return False
+      return True
+  ```
+- **stack on the tool probe** → still emits the correct `<tool_call>{"name":"get_weather","arguments":{"city":"Tokyo"}}</tool_call>`.
+
+Multi-`--lora` parsing verified (a bad extra `--lora path` errors "PEFT adapter directory not found"), and the CUDA stacked-parity test (`LoraStackCudaParityTests`) passes on this GPU (argmax CPU==GPU, cosine 0.999029).
+
+## Conclusions
+1. **End-to-end train→serve→stack works with real adapters.** All 3 adapters serve swappably and compose.
+2. **Stacking retains capabilities** (coding + tool-use both intact under the 3-way stack) — the core promise of additive composition.
+3. The coding adapter is the clearest single-adapter win; instruction/tool-use gains are masked by Qwen3-Instruct-2507 already being strong there. **Follow-up for a sharper demo:** harder/held-out probes or a weaker base (e.g. BitNet, U5) where the base fails and the adapter clearly rescues; and the quantitative eval harness (tool-call accuracy, coding pass@1, instruction LLM-judge) per the U2 plan Phase C.
+
+## Reproduce
+`scripts/lora/train_task_lora.py` (train, see `.docs/train_all.sh`), then serve/stack via `dotnet run --project src/DotLLM.Cli -c Release -- run <qwen-q4_k_m.gguf> --device gpu --prompt <rendered> --lora <dir> [--lora <dir> ...]` (prompts rendered with `tokenizer.apply_chat_template`, per `FORMAT.md`).


### PR DESCRIPTION
Closes #97. Trains the 3 task adapters (instruction/tool-use/coding) on Qwen3-4B with the harness, serves each swappably, and **demonstrates stacking with real adapters** on GPU.

## Results (full writeup in scripts/lora/EVAL.md)
- 3 adapters trained (rank-16/α-32/7-proj, 2000 ex × 400 steps): instruction loss 2.69, tool-use 0.0003, coding 0.31. Valid PEFT.
- **Swappable:** coding adapter shows the clearest shift (terse direct code vs base's verbose markdown); instruction/tool-use modest because Qwen3-Instruct-2507 is already strong (both base+adapter emit correct `<tool_call>`).
- **Stacking (`--lora instruction --lora tooluse --lora coding`, rank-48 composite):** no-regression — stacked still produces correct terse code (with the efficient sqrt bound) AND correct tool-calls. Multi-`--lora` parsing verified; CUDA stacked-parity test passes.

Tracked artifact is `scripts/lora/EVAL.md` (adapters/logs are gitignored). Follow-up: quantitative eval harness (Phase C) + a weaker-base demo (U5 BitNet) where adapter gains are starker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)