### PR TITLE
fix(constraints) + demo: constrained decoding rescues BitNet tool-calling (#112)

### DIFF
--- a/scripts/lora/EVAL_bitnet.md
+++ b/scripts/lora/EVAL_bitnet.md
@@ -40,14 +40,54 @@ This is a **base-model limitation, not a dotLLM/adapter/#100 defect** — the sa
 stackable results on Qwen3-4B (see `EVAL.md`). U5's value is validating the **pipeline + the BitNet tool template +
 stacking on the ternary base**, not matching Qwen quality.
 
-## Clear follow-up
-**Constrained decoding for tool-use.** dotLLM already has JSON-schema constrained decoding + `ToolCallSchemaBuilder`.
-Forcing the tool-call grammar would let even this weak base emit *valid* `<tool_call>` JSON (correctness guaranteed by the
-decoder, not the model) — the natural next demo and the right answer for small/quantised bases. (`--tool-choice required`
-wiring into `run` is the gap.)
+## Clear follow-up — ✅ DONE: constrained decoding rescues tool-calling
+The `--tool-choice required` gap named here was closed (#106 wiring + #104 strict order-independent
+constrained decoding), and a residual constraint bug found during this eval was fixed (#112): the tracker
+unconditionally allowed `\` inside a trie-constrained key/enum string, so the weak base could *escape-flood*
+(`{"name":"calculate_distance", "a\"\"\"…`) and break out of the constraint. With `\` routed through the
+trie like any other char, the constraint now strictly forces the tool-call skeleton **and** the argument keys.
+
+---
+
+# Phase C — Constrained-decoding rescue (quantitative)
+
+**Date:** 2026-06-28 · BitNet I2_S GGUF, GPU, greedy `--repeat-penalty 1.3 --repeat-last-n 256`. Held-out
+`glaive_func_calling` rows (n=10, disjoint from training), served via `run --tools @<row tools> [--tool-choice
+required] [--lora <tooluse>]` (`scripts/lora/eval_tooluse_bitnet.py`). Metrics: **name** = correct function name
+emitted (forced skeleton or parsed); **complete** = a fully-parseable tool-call JSON; **args** = complete AND
+arguments equal the gold call.
+
+| config | name | complete | args |
+|---|---:|---:|---:|
+| base, unconstrained | **0%** | 0% | 0% |
+| base, `--tool-choice required` | **70%** | 0% | 0% |
+| +tooluse adapter, unconstrained | 0% | 0% | 0% |
+| +tooluse adapter, `--tool-choice required` | **80%** | 0% | 0% |
+
+### Findings
+1. **The rescue is real.** Unconstrained, BitNet b1.58 2B emits a usable tool name **0%** of the time (it produces
+   free-text garbage). Under `--tool-choice required` the decoder *forces* the `{"name":"<tool>", "arguments":{…}}`
+   skeleton + the argument keys, yielding the **correct function name 70% (base) / 80% (+adapter)** of the time —
+   correctness supplied by the decoder, not the model.
+2. **The adapter improves tool *selection*** under the constraint (80% vs 70% name): the constraint guarantees a
+   *valid* tool name; the adapter nudges the model toward the *right* one (the <100% comes from multi-tool rows where
+   the model must still pick correctly).
+3. **`complete` = 0% (the honest remaining limit).** The constraint forces structure + keys, but the argument
+   *values* are free-form strings — and this capability-bound 2B base cannot reliably **terminate** a string value
+   (it rambles to the token cap). This is a base-capacity limit, **not** a constraint defect (cf. `EVAL.md`: the same
+   constraint yields fully-valid, terminating calls on Qwen3-4B). **Next constraint enhancement:** propagate JSON-Schema
+   `maxLength` (and enum/format) into `SchemaTracker` so string values are length-bounded — that would let even this base
+   emit a fully-terminating valid tool call.
+
+### Verdict
+Constrained decoding (#104/#106 + the #112 escape-flood fix) **rescues tool-call structure and function-name accuracy
+on a base that fails entirely unconstrained** — exactly the small/quantised-base payoff the constrained-decoding work was
+built for. Full argument-value correctness still needs either a stronger base or value-length bounding.
 
 ## Reproduce
 Train (per adapter): `train_task_lora.py --task <t> --no-4bit --grad-checkpoint --max-seq-len <N> [--chat-template
 scripts/lora/templates/bitnet_tooluse.jinja for tooluse] --base microsoft/bitnet-b1.58-2B-4T-bf16 …`.
 Serve/stack: `dotnet run --project src/DotLLM.Cli -c Release -- run <i2_s.gguf> --device gpu --repeat-penalty 1.3
 --repeat-last-n 256 [--prompt <rendered> | --tools @tools.json] [--lora <dir> …]`.
+Phase C eval: `dotnet build src/DotLLM.Cli -c Release` once, then `PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface python
+scripts/lora/eval_tooluse_bitnet.py --gguf <i2_s.gguf> --lora <bitnet tooluse dir> --n 10`.

--- a/scripts/lora/eval_serve.py
+++ b/scripts/lora/eval_serve.py
@@ -28,13 +28,21 @@ def generate(
     max_tokens: int = 128,
     temp: float = 0.0,
     repeat_penalty: float | None = None,
+    repeat_last_n: int | None = None,
     seed: int | None = None,
-    timeout: int = 300,
+    tools_file: str | None = None,
+    tool_choice: str | None = None,
+    timeout: int = 600,
 ) -> dict:
     """Run one generation and return the parsed `RunJsonResult` dict.
 
     `lora` may be a single adapter dir, a list of dirs (stacked), or None (base).
-    Returns the full JSON object; callers usually want `result["text"]`.
+    When `tools_file` is given, `--tools @<file>` is passed and `run` renders the
+    prompt via the model's chat template with those tools (so `prompt` should be the
+    raw user query, not a pre-rendered string); `tool_choice` (e.g. "required")
+    additionally constrains decoding to a valid tool call. Parsed calls are then in
+    the returned dict under `toolCalls`.
+    Returns the full JSON object; callers usually want `result["text"]` / `result["toolCalls"]`.
     """
     loras = [] if lora is None else ([lora] if isinstance(lora, str) else list(lora))
 
@@ -50,8 +58,14 @@ def generate(
     ]
     for d in loras:
         cmd += ["--lora", d]
+    if tools_file is not None:
+        cmd += ["--tools", f"@{tools_file}"]
+    if tool_choice is not None:
+        cmd += ["--tool-choice", tool_choice]
     if repeat_penalty is not None:
         cmd += ["--repeat-penalty", str(repeat_penalty)]
+    if repeat_last_n is not None:
+        cmd += ["--repeat-last-n", str(repeat_last_n)]
     if seed is not None:
         cmd += ["--seed", str(seed)]
 

--- a/scripts/lora/eval_tooluse_bitnet.py
+++ b/scripts/lora/eval_tooluse_bitnet.py
@@ -1,0 +1,156 @@
+"""BitNet tool-use eval — constrained-decoding rescue demo (U5 Phase C, issue #112).
+
+The capability-bound BitNet b1.58 2B base "cannot reliably emit valid <tool_call> JSON"
+(EVAL_bitnet.md). dotLLM constrained decoding (`--tool-choice required`, #106/#104)
+guarantees a valid tool call regardless of the base. This measures the 2x2:
+
+    base / +adapter   x   unconstrained / --tool-choice required
+
+on held-out glaive_func_calling rows, scoring: a valid tool call was produced,
+function-name correct, arguments JSON-equal to the gold call. The headline is that
+the *constrained* configs produce valid tool calls where the unconstrained ones fail.
+
+Each row's tools are passed via `--tools` (so dotLLM renders the BitNet tool template,
+#101, the same form the tool-use adapter was trained on) and the raw user query is the
+prompt. BitNet needs `--repeat-penalty 1.3 --repeat-last-n 256` for coherent decode.
+
+Usage:
+  PYTHONUTF8=1 HF_HOME=E:/.cache/huggingface python eval_tooluse_bitnet.py \
+     --gguf <i2_s.gguf> --lora <bitnet_tooluse_dir> [--n 10] [--start 3000]
+"""
+from __future__ import annotations
+import argparse, json, os, sys, tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import eval_serve
+from eval_tooluse import parse_tool_call  # gold/text tool-call parser
+
+
+def first_user_query(conv):
+    for turn in conv:
+        if turn["from"] in ("human", "user"):
+            return turn.get("value", turn.get("content", ""))
+    return None
+
+
+def gold_call(conv):
+    for turn in conv:
+        if turn["from"] == "gpt":
+            c = turn.get("value", turn.get("content", ""))
+            if c.lstrip().startswith("<tool_call>"):
+                return parse_tool_call(c)
+    return None
+
+
+import re as _re
+# The forced tool-call skeleton always starts `{"name": "<fn>"` even when the weak
+# base then rambles inside a free-form argument *value* and never terminates. This
+# captures the function name from that leading skeleton.
+_LEADING_NAME = _re.compile(r'^\s*\{\s*"name"\s*:\s*"([^"]+)"')
+
+
+def served(result):
+    """Return (got_name, full_call) where got_name is the forced/parsed function name
+    (or None) and full_call is a complete parsed (name, args) tuple (or None)."""
+    full = None
+    tcs = result.get("toolCalls") or []
+    if tcs:
+        tc = tcs[0]
+        name = tc.get("functionName") or tc.get("name")
+        args = tc.get("arguments")
+        if isinstance(args, str):
+            try: args = json.loads(args)
+            except json.JSONDecodeError: pass
+        if name:
+            full = (name, args)
+    text = result.get("text", "")
+    if full is None:
+        full = parse_tool_call(text)
+    got_name = full[0] if full else None
+    if got_name is None:  # incomplete (rambling value) — recover name from the forced skeleton
+        m = _LEADING_NAME.match(text)
+        if m:
+            got_name = m.group(1)
+    return got_name, full
+
+
+CONFIGS = [
+    ("base_unconstrained", {"lora": None, "tool_choice": None}),
+    ("base_constrained",   {"lora": None, "tool_choice": "required"}),
+    ("adapter_unconstrained", {"lora": "ADAPTER", "tool_choice": None}),
+    ("adapter_constrained",   {"lora": "ADAPTER", "tool_choice": "required"}),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gguf", required=True)
+    ap.add_argument("--lora", required=True, help="BitNet tool-use adapter dir")
+    ap.add_argument("--n", type=int, default=10)
+    ap.add_argument("--start", type=int, default=3000)
+    ap.add_argument("--max-tokens", type=int, default=96)
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parents[2] / ".docs" / "eval" / "tooluse_bitnet.json"))
+    args = ap.parse_args()
+
+    import datasets
+    ds = datasets.load_dataset("NousResearch/hermes-function-calling-v1", "glaive_func_calling",
+                               split=f"train[{args.start}:{args.start + args.n * 3}]")
+    examples = []
+    for row in ds:
+        conv = row.get("conversations") or []
+        q = first_user_query(conv)
+        g = gold_call(conv)
+        toolspec = row.get("tools")
+        if q and g and g[0] and toolspec:
+            examples.append((q, g, toolspec))
+        if len(examples) >= args.n:
+            break
+
+    print(f"[bitnet tooluse] {len(examples)} held-out examples (start={args.start})", flush=True)
+    # name = correct function name (forced skeleton or parsed); complete = full valid
+    # tool-call JSON parsed; args = complete AND arguments equal the gold call.
+    agg = {c: {"name": 0, "complete": 0, "args": 0} for c, _ in CONFIGS}
+    per = []
+    tmpdir = tempfile.mkdtemp()
+    for i, (query, (gname, gargs), toolspec) in enumerate(examples):
+        tools_path = os.path.join(tmpdir, f"tools_{i}.json")
+        Path(tools_path).write_text(toolspec if isinstance(toolspec, str) else json.dumps(toolspec), encoding="utf-8")
+        rec = {"i": i, "gold_name": gname, "query": query[:120]}
+        for cfg, opts in CONFIGS:
+            lora = args.lora if opts["lora"] == "ADAPTER" else None
+            got_name, full = None, None
+            try:
+                res = eval_serve.generate(
+                    args.gguf, query, lora=lora, tools_file=tools_path, tool_choice=opts["tool_choice"],
+                    device="gpu", max_tokens=args.max_tokens, repeat_penalty=1.3, repeat_last_n=256)
+                got_name, full = served(res)
+            except Exception as e:
+                rec.setdefault("errors", {})[cfg] = str(e)[:200]
+            name_ok = got_name == gname
+            complete = full is not None and full[0] is not None
+            args_ok = complete and full[0] == gname and full[1] == gargs
+            if name_ok: agg[cfg]["name"] += 1
+            if complete: agg[cfg]["complete"] += 1
+            if args_ok: agg[cfg]["args"] += 1
+            rec[cfg] = {"got_name": got_name, "name_ok": name_ok, "complete": complete, "args_ok": args_ok}
+        per.append(rec)
+        line = " ".join(f"{''.join(w[0] for w in c.split('_'))}={'N' if rec[c]['name_ok'] else '.'}" for c, _ in CONFIGS)
+        print(f"  [{i+1}/{len(examples)}] gold={gname:<22} {line}", flush=True)
+
+    n = len(examples)
+    summary = {c: {k: round(100 * agg[c][k] / n, 1) for k in agg[c]} for c, _ in CONFIGS}
+    out = {"n": n, "start": args.start, "summary_pct": summary, "per_example": per}
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out, indent=2), encoding="utf-8")
+
+    print(f"\n=== BITNET TOOL-USE (n={n}) — name / complete / args (%) ===")
+    print(f"{'config':<24}{'name':>8}{'complete':>10}{'args':>8}")
+    for c, _ in CONFIGS:
+        s = summary[c]
+        print(f"{c:<24}{s['name']:>8}{s['complete']:>10}{s['args']:>8}")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/DotLLM.Engine/Constraints/Schema/SchemaTracker.cs
+++ b/src/DotLLM.Engine/Constraints/Schema/SchemaTracker.cs
@@ -420,7 +420,10 @@ internal struct BranchState
 
     private readonly bool IsInStringCharAllowed(char c, in JsonCharParser parser)
     {
-        // Key string: restrict to trie
+        // Key string: restrict to trie. Note: '\' (escape) is NOT unconditionally
+        // allowed — it must be a valid trie edge like any other char. Property names
+        // contain no backslashes, so allowing '\' here let a weak model escape-flood
+        // ('"a\"\"\"...') and break out of the constraint (BitNet tool-call derail).
         if (_inKeyString)
         {
             if (c == '"')
@@ -428,12 +431,10 @@ internal struct BranchState
                 // Closing quote — property name must be complete (terminal)
                 return _schema.PropertyTries.Length > 0 && IsTrieTerminal();
             }
-            if (c == '\\')
-                return true; // escape sequences handled by parser
             return IsTrieCharValid(c);
         }
 
-        // Enum/const value string: restrict to enum trie
+        // Enum/const value string: restrict to enum trie (same escape-flood reasoning).
         if (_inEnumString)
         {
             if (c == '"')
@@ -441,8 +442,6 @@ internal struct BranchState
                 // Closing quote — value must be complete
                 return IsEnumTrieTerminal();
             }
-            if (c == '\\')
-                return true;
             return IsEnumTrieCharValid(c);
         }
 

