### PR TITLE
lora: U5 — train + serve + stack 3 adapters on BitNet b1.58 (ternary 2B)

### DIFF
--- a/scripts/lora/EVAL_bitnet.md
+++ b/scripts/lora/EVAL_bitnet.md
@@ -1,0 +1,53 @@
+# Task-LoRA — U5 results: train → serve → stack on BitNet b1.58 (ternary 2B)
+
+**Date:** 2026-06-26 · RTX 3060 · base `microsoft/bitnet-b1.58-2B-4T-bf16` (trained) → served on the
+**I2_S ternary GGUF** (`ggml-model-i2_s.gguf`) via dotLLM `--lora`. Decoding: greedy + `--repeat-penalty 1.3 --repeat-last-n 256`
+(a 2B ternary base degenerates into repetition under pure greedy — the penalty is required for coherent output).
+
+Three task LoRAs trained with `scripts/lora/train_task_lora.py` (**rank 16 / α 32 / 7 projections**, 2000 ex × 400 steps,
+`--no-4bit` bf16 base, `--grad-checkpoint --max-seq-len` to fit the 12 GB card). The **tool-use** adapter was trained
+with `--chat-template scripts/lora/templates/bitnet_tooluse.jinja` (#100), so it sees a real `<tools>` block — not the
+degenerate "no tool context" of BitNet's stock template.
+
+## Adapters
+| Adapter | Final loss | Notes |
+|---|---:|---|
+| instruction | ~1.5 | no_robots |
+| coding | 0.30 | python_code_instructions (max-seq-len 1024 + grad checkpointing) |
+| tool-use | ~0.5 | glaive_func_calling, rendered via the BitNet tool template (#100) |
+
+All valid PEFT (r=16/α=32/7 modules).
+
+## What works (the pipeline + #100)
+1. **End-to-end pipeline works on a ternary base.** train (bf16 BitNet, peft) → serve on the **I2_S GGUF** → stack —
+   exactly as on Qwen3-4B (U2), now on BitNet.
+2. **#100 tool template is live at serve time.** With `--tools`, dotLLM renders the new BitNet tool-aware template and
+   the model **references the correct `get_weather` function name** — vs the previous no-op where tool definitions never
+   reached the model at all. The plumbing (template → model → Hermes parser) is exercised end-to-end.
+3. **Stacking applies** — `--lora instruction --lora tooluse --lora coding` composes the 3 rank-16 adapters (rank-48) and
+   runs through the unchanged single-adapter path on the BitNet I2_S GPU path.
+4. **Adapters shift behavior** in the expected direction: the **coding** adapter drops the base's markdown fence/docstring
+   and emits direct code (`def is_prime(n):\n    if n < 2:\n        return False …`); the **instruction** adapter gives a
+   cleaner, more direct numbered list.
+
+## Honest limitation: the 2B ternary base is capability-bound
+BitNet b1.58 2B is a deliberately tiny, extreme-quantisation base. Even with adapters + repetition penalty:
+- Coherent on **short** instruction output; **derails on longer** generation (code past the first few lines, repeated `<|eot_id|>`).
+- For **tool-use**, it references the right function name but **cannot reliably emit valid `<tool_call>` JSON** — the
+  structured-output demand exceeds the base's capacity.
+
+This is a **base-model limitation, not a dotLLM/adapter/#100 defect** — the same harness produces clean, swappable,
+stackable results on Qwen3-4B (see `EVAL.md`). U5's value is validating the **pipeline + the BitNet tool template +
+stacking on the ternary base**, not matching Qwen quality.
+
+## Clear follow-up
+**Constrained decoding for tool-use.** dotLLM already has JSON-schema constrained decoding + `ToolCallSchemaBuilder`.
+Forcing the tool-call grammar would let even this weak base emit *valid* `<tool_call>` JSON (correctness guaranteed by the
+decoder, not the model) — the natural next demo and the right answer for small/quantised bases. (`--tool-choice required`
+wiring into `run` is the gap.)
+
+## Reproduce
+Train (per adapter): `train_task_lora.py --task <t> --no-4bit --grad-checkpoint --max-seq-len <N> [--chat-template
+scripts/lora/templates/bitnet_tooluse.jinja for tooluse] --base microsoft/bitnet-b1.58-2B-4T-bf16 …`.
+Serve/stack: `dotnet run --project src/DotLLM.Cli -c Release -- run <i2_s.gguf> --device gpu --repeat-penalty 1.3
+--repeat-last-n 256 [--prompt <rendered> | --tools @tools.json] [--lora <dir> …]`.

--- a/scripts/lora/train_task_lora.py
+++ b/scripts/lora/train_task_lora.py
@@ -41,11 +41,20 @@ def main():
     ap.add_argument("--lr", type=float, default=2e-4)
     ap.add_argument("--out", required=True)
     ap.add_argument("--no-4bit", action="store_true")
+    ap.add_argument("--chat-template", default=None,
+                    help="Path to a Jinja chat template to override the tokenizer's built-in one. "
+                         "Required for tool-use on bases whose template lacks tool support (e.g. BitNet → "
+                         "scripts/lora/templates/bitnet_tooluse.jinja), so the <tools> block is rendered "
+                         "identically to dotLLM serving.")
     args = ap.parse_args()
 
     tok = AutoTokenizer.from_pretrained(args.base)
     if tok.pad_token is None:
         tok.pad_token = tok.eos_token
+    if args.chat_template:
+        with open(args.chat_template, encoding="utf-8") as f:
+            tok.chat_template = f.read()
+        print(f"Using chat template override: {args.chat_template}")
 
     if args.no_4bit:
         model = AutoModelForCausalLM.from_pretrained(args.base, dtype=torch.bfloat16,

--- a/scripts/lora/train_task_lora.py
+++ b/scripts/lora/train_task_lora.py
@@ -41,6 +41,11 @@ def main():
     ap.add_argument("--lr", type=float, default=2e-4)
     ap.add_argument("--out", required=True)
     ap.add_argument("--no-4bit", action="store_true")
+    ap.add_argument("--max-seq-len", type=int, default=4096,
+                    help="Drop training examples longer than this (tokens). Lower it (e.g. 1024) "
+                         "to bound activation memory for long-example tasks on small GPUs.")
+    ap.add_argument("--grad-checkpoint", action="store_true",
+                    help="Enable gradient checkpointing (saves activation memory at some compute cost).")
     ap.add_argument("--chat-template", default=None,
                     help="Path to a Jinja chat template to override the tokenizer's built-in one. "
                          "Required for tool-use on bases whose template lacks tool support (e.g. BitNet → "
@@ -71,6 +76,11 @@ def main():
     lcfg = LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias="none",
                       task_type="CAUSAL_LM", target_modules=TARGET_MODULES)
     model = get_peft_model(model, lcfg)
+    # Gradient checkpointing trades compute for a large activation-memory saving —
+    # required to fit long examples (e.g. code) of a full-bf16 base on a 12 GB card.
+    if args.grad_checkpoint:
+        model.gradient_checkpointing_enable()
+        model.enable_input_require_grads()
     model.print_trainable_parameters()
 
     ds = datasets.load_dataset(args.dataset, args.dataset_config, split=args.split)
@@ -89,7 +99,7 @@ def main():
                 ids, labels = render(tok, msgs)
         except (KeyError, ValueError):
             continue
-        if len(ids) <= 4096:
+        if len(ids) <= args.max_seq_len:
             examples.append((ids, labels))
         if len(examples) >= args.max_examples:
             break


### PR DESCRIPTION
Closes #99. Ports the task-LoRA pipeline to **BitNet b1.58 2B4T** and validates train→serve→stack on the ternary base, including the new #100 BitNet tool template.

## Harness additions (reusable)
- `--chat-template <file>` on `train_task_lora.py` — override the tokenizer template (BitNet tool-use trains against `bitnet_tooluse.jinja` so it sees a real `<tools>` block; non-degenerate).
- `--grad-checkpoint` + `--max-seq-len` — bound activation memory so a full-bf16 base trains on a 12 GB card (coding/tooluse OOM'd without).

## Results (full writeup: scripts/lora/EVAL_bitnet.md)
3 adapters trained (r16/α32/7-proj) on `bitnet-b1.58-2B-4T-bf16`, served on the **I2_S GGUF** (greedy + `--repeat-penalty 1.3`, required for a coherent 2B ternary base).
- ✅ **Pipeline works on a ternary base** (train→serve→stack), mirroring the Qwen3-4B run (U2).
- ✅ **#100 tool template live at serve time** — with `--tools`, BitNet now references the correct `get_weather` function (vs the prior no-op where tools never reached the model).
- ✅ **Stacking applies** — `--lora instruction --lora tooluse --lora coding` (rank-48) on the BitNet GPU path.
- ✅ **Adapters shift behavior** — coding adapter → direct code (no markdown fence); instruction adapter → cleaner list.
- ⚠️ **Honest limit:** the 2B ternary base is capability-bound — coherent short output, correct code *starts*, right tool name, but derails on long generation and can't reliably emit valid `<tool_call>` JSON. A base-model limit, not a dotLLM/adapter/#100 defect (Qwen3-4B is clean, EVAL.md).

## Follow-up
**Constrained decoding for tool-use** (dotLLM already has JSON-schema constraints + `ToolCallSchemaBuilder`) would force valid `<tool_call>` JSON even on a weak base — the right next demo. (`--tool-choice required` wiring into `run` is the gap.)

Completes the original BitNet thrust's train→serve→stack loop. Adapters/logs gitignored; `EVAL_bitnet.md` is the tracked artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)