### PR TITLE
feat(lora): U2 Phase C quantitative eval harness + results (#97)

### DIFF
--- a/scripts/lora/EVAL.md
+++ b/scripts/lora/EVAL.md
@@ -39,7 +39,46 @@ Multi-`--lora` parsing verified (a bad extra `--lora path` errors "PEFT adapter 
 ## Conclusions
 1. **End-to-end train→serve→stack works with real adapters.** All 3 adapters serve swappably and compose.
 2. **Stacking retains capabilities** (coding + tool-use both intact under the 3-way stack) — the core promise of additive composition.
-3. The coding adapter is the clearest single-adapter win; instruction/tool-use gains are masked by Qwen3-Instruct-2507 already being strong there. **Follow-up for a sharper demo:** harder/held-out probes or a weaker base (e.g. BitNet, U5) where the base fails and the adapter clearly rescues; and the quantitative eval harness (tool-call accuracy, coding pass@1, instruction LLM-judge) per the U2 plan Phase C.
+3. The coding adapter is the clearest single-adapter *style* shift; instruction/tool-use gains are masked by Qwen3-Instruct-2507 already being strong there. Quantified in Phase C below.
+
+---
+
+# Phase C — Quantitative eval (base vs +adapter)
+
+**Date:** 2026-06-28 · same RTX 3060 + Q4_K_M base. Automated harness (`scripts/lora/eval_*.py`): prompts rendered with `apply_chat_template` (train==serve form), served greedy via `dotnet run -- run --json [--lora]`, scored programmatically. Held-out tool-use rows are disjoint from the `train[:3000]` training slice.
+
+## Tool-use — held-out `glaive_func_calling` (n=20), tool-name + arg-JSON match
+| metric | base | +tooluse adapter |
+|---|---:|---:|
+| `<tool_call>` emitted | 100% | 100% |
+| function name correct | 100% | 100% |
+| arguments JSON-equal | **90%** | 85% |
+
+The base is already at ceiling on name selection; the adapter is neutral-to-slightly-lower on argument exactness. No gain on this strong base (consistent with the qualitative finding).
+
+## Coding — 15 self-contained problems, pass@1 (sandboxed execution)
+| | base | +coding adapter |
+|---|---:|---:|
+| pass@1 | **15/15 (100%)** | **15/15 (100%)** |
+
+Both solve every problem — the base is strong enough that these problems don't discriminate. The adapter's effect is **stylistic** (terse, no markdown fence) rather than correctness, so it doesn't move pass@1. (Harder/held-out problems would be needed to separate them.)
+
+## Instruction — 12 fixed probes, pairwise judge (base vs +instruction adapter)
+| outcome | count |
+|---|---:|
+| base preferred | 10 |
+| adapter preferred | 1 |
+| tie | 1 |
+
+The `no_robots` adapter yields a **plainer** style but **slightly degrades constraint-following**: it broke explicit length/format constraints on 4 probes (haiku form; "in one sentence"; "one-line"; "in two sentences") where the base obeyed them. Net: ~83% base win-rate.
+
+## Phase C verdict
+**On the already-strong Qwen3-4B-Instruct-2507 base, none of the three adapters beats the base on its own task quantitatively** — tool-use neutral, coding tied at ceiling, instruction slightly worse. The adapters deliver **stylistic** shifts (terse code, plainer prose), not capability gains, and the instruction adapter can hurt constraint adherence. This is the expected outcome for LoRA on a strong instruct base, and it sharpens the motivation for the **weaker-base demo (BitNet, U5)** where the base fails and an adapter can clearly rescue. The headline that *does* hold here is U3: **3-way stacking preserves each capability with no regression** (cosine 0.999029 CPU==GPU).
 
 ## Reproduce
-`scripts/lora/train_task_lora.py` (train, see `.docs/train_all.sh`), then serve/stack via `dotnet run --project src/DotLLM.Cli -c Release -- run <qwen-q4_k_m.gguf> --device gpu --prompt <rendered> --lora <dir> [--lora <dir> ...]` (prompts rendered with `tokenizer.apply_chat_template`, per `FORMAT.md`).
+- Train: `scripts/lora/train_task_lora.py` (see `.docs/train_all.sh`).
+- Serve/stack: `dotnet run --project src/DotLLM.Cli -c Release -- run <qwen-q4_k_m.gguf> --device gpu --prompt <rendered> --lora <dir> [--lora <dir> ...]` (prompts via `tokenizer.apply_chat_template`, per `FORMAT.md`).
+- Quantitative eval (Phase C): `dotnet build src/DotLLM.Cli -c Release` once, then
+  `python scripts/lora/eval_tooluse.py --gguf <gguf> --lora <tooluse_dir> --n 20`,
+  `python scripts/lora/eval_coding.py --gguf <gguf> --lora <coding_dir>`,
+  `python scripts/lora/eval_instruction.py --gguf <gguf> --lora <instruction_dir>` (env `PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface`).

--- a/scripts/lora/eval_coding.py
+++ b/scripts/lora/eval_coding.py
@@ -1,0 +1,121 @@
+"""Coding eval (pass@1) for the task-LoRA harness (U2 Phase C, Task 9).
+
+A fixed set of self-contained Python problems, each with a function signature the
+model must implement and a set of asserts. The model output is served base vs +lora,
+the code block is extracted (handles both markdown-fenced and terse/no-fence styles),
+written to a temp file with the asserts, and executed in a subprocess with a timeout.
+pass@1 = the asserts pass and the process exits 0.
+
+Usage:
+  PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface python eval_coding.py \
+     --gguf <q4_k_m.gguf> --lora <coding_adapter_dir> [--max-tokens 320]
+"""
+from __future__ import annotations
+import argparse, json, os, re, subprocess, sys, tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import eval_serve
+from transformers import AutoTokenizer
+
+# (name, instruction, test-asserts). Instructions name the exact signature the test calls.
+PROBLEMS = [
+    ("is_prime", "Write a Python function `is_prime(n)` that returns True if the integer n is prime, else False.",
+     "assert is_prime(2) and is_prime(13) and not is_prime(1) and not is_prime(15) and not is_prime(0)"),
+    ("factorial", "Write a Python function `factorial(n)` returning n! (factorial). factorial(0) == 1.",
+     "assert factorial(0)==1 and factorial(5)==120 and factorial(1)==1"),
+    ("fib", "Write a Python function `fib(n)` returning the n-th Fibonacci number (0-indexed, fib(0)=0, fib(1)=1).",
+     "assert fib(0)==0 and fib(1)==1 and fib(10)==55"),
+    ("reverse_string", "Write a Python function `reverse_string(s)` that returns the string s reversed.",
+     "assert reverse_string('abc')=='cba' and reverse_string('')==''"),
+    ("is_palindrome", "Write a Python function `is_palindrome(s)` returning True if s reads the same forwards and backwards.",
+     "assert is_palindrome('racecar') and is_palindrome('') and not is_palindrome('abc')"),
+    ("gcd", "Write a Python function `gcd(a, b)` returning the greatest common divisor of a and b.",
+     "assert gcd(12,8)==4 and gcd(17,5)==1 and gcd(100,10)==10"),
+    ("sum_list", "Write a Python function `sum_list(xs)` returning the sum of a list of numbers (empty list -> 0).",
+     "assert sum_list([1,2,3])==6 and sum_list([])==0 and sum_list([-1,1])==0"),
+    ("count_vowels", "Write a Python function `count_vowels(s)` returning the number of vowels (aeiou, case-insensitive) in s.",
+     "assert count_vowels('Hello')==2 and count_vowels('xyz')==0 and count_vowels('AEIOU')==5"),
+    ("fizzbuzz", "Write a Python function `fizzbuzz(n)` that returns 'Fizz' if n divisible by 3, 'Buzz' if by 5, 'FizzBuzz' if both, else str(n).",
+     "assert fizzbuzz(3)=='Fizz' and fizzbuzz(5)=='Buzz' and fizzbuzz(15)=='FizzBuzz' and fizzbuzz(7)=='7'"),
+    ("max_of_list", "Write a Python function `max_of_list(xs)` returning the maximum value in a non-empty list.",
+     "assert max_of_list([1,5,3])==5 and max_of_list([-2,-9])==-2"),
+    ("celsius_to_fahrenheit", "Write a Python function `celsius_to_fahrenheit(c)` converting Celsius to Fahrenheit.",
+     "assert celsius_to_fahrenheit(0)==32 and celsius_to_fahrenheit(100)==212"),
+    ("find_duplicates", "Write a Python function `find_duplicates(xs)` returning a sorted list of values that appear more than once in xs.",
+     "assert find_duplicates([1,2,2,3,3,3])==[2,3] and find_duplicates([1,2,3])==[]"),
+    ("flatten", "Write a Python function `flatten(xss)` that flattens a list of lists into a single list, preserving order.",
+     "assert flatten([[1,2],[3],[4,5]])==[1,2,3,4,5] and flatten([])==[]"),
+    ("binary_search", "Write a Python function `binary_search(xs, target)` returning the index of target in the sorted list xs, or -1 if absent.",
+     "assert binary_search([1,3,5,7,9],5)==2 and binary_search([1,3,5],4)==-1 and binary_search([],1)==-1"),
+    ("title_case", "Write a Python function `title_case(s)` returning s with the first letter of each word capitalized.",
+     "assert title_case('hello world')=='Hello World' and title_case('a b')=='A B'"),
+]
+
+
+def extract_code(text: str) -> str:
+    """Pull runnable Python from a model response: prefer a fenced block, else from the
+    first def/import/class onward (the terse CodeAlpaca-style adapter emits no fence)."""
+    fences = re.findall(r"```(?:python|py)?\s*(.*?)```", text, re.DOTALL)
+    if fences:
+        # Use the longest fenced block (most likely the implementation).
+        return max(fences, key=len).strip()
+    m = re.search(r"(?:^|\n)\s*(?:def |import |from |class )", text)
+    if m:
+        return text[m.start():].strip()
+    return text.strip()
+
+
+def run_passes(code: str, test: str, timeout: int = 8) -> bool:
+    src = code + "\n\n" + test + "\nprint('PASS')\n"
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as f:
+        f.write(src)
+        path = f.name
+    try:
+        p = subprocess.run([sys.executable, path], capture_output=True, text=True,
+                           encoding="utf-8", errors="replace", timeout=timeout)
+        return p.returncode == 0 and "PASS" in p.stdout
+    except subprocess.TimeoutExpired:
+        return False
+    finally:
+        try: os.unlink(path)
+        except OSError: pass
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gguf", required=True)
+    ap.add_argument("--lora", required=True, help="coding adapter dir")
+    ap.add_argument("--max-tokens", type=int, default=320)
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parents[2] / ".docs" / "eval" / "coding.json"))
+    args = ap.parse_args()
+
+    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")
+    agg = {"base": 0, "adapter": 0}
+    per = []
+    for name, instruction, test in PROBLEMS:
+        prompt = tok.apply_chat_template(
+            [{"role": "user", "content": instruction + " Output only the function."}],
+            add_generation_prompt=True, tokenize=False)
+        rec = {"name": name}
+        for cfg, lora in (("base", None), ("adapter", args.lora)):
+            text = eval_serve.generate_text(args.gguf, prompt, lora=lora, max_tokens=args.max_tokens)
+            ok = run_passes(extract_code(text), test)
+            agg[cfg] += int(ok)
+            rec[cfg] = {"pass": ok}
+        per.append(rec)
+        print(f"  {name:<22} base={'P' if rec['base']['pass'] else '.'} adapter={'P' if rec['adapter']['pass'] else '.'}", flush=True)
+
+    n = len(PROBLEMS)
+    summary = {cfg: {"pass1_pct": round(100 * agg[cfg] / n, 1), "passed": agg[cfg], "n": n} for cfg in agg}
+    out = {"n": n, "summary": summary, "per_problem": per}
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"\n=== CODING pass@1 (n={n}) ===")
+    print(f"base   : {summary['base']['passed']}/{n} = {summary['base']['pass1_pct']}%")
+    print(f"adapter: {summary['adapter']['passed']}/{n} = {summary['adapter']['pass1_pct']}%")
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lora/eval_instruction.py
+++ b/scripts/lora/eval_instruction.py
@@ -1,0 +1,61 @@
+"""Instruction eval for the task-LoRA harness (U2 Phase C, Task 10).
+
+Serves base vs +lora on a fixed set of instruction-following probes and records the
+output pairs for pairwise judging (base vs adapter). The judge is run out-of-band by
+the harness operator (an LLM judge / Claude in this environment), per the U2 plan —
+this script produces the reproducible (probe, base, adapter) pairs and a JSON file.
+
+Usage:
+  PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface python eval_instruction.py \
+     --gguf <q4_k_m.gguf> --lora <instruction_adapter_dir> [--max-tokens 140]
+"""
+from __future__ import annotations
+import argparse, json, os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import eval_serve
+from transformers import AutoTokenizer
+
+PROBES = [
+    "Explain what a hash map is in two sentences.",
+    "Write a haiku about autumn leaves.",
+    "List three practical tips for staying focused while working from home.",
+    "Rewrite this sentence in a formal tone: 'hey can u send me that file asap'.",
+    "Summarize the water cycle in one sentence.",
+    "Give me a short, friendly reply declining a meeting invitation.",
+    "What are two pros and two cons of remote work? Be concise.",
+    "Convert this to a polite request: 'give me the report now'.",
+    "Explain the difference between weather and climate in two sentences.",
+    "Write a one-line motivational message for someone starting a new job.",
+    "Describe the taste of coffee to someone who has never had it, in two sentences.",
+    "Give three bullet points on how to reduce household energy use.",
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gguf", required=True)
+    ap.add_argument("--lora", required=True, help="instruction adapter dir")
+    ap.add_argument("--max-tokens", type=int, default=140)
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parents[2] / ".docs" / "eval" / "instruction.json"))
+    args = ap.parse_args()
+
+    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")
+    pairs = []
+    for i, probe in enumerate(PROBES):
+        prompt = tok.apply_chat_template(
+            [{"role": "user", "content": probe}], add_generation_prompt=True, tokenize=False)
+        base = eval_serve.generate_text(args.gguf, prompt, lora=None, max_tokens=args.max_tokens)
+        adapt = eval_serve.generate_text(args.gguf, prompt, lora=args.lora, max_tokens=args.max_tokens)
+        pairs.append({"i": i, "probe": probe, "base": base.strip(), "adapter": adapt.strip()})
+        print(f"  [{i+1}/{len(PROBES)}] {probe[:50]}", flush=True)
+
+    out = {"n": len(PROBES), "pairs": pairs}
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"\nwrote {args.out} ({len(PROBES)} probe pairs for pairwise judging)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lora/eval_serve.py
+++ b/scripts/lora/eval_serve.py
@@ -1,0 +1,90 @@
+"""dotLLM serving shim for the task-LoRA eval harness (U2 Phase C, Task 7).
+
+Shells out to the dotLLM `run` CLI in `--json` mode and returns the generated text.
+Prompts are pre-rendered with `tokenizer.apply_chat_template` (the U0-verified
+train==serve form) and passed RAW: `run` only applies its own chat template when
+`--tools` is given, so a pre-rendered prompt with no `--tools` is used verbatim.
+
+Build the Release CLI once before looping:
+    dotnet build src/DotLLM.Cli -c Release
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root = three levels up from this file (scripts/lora/eval_serve.py).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_PROJECT = REPO_ROOT / "src" / "DotLLM.Cli"
+
+
+def generate(
+    model_gguf: str,
+    prompt: str,
+    lora: list[str] | str | None = None,
+    device: str = "gpu",
+    max_tokens: int = 128,
+    temp: float = 0.0,
+    repeat_penalty: float | None = None,
+    seed: int | None = None,
+    timeout: int = 300,
+) -> dict:
+    """Run one generation and return the parsed `RunJsonResult` dict.
+
+    `lora` may be a single adapter dir, a list of dirs (stacked), or None (base).
+    Returns the full JSON object; callers usually want `result["text"]`.
+    """
+    loras = [] if lora is None else ([lora] if isinstance(lora, str) else list(lora))
+
+    cmd = [
+        "dotnet", "run", "--project", str(CLI_PROJECT), "-c", "Release",
+        "--",
+        "run", model_gguf,
+        "--prompt", prompt,
+        "--max-tokens", str(max_tokens),
+        "--temp", str(temp),
+        "--device", device,
+        "--json",
+    ]
+    for d in loras:
+        cmd += ["--lora", d]
+    if repeat_penalty is not None:
+        cmd += ["--repeat-penalty", str(repeat_penalty)]
+    if seed is not None:
+        cmd += ["--seed", str(seed)]
+
+    proc = subprocess.run(
+        cmd, cwd=str(REPO_ROOT), capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"dotLLM run failed (exit {proc.returncode}).\n"
+            f"CMD: {' '.join(cmd)}\nSTDERR:\n{proc.stderr[-2000:]}\nSTDOUT:\n{proc.stdout[-2000:]}"
+        )
+
+    # `--json` prints a single JSON object. `dotnet run` may emit build chatter on the
+    # first invocation; isolate the JSON object (first '{' to last '}').
+    out = proc.stdout
+    start, end = out.find("{"), out.rfind("}")
+    if start < 0 or end < 0:
+        raise RuntimeError(f"No JSON object in CLI output:\n{out[-2000:]}")
+    return json.loads(out[start:end + 1])
+
+
+def generate_text(model_gguf: str, prompt: str, **kw) -> str:
+    return generate(model_gguf, prompt, **kw)["text"]
+
+
+if __name__ == "__main__":
+    # Smoke test: base generation returns non-empty text. Usage: eval_serve.py <gguf> [lora_dir]
+    gguf = sys.argv[1]
+    lora = sys.argv[2] if len(sys.argv) > 2 else None
+    res = generate(gguf, "Write one short sentence about Tokyo.", lora=lora, max_tokens=40)
+    print("FINISH:", res.get("finishReason"))
+    print("TIMINGS_ms:", res.get("timings"))
+    print("TEXT:", repr(res.get("text"))[:500])
+    assert res.get("text"), "expected non-empty generated text"
+    print("OK")

--- a/scripts/lora/eval_tooluse.py
+++ b/scripts/lora/eval_tooluse.py
@@ -1,0 +1,146 @@
+"""Tool-use eval for the task-LoRA harness (U2 Phase C, Task 8).
+
+Held-out glaive_func_calling rows (disjoint from the train[:3000] used for training),
+rendered with the canonical tooluse_render path (template-generated <tools> block),
+served base vs +lora, scoring per example:
+  (a) a <tool_call> with parseable JSON was emitted,
+  (b) the function name matches the gold call,
+  (c) the arguments JSON is equal to the gold arguments.
+
+Reports base-vs-adapted accuracy. Writes results JSON + a markdown fragment.
+
+Usage:
+  PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface python eval_tooluse.py \
+     --gguf <q4_k_m.gguf> --lora <tooluse_adapter_dir> [--n 20] [--start 3000]
+"""
+from __future__ import annotations
+import argparse, json, os, re, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tooluse_render import extract_tools, _SHAREGPT_ROLE, _strip_tools_block
+import eval_serve
+
+TOOLCALL_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+
+
+def parse_tool_call(text: str):
+    """Return (name, args_dict) from the first parseable <tool_call> JSON, or None."""
+    m = TOOLCALL_RE.search(text)
+    if not m:
+        # Some outputs may emit a bare JSON object without tags; try that too.
+        m2 = re.search(r"\{[^{}]*\"name\"\s*:.*?\}", text, re.DOTALL)
+        if not m2:
+            return None
+        blob = m2.group(0)
+    else:
+        blob = m.group(1)
+    try:
+        obj = json.loads(blob)
+    except json.JSONDecodeError:
+        return None
+    name = obj.get("name")
+    args = obj.get("arguments", obj.get("parameters"))
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except json.JSONDecodeError:
+            pass
+    return (name, args)
+
+
+def build_prompt_and_gold(tok, row):
+    """Render the eval prompt (system+user+tools, add_generation_prompt) and the gold call."""
+    tools = extract_tools(row)
+    conv = row["conversations"]
+    target = None
+    for i, turn in enumerate(conv):
+        if turn["from"] == "gpt":
+            c = turn.get("value", turn.get("content", ""))
+            if c.lstrip().startswith("<tool_call>"):
+                target = i
+                break
+    if target is None:
+        return None
+    prompt_msgs = []
+    for turn in conv[:target]:
+        role = _SHAREGPT_ROLE.get(turn["from"], turn["from"])
+        content = turn.get("value", turn.get("content", ""))
+        if role == "system":
+            content = _strip_tools_block(content)
+        prompt_msgs.append({"role": role, "content": content})
+    prompt = tok.apply_chat_template(prompt_msgs, tools=tools, add_generation_prompt=True, tokenize=False)
+    gold = parse_tool_call(conv[target].get("value", conv[target].get("content", "")))
+    if gold is None or gold[0] is None:
+        return None
+    return prompt, gold
+
+
+def score(gguf, prompt, lora, **kw):
+    text = eval_serve.generate_text(gguf, prompt, lora=lora, **kw)
+    call = parse_tool_call(text)
+    return text, call
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gguf", required=True)
+    ap.add_argument("--lora", required=True, help="tool-use adapter dir")
+    ap.add_argument("--n", type=int, default=20)
+    ap.add_argument("--start", type=int, default=3000, help="held-out slice start (train[:3000] was used for training)")
+    ap.add_argument("--max-tokens", type=int, default=160)
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parents[2] / ".docs" / "eval" / "tooluse.json"))
+    args = ap.parse_args()
+
+    from transformers import AutoTokenizer
+    import datasets
+    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")
+
+    # Pull a generous slice and keep the first N renderable rows.
+    ds = datasets.load_dataset("NousResearch/hermes-function-calling-v1", "glaive_func_calling",
+                               split=f"train[{args.start}:{args.start + args.n * 3}]")
+    examples = []
+    for row in ds:
+        try:
+            pg = build_prompt_and_gold(tok, row)
+        except Exception:
+            pg = None
+        if pg is not None:
+            examples.append(pg)
+        if len(examples) >= args.n:
+            break
+
+    print(f"[tooluse] evaluating {len(examples)} held-out examples (start={args.start})", flush=True)
+
+    agg = {"base": {"emitted": 0, "name": 0, "args": 0}, "adapter": {"emitted": 0, "name": 0, "args": 0}}
+    per = []
+    for i, (prompt, (gname, gargs)) in enumerate(examples):
+        rec = {"i": i, "gold_name": gname, "gold_args": gargs}
+        for cfg, lora in (("base", None), ("adapter", args.lora)):
+            _, call = score(args.gguf, prompt, lora, max_tokens=args.max_tokens)
+            emitted = call is not None and call[0] is not None
+            name_ok = emitted and call[0] == gname
+            args_ok = name_ok and call[1] == gargs
+            if emitted: agg[cfg]["emitted"] += 1
+            if name_ok: agg[cfg]["name"] += 1
+            if args_ok: agg[cfg]["args"] += 1
+            rec[cfg] = {"name": call[0] if call else None, "args": call[1] if call else None,
+                        "emitted": emitted, "name_ok": name_ok, "args_ok": args_ok}
+        per.append(rec)
+        print(f"  [{i+1}/{len(examples)}] gold={gname} base={rec['base']['name']} adapter={rec['adapter']['name']}", flush=True)
+
+    n = len(examples)
+    summary = {cfg: {k: round(100 * v / n, 1) for k, v in agg[cfg].items()} for cfg in agg}
+    out = {"n": n, "start": args.start, "summary_pct": summary, "per_example": per}
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out, indent=2), encoding="utf-8")
+
+    print("\n=== TOOL-USE RESULTS (n=%d) ===" % n)
+    print(f"{'metric':<14}{'base %':>10}{'adapter %':>12}")
+    for k in ("emitted", "name", "args"):
+        print(f"{k:<14}{summary['base'][k]:>10}{summary['adapter'][k]:>12}")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Completes **U2 Phase C** — the quantitative task-LoRA eval harness — and records base-vs-adapter results in `scripts/lora/EVAL.md`. Closes #97.

Phase A (template-rendered tool-use) and Phase B (3 trained Qwen adapters) already landed; the prior EVAL.md had only qualitative results and explicitly deferred the quantitative harness. This adds it.

## Harness (scripts/lora/)
- `eval_serve.py` — shim over `dotnet run -- run --json [--lora]`; prompts pre-rendered with `apply_chat_template` (train==serve form) and passed raw (`run` only templates when `--tools` is given). Warm model loads ~3s, so CLI-per-call is practical.
- `eval_tooluse.py` — held-out `glaive_func_calling` rows **disjoint from the `train[:3000]` training slice**; scores `<tool_call>` emitted / function-name correct / arguments-JSON match.
- `eval_coding.py` — 15 self-contained problems, pass@1 via sandboxed subprocess execution; extracts both markdown-fenced (base) and terse/no-fence (adapter) code.
- `eval_instruction.py` — fixed probes; emits base/adapter output pairs for pairwise judging.

## Results (Qwen3-4B-Instruct-2507, greedy, GPU)
| task | metric | base | +adapter |
|---|---|---:|---:|
| tool-use (n=20) | name / args | 100% / 90% | 100% / 85% |
| coding (n=15) | pass@1 | 100% | 100% |
| instruction (n=12) | pairwise wins | 10 | 1 (1 tie) |

**Verdict:** on this already-strong instruct base, no adapter beats base on its task — adapters give **stylistic** shifts (terse code, plainer prose), not capability gains, and the instruction adapter slightly hurts constraint-following (it broke explicit "one sentence"/"one-line"/haiku-form constraints on 4 probes). This is the expected LoRA-on-strong-base outcome and motivates the weaker-base demo (BitNet, U5). The U3 result that holds: 3-way stacking preserves each capability with no regression.

No engine/source changes — Python eval scripts + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