--- a/tests/DotLLM.Tests.Unit/Engine/Constraints/JsonSchemaConstraintTests.cs
+++ b/tests/DotLLM.Tests.Unit/Engine/Constraints/JsonSchemaConstraintTests.cs
@@ -15,12 +15,13 @@ public class JsonSchemaConstraintTests
         // Token map: 0='{', 1='}', 2='"', 3=':', 4=',', 5='n', 6='a', 7='m', 8='e',
         // 9='g', 10='1', 11='[', 12=']', 13='t', 14='r', 15='u', 16='f', 17='l',
         // 18='s', 19=' ', 20=EOS, 21='"name"', 22='"age"', 23='-', 24='0',
-        // 25='.', 26='2', 27='d', 28='v', 29='c', 30='o', 31='i', 32='b', 33='p'
+        // 25='.', 26='2', 27='d', 28='v', 29='c', 30='o', 31='i', 32='b', 33='p',
+        // 34='\\' (backslash — for the escape-flood constraint test)
         private static readonly string[] Tokens =
             ["{", "}", "\"", ":", ",", "n", "a", "m", "e",
              "g", "1", "[", "]", "t", "r", "u", "f", "l",
              "s", " ", "<eos>", "\"name\"", "\"age\"", "-", "0",
-             ".", "2", "d", "v", "c", "o", "i", "b", "p"];
+             ".", "2", "d", "v", "c", "o", "i", "b", "p", "\\"];
 
         public int VocabSize => Tokens.Length;
         public int BosTokenId => 0;
