### PR TITLE
chat: tool-aware BitNet chat template (train==serve)

### DIFF
--- a/scripts/lora/dump_bitnet_format.py
+++ b/scripts/lora/dump_bitnet_format.py
@@ -1,0 +1,69 @@
+# scripts/lora/dump_bitnet_format.py
+"""Task 1 (BitNet tool-use): extract the tool-aware BitNet chat-template rendering
+for a fixed messages+tools fixture, so a C# test can assert dotLLM renders the same string.
+Run: PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface C:/Python311/python.exe scripts/lora/dump_bitnet_format.py
+"""
+import json, os
+from transformers import AutoTokenizer
+
+BASE = "microsoft/bitnet-b1.58-2B-4T-bf16"
+TEMPLATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates", "bitnet_tooluse.jinja")
+FIX = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+os.makedirs(FIX, exist_ok=True)
+
+# Fixed inputs shared with the C# test (kept tiny + deterministic).
+MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is the weather in Tokyo?"},
+]
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string", "description": "City name"}},
+            "required": ["city"],
+        },
+    },
+}]
+ASSISTANT_TOOL_CALL = (
+    '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Tokyo"}}\n</tool_call>'
+)
+
+
+def main():
+    tok = AutoTokenizer.from_pretrained(BASE)
+    template = open(TEMPLATE_FILE, encoding="utf-8").read()
+    tok.chat_template = template
+
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+    with open(os.path.join(FIX, "bitnet_tooluse_reference.txt"), "w", encoding="utf-8") as f:
+        f.write(rendered)
+
+    # Flatten tools to dotLLM's ToolDefinition shape (name/description/parameters-as-json-string).
+    dotllm_tools = [{
+        "name": t["function"]["name"],
+        "description": t["function"]["description"],
+        "parameters": json.dumps(t["function"]["parameters"]),
+    } for t in TOOLS]
+    with open(os.path.join(FIX, "bitnet_format_inputs.json"), "w", encoding="utf-8") as f:
+        json.dump({"messages": MESSAGES, "tools": dotllm_tools,
+                   "assistant_tool_call": ASSISTANT_TOOL_CALL,
+                   "bos_token": tok.bos_token or "", "eos_token": tok.eos_token or ""},
+                  f, indent=2, ensure_ascii=False)
+
+    print("Wrote fixtures to", FIX)
+    print("--- rendered (first 800 chars) ---")
+    print(rendered[:800])
+    assert "<tools>" in rendered, "ERROR: <tools> block missing from rendered output"
+    assert "get_weather" in rendered, "ERROR: tool name missing from rendered output"
+    assert rendered.rstrip().endswith("Assistant:"), f"ERROR: does not end at assistant turn, ends: {rendered[-50:]!r}"
+    print("--- assertions passed ---")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lora/fixtures/bitnet_format_inputs.json
+++ b/scripts/lora/fixtures/bitnet_format_inputs.json
@@ -1,0 +1,22 @@
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful assistant."
+    },
+    {
+      "role": "user",
+      "content": "What is the weather in Tokyo?"
+    }
+  ],
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather for a city.",
+      "parameters": "{\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\", \"description\": \"City name\"}}, \"required\": [\"city\"]}"
+    }
+  ],
+  "assistant_tool_call": "<tool_call>\n{\"name\": \"get_weather\", \"arguments\": {\"city\": \"Tokyo\"}}\n</tool_call>",
+  "bos_token": "<|begin_of_text|>",
+  "eos_token": "<|eot_id|>"
+}

--- a/scripts/lora/fixtures/bitnet_tooluse_reference.txt
+++ b/scripts/lora/fixtures/bitnet_tooluse_reference.txt
@@ -1,0 +1,15 @@
+System: You are a helpful assistant.
+
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{"type": "function", "function": {"name": "get_weather", "description": "Get the current weather for a city.", "parameters": {"type": "object", "properties": {"city": {"type": "string", "description": "City name"}}, "required": ["city"]}}}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
+<tool_call>
+{"name": <function-name>, "arguments": <args-json-object>}
+</tool_call><|eot_id|>User: What is the weather in Tokyo?<|eot_id|>Assistant: 

