### PR TITLE
fix(chat-template): support Python step slices in Jinja — Qwen GGUF + tools (#105)

### DIFF
--- a/src/DotLLM.Tokenizers/ChatTemplates/JinjaAst.cs
+++ b/src/DotLLM.Tokenizers/ChatTemplates/JinjaAst.cs
@@ -60,7 +60,7 @@ internal sealed record ListExpr(IReadOnlyList<IExpression> Items) : IExpression;
 
 internal sealed record DictExpr(IReadOnlyList<(IExpression Key, IExpression Value)> Pairs) : IExpression;
 
-internal sealed record SliceExpr(IExpression Object, IExpression? Start, IExpression? Stop) : IExpression;
+internal sealed record SliceExpr(IExpression Object, IExpression? Start, IExpression? Stop, IExpression? Step = null) : IExpression;
 
 // ── Operators ──
 

--- a/src/DotLLM.Tokenizers/ChatTemplates/JinjaEvaluator.cs
+++ b/src/DotLLM.Tokenizers/ChatTemplates/JinjaEvaluator.cs
@@ -519,33 +519,61 @@ internal sealed class JinjaEvaluator
         var obj = EvalExpr(expr.Object);
         int? startVal = expr.Start != null ? ToInt(EvalExpr(expr.Start)) : null;
         int? stopVal = expr.Stop != null ? ToInt(EvalExpr(expr.Stop)) : null;
+        int? stepVal = expr.Step != null ? ToInt(EvalExpr(expr.Step)) : null;
 
         if (obj is string s)
         {
-            int from = startVal ?? 0;
-            int to = stopVal ?? s.Length;
-            if (from < 0) from = Math.Max(0, s.Length + from);
-            if (to < 0) to = Math.Max(0, s.Length + to);
-            to = Math.Min(to, s.Length);
-            from = Math.Min(from, to);
-            return s[from..to];
+            var sliced = SliceSequence(s.Length, startVal, stopVal, stepVal, i => s[i]);
+            var sb = new StringBuilder(sliced.Count);
+            foreach (var c in sliced) sb.Append((char)c!);
+            return sb.ToString();
         }
 
         if (obj is IList list)
-        {
-            int from = startVal ?? 0;
-            int to = stopVal ?? list.Count;
-            if (from < 0) from = Math.Max(0, list.Count + from);
-            if (to < 0) to = Math.Max(0, list.Count + to);
-            to = Math.Min(to, list.Count);
-            from = Math.Min(from, to);
-            var sliced = new List<object?>();
-            for (int i = from; i < to; i++)
-                sliced.Add(list[i]);
-            return sliced;
-        }
+            return SliceSequence(list.Count, startVal, stopVal, stepVal, i => list[i]);
 
         return Undefined;
+    }
+
+    /// <summary>
+    /// Applies Python slice semantics (including negative <paramref name="stepVal"/> for reversal,
+    /// e.g. <c>[::-1]</c>) over a sequence of <paramref name="length"/> items. Index normalization
+    /// follows CPython's <c>PySlice_AdjustIndices</c>.
+    /// </summary>
+    private static List<object?> SliceSequence(int length, int? startVal, int? stopVal, int? stepVal, Func<int, object?> get)
+    {
+        int step = stepVal ?? 1;
+        var result = new List<object?>();
+        if (step == 0) return result; // Python raises; we yield empty rather than throw mid-template.
+
+        int lower, upper;
+        if (step < 0) { lower = -1; upper = length - 1; }
+        else { lower = 0; upper = length; }
+
+        int start;
+        if (startVal is null) start = step < 0 ? upper : lower;
+        else
+        {
+            start = startVal.Value;
+            if (start < 0) start = Math.Max(start + length, lower);
+            else start = Math.Min(start, upper);
+        }
+
+        int stop;
+        if (stopVal is null) stop = step < 0 ? lower : upper;
+        else
+        {
+            stop = stopVal.Value;
+            if (stop < 0) stop = Math.Max(stop + length, lower);
+            else stop = Math.Min(stop, upper);
+        }
+
+        if (step > 0)
+            for (int i = start; i < stop; i += step) result.Add(get(i));
+        else
+            for (int i = start; i > stop; i += step) result.Add(get(i));
+
+        return result;
     }
 
     // ── Scope management ──

--- a/src/DotLLM.Tokenizers/ChatTemplates/JinjaParser.cs
+++ b/src/DotLLM.Tokenizers/ChatTemplates/JinjaParser.cs
@@ -413,33 +413,35 @@ internal sealed class JinjaParser
                 continue;
             }
 