@@ -55,6 +56,23 @@ public class JsonSchemaConstraintTests
 
         // EOS should not be allowed
         Assert.False(mask.IsAllowed(20), "EOS not allowed at start");
+    }
+
+    [Fact]
+    public void ConstrainedString_RejectsBackslashEscape_WhenTrieHasNoBackslash()
+    {
+        // A const value "name" — inside the constrained value string the only valid
+        // continuation after "na" is 'm'. A weak model must not be able to emit a '\'
+        // escape to break out of the trie (the escape-flood that derailed BitNet
+        // constrained tool calls). '\' is token 34; 'm' is token 7.
+        var constraint = CreateConstraint("""
+            { "type": "object", "properties": { "val": { "const": "name" } },
+              "required": ["val"], "additionalProperties": false }
+            """);
+        AdvanceString(constraint, "{\"val\":\"na");
+        var mask = constraint.GetAllowedTokens();
+        Assert.True(mask.IsAllowed(7), "'m' should be allowed to continue the const \"name\"");
+        Assert.False(mask.IsAllowed(34), "'\\\\' escape must NOT be allowed inside a trie-constrained value string");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Demonstrates — quantitatively — that dotLLM constrained decoding **rescues tool-calling on the capability-bound BitNet b1.58 2B base**, the explicit follow-up named in `EVAL_bitnet.md`. Also fixes a residual constraint-engine bug found along the way. Closes #112.

## Engine fix (hardens #104)
`SchemaTracker` allowed `\` unconditionally inside a *trie-constrained* key/enum/const string. Under `--tool-choice required` a weak base could exploit this to **escape-flood** — `{"name":"calculate_distance", "a\"\"\"\"…` — and break out of the constraint. Property names and tool-name consts contain no backslashes, so `\` must be a valid trie edge like any other char. Now routed through the trie check; free (unconstrained) string values are unaffected. New discriminating unit test; **65 constraint tests green**.

## Eval harness (extends #97)
- `eval_serve.py`: `--tools`/`--tool-choice`/`--repeat-last-n` support (reads CLI-parsed `toolCalls`).
- `eval_tooluse_bitnet.py`: 2×2 (base/+adapter × unconstrained/`--tool-choice required`) on held-out glaive rows; metrics name / complete / args.

## Result (n=10 held-out, BitNet I2_S, GPU)
| config | name | complete | args |
|---|---:|---:|---:|
| base, unconstrained | **0%** | 0% | 0% |
| base, `--tool-choice required` | **70%** | 0% | 0% |
| +adapter, `--tool-choice required` | **80%** | 0% | 0% |

**The rescue:** unconstrained BitNet emits a usable tool call 0% of the time; under constraint the decoder forces the `{"name":…,"arguments":{…}}` skeleton + arg keys, giving the correct function name 70% (base) / 80% (+adapter — the adapter improves tool *selection*). `complete`=0% because the 2B base can't *terminate* free-form string argument values in the token budget — a base-capacity limit, not a constraint defect (the same constraint yields fully-valid terminating calls on Qwen3-4B, see `EVAL.md`). **Named next enhancement:** propagate JSON-Schema `maxLength` into `SchemaTracker` to bound string values.

Engine fix is gated by a unit test; the eval scripts + docs are GPU-run artifacts (no CI dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