--- a/scripts/lora/templates/bitnet_tooluse.jinja
+++ b/scripts/lora/templates/bitnet_tooluse.jinja
@@ -1,0 +1,28 @@
+{%- if tools %}
+{%- if messages | length > 0 and messages[0].role == 'system' %}
+{{- 'System: ' + messages[0].content | trim + '\n\n' }}
+{%- endif %}
+{{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+{%- for tool in tools %}
+{{- "\n" }}
+{{- tool | tojson }}
+{%- endfor %}
+{{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>" }}
+{{- '<|eot_id|>' }}
+{%- else %}
+{%- if messages | length > 0 and messages[0].role == 'system' %}
+{{- 'System: ' + messages[0].content | trim + '<|eot_id|>' }}
+{%- endif %}
+{%- endif %}
+{%- for message in messages %}
+{%- if message.role == 'user' %}
+{{- 'User: ' + message.content | trim + '<|eot_id|>' }}
+{%- elif message.role == 'assistant' %}
+{{- 'Assistant: ' + message.content | trim + '<|eot_id|>' }}
+{%- elif message.role == 'tool' %}
+{{- 'Tool: ' + message.content | trim + '<|eot_id|>' }}
+{%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+{{- 'Assistant: ' }}
+{%- endif %}

--- a/scripts/lora/tests/test_bitnet_tooluse_render.py
+++ b/scripts/lora/tests/test_bitnet_tooluse_render.py
@@ -1,0 +1,122 @@
+"""Task 1 (BitNet tool-use): verify the tool-aware BitNet chat template renders correctly.
+
+Run: PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface C:/Python311/python.exe -m pytest scripts/lora/tests/test_bitnet_tooluse_render.py -v
+"""
+import sys, os, json, re
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "fixtures")
+TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "templates")
+TEMPLATE_FILE = os.path.join(TEMPLATES_DIR, "bitnet_tooluse.jinja")
+
+BASE = "microsoft/bitnet-b1.58-2B-4T-bf16"
+
+MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is the weather in Tokyo?"},
+]
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string", "description": "City name"}},
+            "required": ["city"],
+        },
+    },
+}]
+ASSISTANT_TOOL_CALL = (
+    '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Tokyo"}}\n</tool_call>'
+)
+
+
+def _load_tok():
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained(BASE)
+    tok.chat_template = open(TEMPLATE_FILE, encoding="utf-8").read()
+    return tok
+
+
+def test_template_file_exists():
+    assert os.path.isfile(TEMPLATE_FILE), f"Template file not found: {TEMPLATE_FILE}"
+
+
+def test_rendered_contains_tools_block():
+    tok = _load_tok()
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+    assert "<tools>" in rendered, f"Expected <tools> block. Got:\n{rendered[:600]}"
+    assert "</tools>" in rendered, "Missing </tools>"
+
+
+def test_rendered_contains_tool_name():
+    tok = _load_tok()
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+    assert "get_weather" in rendered, f"Tool name 'get_weather' missing. Got:\n{rendered[:600]}"
+
+
+def test_rendered_ends_at_assistant_turn():
+    tok = _load_tok()
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+    assert rendered.rstrip().endswith("Assistant:"), (
+        f"Expected prompt to end at 'Assistant:'. Ends with: {rendered[-80:]!r}"
+    )
+
+
+def test_rendered_contains_tool_call_instructions():
+    tok = _load_tok()
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+    assert "<tool_call>" in rendered, "Expected <tool_call> instruction in tools preamble"
+    assert "</tool_call>" in rendered, "Expected </tool_call> instruction in tools preamble"
+
+
+def test_rendered_contains_eot_id_separator():
+    tok = _load_tok()
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+    assert "<|eot_id|>" in rendered, "Expected BitNet turn separator <|eot_id|>"
+
+
+def test_rendered_matches_reference_fixture():
+    """Parity: rendered output must match the pre-generated reference fixture."""
+    ref_path = os.path.join(FIXTURES_DIR, "bitnet_tooluse_reference.txt")
+    assert os.path.isfile(ref_path), (
+        f"Reference fixture not found at {ref_path}. "
+        "Run 'python scripts/lora/dump_bitnet_format.py' first."
+    )
+    reference = open(ref_path, encoding="utf-8").read()
+    tok = _load_tok()
+    rendered = tok.apply_chat_template(
+        MESSAGES, tools=TOOLS, add_generation_prompt=True, tokenize=False
+    )
+
+    def norm(s): return s.replace("\r\n", "\n").rstrip()
+
+    assert norm(rendered) == norm(reference), (
+        f"Rendered output differs from reference fixture.\n"
+        f"Expected:\n{reference[:600]}\n\nActual:\n{rendered[:600]}"
+    )
+
+
+def test_hermes_parser_roundtrips_tool_call():
+    """Python-side Hermes parse: extract name+arguments from <tool_call> block."""
+    # Simple inline parser matching HermesToolCallParser logic
+    open_tag = "<tool_call>"
+    close_tag = "</tool_call>"
+    text = ASSISTANT_TOOL_CALL
+    start = text.index(open_tag) + len(open_tag)
+    end = text.index(close_tag, start)
+    json_blob = text[start:end].strip()
+    parsed = json.loads(json_blob)
+    assert parsed["name"] == "get_weather"
+    assert parsed["arguments"]["city"] == "Tokyo"

