### PR TITLE
cli(run): --tool-choice required/function — constrained tool-call decoding

### DIFF
--- a/src/DotLLM.Cli/Commands/ChatCommand.cs
+++ b/src/DotLLM.Cli/Commands/ChatCommand.cs
@@ -782,7 +782,7 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
         }
     }
 
-    private static ToolChoice ParseToolChoice(string choice, ToolDefinition[]? tools)
+    internal static ToolChoice ParseToolChoice(string choice, ToolDefinition[]? tools)
     {
         return choice.ToLowerInvariant() switch
         {

--- a/src/DotLLM.Cli/Commands/RunCommand.cs
+++ b/src/DotLLM.Cli/Commands/RunCommand.cs
@@ -7,6 +7,7 @@ using DotLLM.Core.Configuration;
 using DotLLM.Core.Lora;
 using DotLLM.Core.Models;
 using DotLLM.Engine;
+using DotLLM.Engine.Constraints;
 using DotLLM.Models.Architectures;
 using DotLLM.Models.Gguf;
 using DotLLM.Tokenizers;
@@ -158,6 +159,11 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
         [Description("Tool definitions: JSON array string or file path (prefixed with @). " +
                      "When provided, the prompt is formatted via the model's chat template with tool definitions.")]
         public string? Tools { get; set; }
+
+        /// <summary>Tool selection mode.</summary>
+        [CommandOption("--tool-choice")]
+        [Description("Tool selection: 'auto' (default), 'none', 'required' (constrain output to a valid tool call), or a function name.")]
+        public string ToolChoiceStr { get; set; } = "auto";
 
         /// <summary>Draft model for speculative decoding.</summary>
         [CommandOption("--speculative-model")]
@@ -317,6 +323,7 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
             });
             toolCallParser = GgufChatTemplateFactory.CreateToolCallParser(gguf.Metadata, config.Architecture);
         }
+        var toolChoice = ChatCommand.ParseToolChoice(settings.ToolChoiceStr, tools);
 
         // Build inference options from CLI flags
         var responseFormat = settings.ResponseFormat.ToLowerInvariant() switch
@@ -327,6 +334,22 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
             "grammar" => BuildGrammarFormat(settings.Grammar),
             _ => null
         };