-            // Index/bracket access: [expr] or slice: [start:stop]
+            // Index/bracket access: [expr] or slice: [start:stop:step] (any part optional)
             if (CurrentIs(JinjaTokenType.LeftBracket))
             {
                 Advance();
 
                 IExpression? start = null;
                 IExpression? stop = null;
+                IExpression? step = null;
                 bool isSlice = false;
+
+                // start (absent for [:stop] / [::step] / [:])
+                if (!CurrentIs(JinjaTokenType.Colon))
+                    start = ParseExpression();
 
                 if (CurrentIs(JinjaTokenType.Colon))
                 {
-                    // [:stop] or [:]
+                    // first ':' makes this a slice
                     isSlice = true;
                     Advance();
-                    if (!CurrentIs(JinjaTokenType.RightBracket))
+                    // stop (absent for [start:] / [start::step] / [:])
+                    if (!CurrentIs(JinjaTokenType.Colon) && !CurrentIs(JinjaTokenType.RightBracket))
                         stop = ParseExpression();
-                }
-                else
-                {
-                    start = ParseExpression();
+
                     if (CurrentIs(JinjaTokenType.Colon))
                     {
-                        // [start:stop] or [start:]
-                        isSlice = true;
+                        // second ':' introduces the optional step
                         Advance();
                         if (!CurrentIs(JinjaTokenType.RightBracket))
-                            stop = ParseExpression();
+                            step = ParseExpression();
                     }
                 }
 
@@ -447,7 +449,7 @@ internal sealed class JinjaParser
 
                 if (isSlice)
                 {
-                    expr = new SliceExpr(expr, start, stop);
+                    expr = new SliceExpr(expr, start, stop, step);
                 }
                 else
                 {

--- a/tests/DotLLM.Tests.Unit/Tokenizers/ChatTemplates/JinjaEvaluatorTests.cs
+++ b/tests/DotLLM.Tests.Unit/Tokenizers/ChatTemplates/JinjaEvaluatorTests.cs
@@ -59,6 +59,62 @@ public class JinjaEvaluatorTests
         Assert.Equal("False", Eval("{{ false }}"));
     }
 
+    // ── Slicing with step (#105: Qwen GGUF template uses messages[::-1]) ──
+
+    [Fact]
+    public void Slice_String_Reverse()
+    {
+        Assert.Equal("dcba", Eval("{{ 'abcd'[::-1] }}"));
+    }
+
+    [Fact]
+    public void Slice_String_PositiveStep()
+    {
+        Assert.Equal("ace", Eval("{{ 'abcdef'[::2] }}"));
+    }
+
+    [Fact]
+    public void Slice_String_StartStopStep()
+    {
+        Assert.Equal("bd", Eval("{{ 'abcdef'[1:5:2] }}"));
+    }
+
+    [Fact]
+    public void Slice_String_StartStop_NoStep_StillWorks()
+    {
+        Assert.Equal("bc", Eval("{{ 'abcd'[1:3] }}"));
+    }
+
+    [Fact]
+    public void Slice_List_Reverse_InForLoop()
+    {
+        var vars = new Dictionary<string, object?> { ["xs"] = new List<object?> { 1, 2, 3 } };
+        Assert.Equal("321", Eval("{% for x in xs[::-1] %}{{ x }}{% endfor %}", vars));
+    }
+
+    [Fact]
+    public void Slice_List_NegativeStep_StartStop()
+    {
+        // Python: [10,20,30,40,50][4:1:-1] == [50,40,30]
+        var vars = new Dictionary<string, object?> { ["xs"] = new List<object?> { 10, 20, 30, 40, 50 } };
+        Assert.Equal("50,40,30,", Eval("{% for x in xs[4:1:-1] %}{{ x }},{% endfor %}", vars));
+    }
+
+    [Fact]
+    public void Slice_QwenTemplate_ReversedMessagesLoop()
+    {
+        // The exact construct from the Qwen3 GGUF embedded template (#105 line 18).
+        var vars = new Dictionary<string, object?>
+        {
+            ["messages"] = new List<object?>
+            {
+                new Dictionary<string, object?> { ["role"] = "system", ["content"] = "s" },
+                new Dictionary<string, object?> { ["role"] = "user", ["content"] = "u" },
+            }
+        };
+        Assert.Equal("us", Eval("{%- for m in messages[::-1] %}{{- m.content }}{%- endfor %}", vars));
+    }
+
     // ── String concatenation ──
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes serve-time failure of the **Qwen3-4B-Instruct-2507 GGUF embedded chat template** with `--tools`. Closes #105.

`run <Qwen3-4B Q4_K_M gguf> --tools @tools.json` errored:
```
Line 18, Col 30: Expected expression, got Colon
```
Line 18 of the GGUF-embedded template is `{%- for message in messages[::-1] %}` — a Python **step-slice** (reverse). dotLLM's Jinja parser supported 2-part slices (`[:n]`, `[a:b]`) but not the step component, so it failed at the second `:`. (The U0 parity test `QwenToolFormatVerificationTests` passed only because it uses the **HF tokenizer** template, not the GGUF-embedded one — which is what's used at serve time.)

## Fix (general — benefits any template using step slices)
- **`JinjaAst`** — `SliceExpr` gains an optional `Step`.
- **`JinjaParser`** — parses the optional third slice component: `[start:stop:step]` and all subsets (`[::-1]`, `[::2]`, `[a::c]`, `[:b:c]`, …).
- **`JinjaEvaluator`** — applies Python slice semantics including negative step / reversal, via CPython's `PySlice_AdjustIndices` index normalization, for both strings and lists.

## Verification
- 7 new `JinjaEvaluatorTests` covering string/list step slices, negative-step reversal, start:stop:step, and the **exact** `messages[::-1]` construct; the existing 2-part slice still works. **140 ChatTemplates tests green**, source builds 0 warnings.
- Rendered the **full real Qwen3 GGUF embedded template** (4051 chars) end-to-end with a tool definition — it now renders the `<tools>` block and tool-call instructions with no error, confirming the step-slice was the only unsupported construct blocking the Qwen GGUF + tools path (every other construct — `namespace`, `is string`, `not(...)`, `.startswith/.endswith`, `|tojson`, `loop.*` — already worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