--- a/src/DotLLM.Cli/Commands/ChatCommand.cs
+++ b/src/DotLLM.Cli/Commands/ChatCommand.cs
@@ -258,7 +258,7 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
         if (vramWarning is not null)
             AnsiConsole.MarkupLine($"[yellow]WARNING: {Markup.Escape(vramWarning)}[/]");
 
-        var jinjaTemplate = GgufChatTemplateFactory.TryCreate(gguf!.Metadata, tokenizer!);
+        var jinjaTemplate = GgufChatTemplateFactory.TryCreate(gguf!.Metadata, tokenizer!, config!.Architecture);
         IChatTemplate chatTemplate = jinjaTemplate ?? GgufChatTemplateFactory.CreatePlainFallback(tokenizer!);
         if (jinjaTemplate is null)
         {

--- a/src/DotLLM.Cli/Commands/RunCommand.cs
+++ b/src/DotLLM.Cli/Commands/RunCommand.cs
@@ -303,7 +303,7 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
         {
             string bosToken = tokenizer.DecodeToken(tokenizer.BosTokenId);
             string eosToken = tokenizer.DecodeToken(tokenizer.EosTokenId);
-            var chatTemplate = GgufChatTemplateFactory.TryCreate(gguf.Metadata, tokenizer)
+            var chatTemplate = GgufChatTemplateFactory.TryCreate(gguf.Metadata, tokenizer, config.Architecture)
                 ?? GgufChatTemplateFactory.CreatePlainFallback(tokenizer);
 
             var messages = new List<ChatMessage>

--- a/src/DotLLM.Models/Gguf/GgufChatTemplateFactory.cs
+++ b/src/DotLLM.Models/Gguf/GgufChatTemplateFactory.cs
@@ -27,6 +27,43 @@ public static class GgufChatTemplateFactory
         "{% if add_generation_prompt %}{{ 'Assistant: ' }}{% endif %}";
 
     /// <summary>
+    /// Tool-aware Jinja2 chat template for BitNet b1.58.
+    /// Preserves BitNet's <c>User:/Assistant:/&lt;|eot_id|&gt;</c> turn format and injects
+    /// a Hermes-style <c>&lt;tools&gt;/&lt;tool_call&gt;</c> preamble when tools are present.
+    /// Source of truth: kept byte-identical to <c>scripts/lora/templates/bitnet_tooluse.jinja</c>
+    /// and guarded by <c>BitNetToolFormatVerificationTests</c>.
+    /// </summary>
+    public const string BitNetToolAwareTemplateText =
+        "{%- if tools %}\n" +
+        "{%- if messages | length > 0 and messages[0].role == 'system' %}\n" +
+        "{{- 'System: ' + messages[0].content | trim + '\\n\\n' }}\n" +
+        "{%- endif %}\n" +
+        "{{- \"# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n" +
+        "{%- for tool in tools %}\n" +
+        "{{- \"\\n\" }}\n" +
+        "{{- tool | tojson }}\n" +
+        "{%- endfor %}\n" +
+        "{{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call>\" }}\n" +
+        "{{- '<|eot_id|>' }}\n" +
+        "{%- else %}\n" +
+        "{%- if messages | length > 0 and messages[0].role == 'system' %}\n" +
+        "{{- 'System: ' + messages[0].content | trim + '<|eot_id|>' }}\n" +
+        "{%- endif %}\n" +
+        "{%- endif %}\n" +
+        "{%- for message in messages %}\n" +
+        "{%- if message.role == 'user' %}\n" +
+        "{{- 'User: ' + message.content | trim + '<|eot_id|>' }}\n" +
+        "{%- elif message.role == 'assistant' %}\n" +
+        "{{- 'Assistant: ' + message.content | trim + '<|eot_id|>' }}\n" +
+        "{%- elif message.role == 'tool' %}\n" +
+        "{{- 'Tool: ' + message.content | trim + '<|eot_id|>' }}\n" +
+        "{%- endif %}\n" +
+        "{%- endfor %}\n" +
+        "{%- if add_generation_prompt %}\n" +
+        "{{- 'Assistant: ' }}\n" +
+        "{%- endif %}";
+
+    /// <summary>
     /// Tries to create a <see cref="JinjaChatTemplate"/> from GGUF metadata.
     /// Returns null if no chat template is present in the metadata.
     /// </summary>
@@ -40,6 +77,32 @@ public static class GgufChatTemplateFactory
 
         string bosToken = tokenizer.DecodeToken(tokenizer.BosTokenId);
         string eosToken = tokenizer.DecodeToken(tokenizer.EosTokenId);
+        return new JinjaChatTemplate(template, bosToken, eosToken);
+    }
+
+    /// <summary>
+    /// Tries to create a <see cref="JinjaChatTemplate"/> from GGUF metadata.
+    /// Returns null if no chat template is present in the metadata.
+    /// For <see cref="Architecture.BitNet"/>, substitutes the built-in tool-aware template
+    /// so that <c>--tools</c> injects tool definitions correctly.
+    /// </summary>
+    /// <param name="metadata">GGUF metadata containing the template string and token info.</param>
+    /// <param name="tokenizer">Tokenizer for resolving BOS/EOS token strings.</param>
+    /// <param name="architecture">Model architecture (used for per-arch template substitution).</param>
+    public static JinjaChatTemplate? TryCreate(GgufMetadata metadata, ITokenizer tokenizer,
+        Architecture architecture)
+    {
+        string bosToken = tokenizer.DecodeToken(tokenizer.BosTokenId);
+        string eosToken = tokenizer.DecodeToken(tokenizer.EosTokenId);
+
+        // Approach A: BitNet's built-in GGUF template has no tool support.
+        // Substitute the tool-aware template unconditionally for BitNet.
+        if (architecture == Architecture.BitNet)
+            return new JinjaChatTemplate(BitNetToolAwareTemplateText, bosToken, eosToken);
+
+        string? template = metadata.GetStringOrDefault("tokenizer.chat_template", null!);
+        if (string.IsNullOrEmpty(template))
+            return null;
 
         return new JinjaChatTemplate(template, bosToken, eosToken);
     }

--- a/src/DotLLM.Server/ServerStartup.cs
+++ b/src/DotLLM.Server/ServerStartup.cs
@@ -110,7 +110,7 @@ public static class ServerStartup
         }
 
         // Create chat template