+
+        // When required/function, constrain output to valid tool-call JSON (bare JSON object).
+        if (responseFormat is null && tools is { Length: > 0 } && (toolChoice is ToolChoice.Required or ToolChoice.Function))
+        {
+            string argumentsKey = toolCallParser is LlamaToolCallParser ? "parameters" : "arguments";
+            responseFormat = toolChoice switch
+            {
+                ToolChoice.Required => new Core.Configuration.ResponseFormat.JsonSchema
+                    { Schema = ToolCallSchemaBuilder.BuildForRequired(tools, argumentsKey), Name = "tool_call" },
+                ToolChoice.Function fn => new Core.Configuration.ResponseFormat.JsonSchema
+                    { Schema = ToolCallSchemaBuilder.BuildForFunction(tools.First(t => t.Name == fn.Name), argumentsKey), Name = "tool_call" },
+                _ => responseFormat
+            };
+            // Constrained output is bare JSON → parse with the generic (markerless) parser.
+            toolCallParser = new GenericToolCallParser();
+        }
         var inferenceOptions = new InferenceOptions
         {
             Temperature = settings.Temperature,
@@ -467,9 +490,8 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
 
             await foreach (var token in generator.GenerateStreamingTokensAsync(effectivePrompt, inferenceOptions, adapter: loraAdapter))
             {
-                if (settings.Json)
-                    generatedText.Append(token.Text);
-                else
+                generatedText.Append(token.Text);
+                if (!settings.Json)
                     Console.Write(token.Text);
 
                 if (token.FinishReason is null || token.Text.Length > 0)
@@ -538,6 +560,14 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
                 detectedToolCalls = toolCallParser.TryParse(outputText);
                 if (detectedToolCalls is { Length: > 0 })
                     finishReason = FinishReason.ToolCalls;
+            }
+
+            // For constrained tool-choice paths, display the resolved tool call in non-JSON mode.
+            if (!settings.Json && detectedToolCalls is { Length: > 0 }
+                && (toolChoice is ToolChoice.Required or ToolChoice.Function))
+            {
+                foreach (var tc in detectedToolCalls)
+                    AnsiConsole.MarkupLine($"[dim]tool call:[/] [green]{Markup.Escape(tc.FunctionName)}[/]({Markup.Escape(tc.Arguments)})");
             }
 
             if (settings.Json)

--- a/tests/DotLLM.Tests.Unit/Cli/RunToolChoiceTests.cs
+++ b/tests/DotLLM.Tests.Unit/Cli/RunToolChoiceTests.cs
@@ -1,0 +1,80 @@
+using DotLLM.Engine.Constraints;
+using DotLLM.Tokenizers;
+using DotLLM.Tokenizers.ToolCallParsers;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Cli;
+
+/// <summary>
+/// Verifies the constrained tool-calling round-trip used by <c>run --tool-choice required</c>:
+/// <c>ToolCallSchemaBuilder</c> produces a schema for constrained decoding, and
+/// <c>GenericToolCallParser</c> correctly parses the bare-JSON output the constrained decoder emits.
+/// </summary>
+public sealed class RunToolChoiceTests
+{
+    private static readonly ToolDefinition WeatherTool =
+        new("get_weather", "Get current weather for a city",
+            """{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}""");
+
+    private static readonly ToolDefinition[] SingleTools = [WeatherTool];
+
+    private static readonly ToolDefinition[] MultiTools =
+    [
+        new("get_weather", "Weather",  "{\"type\":\"object\"}"),
+        new("search_web",  "Search",   "{\"type\":\"object\"}")
+    ];
+
+    [Fact]
+    public void BuildForRequired_SingleTool_ProducesNonEmptySchema()
+    {
+        string schema = ToolCallSchemaBuilder.BuildForRequired(SingleTools, "arguments");
+        Assert.NotEmpty(schema);
+        Assert.Contains("get_weather", schema);
+        Assert.Contains("arguments", schema);
+    }
+
+    [Fact]
+    public void BuildForRequired_MultiTool_ContainsAllNames()
+    {
+        string schema = ToolCallSchemaBuilder.BuildForRequired(MultiTools, "arguments");
+        Assert.Contains("get_weather", schema);
+        Assert.Contains("search_web", schema);
+    }
+
+    [Fact]
+    public void BuildForFunction_ProducesConstSchema()
+    {
+        string schema = ToolCallSchemaBuilder.BuildForFunction(WeatherTool, "arguments");
+        Assert.Contains("get_weather", schema);
+        // Single-function schema uses const for name
+        Assert.Contains("const", schema);
+    }
+
+    [Fact]
+    public void GenericToolCallParser_ParsesBareJson_WithArgumentsKey()
+    {
+        const string bareJson = """{"name":"get_weather","arguments":{"city":"Tokyo"}}""";
+        var parser = new GenericToolCallParser();
+
+        var calls = parser.TryParse(bareJson);
+
+        Assert.NotNull(calls);
+        Assert.Single(calls);
+        Assert.Equal("get_weather", calls![0].FunctionName);
+        Assert.Contains("Tokyo", calls[0].Arguments);
+    }
+
+    [Fact]
+    public void GenericToolCallParser_ParsesBareJson_WithParametersKey()
+    {
+        const string bareJson = """{"name":"search_web","parameters":{"query":"dotnet"}}""";
+        var parser = new GenericToolCallParser();
+
+        var calls = parser.TryParse(bareJson);
+
+        Assert.NotNull(calls);
+        Assert.Single(calls);
+        Assert.Equal("search_web", calls![0].FunctionName);
+        Assert.Contains("dotnet", calls[0].Arguments);
+    }
+}


### PR DESCRIPTION
Closes #103. Adds `--tool-choice <auto|none|required|fn>` to `run`, mirroring `chat`: required/function sets a `ResponseFormat.JsonSchema` from `ToolCallSchemaBuilder` (constrains output to a bare tool-call JSON object) and parses the result with `GenericToolCallParser` (bare JSON, no `<tool_call>` tags). Also makes `ChatCommand.ParseToolChoice` internal for reuse, and fixes a pre-existing bug where `run` accumulated generated text only in `--json` mode (tool-call detection saw empty text otherwise).

## Tests
- `RunToolChoiceTests` **5/5** (ToolCallSchemaBuilder.BuildForRequired single+multi, BuildForFunction const, GenericToolCallParser round-trips bare JSON with both `arguments` and `parameters` keys).
- `dotnet build src/DotLLM.Cli` clean.

## Honest runtime finding (motivates follow-ups)
Validated on the BitNet I2_S GGUF. The wiring works — `--tool-choice required` forced the correct skeleton (`{"name": "get_weather", "arguments":{` with the tool-use adapter). BUT two pre-existing engine limits block a fully-clean end-to-end demo:
- **#104** — dotLLM's JSON-schema constraint is an overapproximation: it doesn't strictly enforce the nested arguments object / required / additionalProperties / termination, so a degeneration-prone base leaks garbage inside `arguments`. Strict grammar enforcement would make constrained tool-calls fully valid even on weak bases (the real payoff).
- **#105** — Qwen GGUF embedded chat template fails the Jinja evaluator with `--tools` at serve time (couldn't validate the clean-base path via GGUF as a result).

This PR is the correct, tested wiring; the guaranteed-valid-JSON payoff depends on #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)