-        var declaredChatTemplate = GgufChatTemplateFactory.TryCreate(gguf.Metadata, tokenizer);
+        var declaredChatTemplate = GgufChatTemplateFactory.TryCreate(gguf.Metadata, tokenizer, config.Architecture);
         if (declaredChatTemplate is null)
             Console.WriteLine("[dotllm] Model has no GGUF chat template; using a plain completion-style transcript.");
         IChatTemplate chatTemplate = declaredChatTemplate ?? GgufChatTemplateFactory.CreatePlainFallback(tokenizer);

--- a/src/DotLLM.Tokenizers/ToolCallParsers/ToolCallParserFactory.cs
+++ b/src/DotLLM.Tokenizers/ToolCallParsers/ToolCallParserFactory.cs
@@ -48,6 +48,10 @@ public static class ToolCallParserFactory
             // SmolLM3 defaults to the XML (Hermes-compatible) format; the
             // Pythonic variant is template-gated above.
             Architecture.SmolLM3 => new XmlToolCallParser(),
+            // BitNet uses a tool-aware template that emits <tool_call> blocks
+            // (Hermes-compatible). Route to HermesToolCallParser regardless of
+            // what the GGUF metadata declares (the template is substituted).
+            Architecture.BitNet => new HermesToolCallParser(),
             _ => new GenericToolCallParser()
         };
     }

--- a/tests/DotLLM.Tests.Unit/Tokenizers/ChatTemplates/BitNetToolFormatVerificationTests.cs
+++ b/tests/DotLLM.Tests.Unit/Tokenizers/ChatTemplates/BitNetToolFormatVerificationTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using DotLLM.Models.Gguf;
+using DotLLM.Tokenizers;
+using DotLLM.Tokenizers.ChatTemplates;
+using DotLLM.Tokenizers.ToolCallParsers;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Tokenizers.ChatTemplates;
+
+public sealed class BitNetToolFormatVerificationTests
+{
+    private static string FixtureDir()
+    {
+        // Walk up from the test bin dir to the repo root, then into scripts/lora/fixtures.
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "dotLLM.slnx")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.NotNull(dir);
+        return Path.Combine(dir!, "scripts", "lora", "fixtures");
+    }
+
+    private static string TemplateDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "dotLLM.slnx")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.NotNull(dir);
+        return Path.Combine(dir!, "scripts", "lora", "templates");
+    }
+
+    private sealed record Inputs(JsonElement messages, JsonElement tools,
+        string assistant_tool_call, string bos_token, string eos_token);
+
+    [Fact]
+    public void DotLlm_Renders_BitNet_Tool_Template_Identically_To_Reference()
+    {
+        var fix = FixtureDir();
+        var expected = File.ReadAllText(Path.Combine(fix, "bitnet_tooluse_reference.txt"));
+        var inp = JsonSerializer.Deserialize<Inputs>(
+            File.ReadAllText(Path.Combine(fix, "bitnet_format_inputs.json")))!;
+
+        var messages = inp.messages.EnumerateArray()
+            .Select(m => new ChatMessage {
+                Role = m.GetProperty("role").GetString()!,
+                Content = m.GetProperty("content").GetString()! })
+            .ToList();
+        var tools = inp.tools.EnumerateArray()
+            .Select(t => new ToolDefinition(
+                t.GetProperty("name").GetString()!,
+                t.GetProperty("description").GetString()!,
+                t.GetProperty("parameters").GetString()!))
+            .ToArray();
+
+        // Use the embedded const (approach A) — same source as bitnet_tooluse.jinja.
+        var tmpl = new JinjaChatTemplate(
+            GgufChatTemplateFactory.BitNetToolAwareTemplateText,
+            inp.bos_token,
+            inp.eos_token);
+        var actual = tmpl.Apply(messages, new ChatTemplateOptions {
+            AddGenerationPrompt = true, Tools = tools });
+
+        // Normalize trailing whitespace/newlines only — content must match.
+        static string N(string s) => s.Replace("\r\n", "\n").TrimEnd();
+        Assert.Equal(N(expected), N(actual));
+    }
+
+    [Fact]
+    public void Embedded_Const_Matches_Jinja_File_On_Disk()
+    {
+        // Guard that the embedded C# const stays byte-identical to the .jinja file.
+        var templatePath = Path.Combine(TemplateDir(), "bitnet_tooluse.jinja");
+        var fileTemplate = File.ReadAllText(templatePath);
+
+        static string N(string s) => s.Replace("\r\n", "\n").TrimEnd();
+
+        // Both should render the same output for a fixed input (indirection through render,
+        // not raw text comparison, since the file has actual newlines and the const uses \n).
+        var messages = new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "You are a helpful assistant." },
+            new() { Role = "user", Content = "What is the weather in Tokyo?" },
+        };
+        var tools = new[] { new ToolDefinition(
+            "get_weather",
+            "Get the current weather for a city.",
+            "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\",\"description\":\"City name\"}},\"required\":[\"city\"]}") };
+        const string bos = "<|begin_of_text|>";
+        const string eos = "<|eot_id|>";
+
+        var fromFile = new JinjaChatTemplate(fileTemplate, bos, eos)
+            .Apply(messages, new ChatTemplateOptions { AddGenerationPrompt = true, Tools = tools });
+        var fromConst = new JinjaChatTemplate(
+            GgufChatTemplateFactory.BitNetToolAwareTemplateText, bos, eos)
+            .Apply(messages, new ChatTemplateOptions { AddGenerationPrompt = true, Tools = tools });
+
+        Assert.Equal(N(fromFile), N(fromConst));
+    }
+
+    [Fact]
+    public void Hermes_Parser_RoundTrips_The_BitNet_Assistant_Tool_Call()
+    {
+        var fix = FixtureDir();
+        var inp = JsonSerializer.Deserialize<Inputs>(
+            File.ReadAllText(Path.Combine(fix, "bitnet_format_inputs.json")))!;
+
+        var calls = new HermesToolCallParser().TryParse(inp.assistant_tool_call);
+
+        Assert.NotNull(calls);
+        Assert.Single(calls!);
+        Assert.Equal("get_weather", calls![0].FunctionName);
+        using var args = JsonDocument.Parse(calls[0].Arguments);
+        Assert.Equal("Tokyo", args.RootElement.GetProperty("city").GetString());
+    }
+
+    [Fact]
+    public void ToolCallParserFactory_Returns_Hermes_For_BitNet()
+    {
+        // Confirm the parser factory routes BitNet to HermesToolCallParser.
+        var parser = ToolCallParserFactory.Create(DotLLM.Core.Configuration.Architecture.BitNet);
+        Assert.IsType<HermesToolCallParser>(parser);
+    }
+}


### PR DESCRIPTION
Closes #100. Gives BitNet b1.58 real tool-calling: a tool-aware chat template used identically at train (tokenizer) and serve (dotLLM).

## Problem
BitNet's chat template (HF tokenizer + I2_S GGUF metadata) is minimal `User:/Assistant:` with no tool support → `apply_chat_template(tools=)` drops tools and dotLLM `--tools` was a no-op for BitNet.

## Fix (approach A)
- `scripts/lora/templates/bitnet_tooluse.jinja` — BitNet turns + a Qwen-style `<tools>`/`<tool_call>` block (only Jinja constructs dotLLM's evaluator already handles, proven by the Qwen test). Single source of truth.
- `GgufChatTemplateFactory.TryCreate(meta, tokenizer, Architecture)` substitutes it for `Architecture.BitNet`; non-BitNet unchanged (2-arg overload preserved). Callers (Run/Chat/Server) pass `config.Architecture`.
- `ToolCallParserFactory`: BitNet → `HermesToolCallParser` (so the emitted `<tool_call>` parses).
- `dump_bitnet_format.py` emits golden fixtures.

## Tests
- Python **8/8** (render contains `<tools>`+tool, ends at Assistant:, Hermes round-trip).
- C# **4/4**: dotLLM render == tokenizer reference (exact), embedded-const-matches-`.jinja`-file drift guard, Hermes round-trip, factory returns Hermes for BitNet. Existing Qwen template test still green (no regression).

Unblocks a real (non-degenerate) BitNet tool-use adapter. Upstream-relevant (#334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)