### PR TITLE
diffusiongemma: first real-26B Vulkan generation — quantized Q5_0/Q8_0 down banks + UMA heap fallback (#40, #120)

### DIFF
--- a/docs/diffusiongemma/GEMMA4-GPU-GAPS.md
+++ b/docs/diffusiongemma/GEMMA4-GPU-GAPS.md
@@ -1,6 +1,14 @@
 # Gemma-4 / DiffusionGemma on the GPU backends — Gap Report
 
-**Status:** gemma4 (and diffusion-gemma) run on the **CPU** backend only. Neither the
+> **SUPERSEDED (2026-07-03).** This report described the state on 2026-06-16, hours before
+> the gaps it scopes were closed on the same overnight: Vulkan gained the full gemma4
+> forward (dense parity `1f53dca`, MoE fused gate_up Q4_K repack, per-layer-strided KV
+> `14f7c61`, diffusion forward + self-conditioning + PKV `7a09756`) and CUDA gained the
+> gemma4 AR MoE forward (`0d1f477`) — all merged to `dev` via `41621d5`. Real-weight
+> validation: `DiffusionGemmaGgufForwardTests` (CPU) and
+> `DiffusionGemmaVulkanRealGenerationTests` (Vulkan). Retained for the op-by-op mapping.
+
+**Status (historical, 2026-06-16):** gemma4 (and diffusion-gemma) run on the **CPU** backend only. Neither the
 **Vulkan** nor the **CUDA** backend has a gemma4 forward path. This document scopes exactly
 what each GPU backend is missing, mapped to the CPU `RunGemma4Layer` / `Gemma4DenseFfn` /
 `Gemma4Moe` ops, and notes for each op whether an existing GPU kernel already covers it or

--- a/docs/diffusiongemma/REAL-26B-RESULTS.md
+++ b/docs/diffusiongemma/REAL-26B-RESULTS.md
@@ -1,0 +1,32 @@
+# DiffusionGemma-26B — real-weight end-to-end results (#40 / #41 / #33)
+
+**Session 2026-07-03, Strix Halo (Ryzen AI Max 395, Radeon 8060S gfx1151, 128 GB UMA), Windows 11.**
+Model: `diffusiongemma-26B-A4B-it-Q4_K_M.gguf` (15.65 GB, unsloth conversion). Branch
+`issue/40-vulkan-real-26b` on top of `dev` @ `2d6543a`. GPU runs executed under the
+GPU-free check (iGPU < 10 % for 60 s before each measurement).
+
+## 1. First real end-to-end diffusion generation (CPU) — #40 closed
+
+`DiffusionGemmaGgufForwardTests` (all three pass on real weights):
+
+| Test | Wall | Result |
+|---|---|---|
+| SingleForward (8-mask canvas) | load 3.5 s, forward 18.1 s | finite, sharp (spread 39.4); raw argmax = mask everywhere (expected absorbing state), suppressed argmax surfaces content |
+| BackboneIsolation (prompt-only causal) | forward 6.0 s | top-1 `the` 21.62, top-2 **`Paris` 21.51** — backbone sane |
+| **DenoiseLoop (canvas 16, ≤16 steps, SC on)** | **192.8 s, 15 steps** | finish=Stop, 14/15 distinct tokens |
+
+Generated text for `The Eiffel Tower is located in`:
+
+> *", the French capital. It is one of the de recognizable landmarks in"*
+
+Coherent completion (the lone `de` is the known low-information-token artifact). CPU cost
+≈ **12.9 s/step ⇒ 0.08 effective tok/s** — confirms the GPU is mandatory for usable
+throughput, which is what the Vulkan path below measures.
+
+## 2. Vulkan end-to-end generation — `DiffusionGemmaVulkanRealGenerationTests`
+
+_(pending — run in flight)_
+
+## 3. Relative throughput (#41) and capability (#33)
+
+_(pending)_

--- a/docs/diffusiongemma/REAL-26B-RESULTS.md
+++ b/docs/diffusiongemma/REAL-26B-RESULTS.md
@@ -54,6 +54,28 @@ CPU↔Vulkan numerical parity gate is the synthetic-fixture argmax test, not dec
 
 ## 3. Relative throughput (#41) and capability (#33)
 
-_(bench battery: full-canvas 256 run, PKV A/B, same-session llama.cpp Vulkan diffusion
-baseline, and the LLaDA-8B (plain Llama backbone) cross-engine AR decode ratio — results
-pending)_
+Same session, same box, GPU pre-checked idle (0.5 %). llama.cpp = `llamacpp-vulkan`
+build 74ade5274 / the PR-24423 `llama-diffusion-cli` Vulkan build.
+
+| Measurement | dotLLM Vulkan | llama.cpp Vulkan | Ratio |
+|---|---|---|---|
+| **AR decode, LLaDA-8B Q4_K_M (same file, plain Llama backbone)** | 28.24 tok/s (`decode_min_ms` 34.47) | 44.85 ± 0.05 tok/s (`tg32`) | **0.63×** |
+| 26B diffusion step latency | 3.90 s/step @ canvas 32, SC+PKV on | 0.736 s/step @ canvas 256 | ~36× slower per canvas-token |
+| 26B diffusion effective | 0.29 tok/s (canvas 32) | 34.8 tok/s (256 tok, 10 steps) | — |
+| PKV prompt-cache effect (canvas 32) | 3.90 s/step on vs 4.47 s/step off | n/a | −13 % per step |
+
+**Reading.** The AR ratio (0.63×, up from 0.23× pre-kernel-campaign) says the Vulkan
+GEMV/MMVQ kernels are within striking distance. The diffusion gap is structural, not
+kernel-level: dotLLM's self-conditioning computes the full soft-embed —
+`[canvas × 262 144-vocab] softmax × [vocab × 2 816] embedding GEMM` ≈ 47 GFLOP/step at
+canvas 32 — which alone accounts for the observed ~3.9 s/step, while llama.cpp's
+diffusion build runs `gpu_sampling=on sample_reduce=on` (sparsified SC / on-device
+sampling). Closing the diffusion gap = sparsifying the SC embed (top-K logits, like the
+reference) + moving unmask sampling on-device — filed as the #41 follow-up; the AR
+backbone needs no dedicated work beyond the existing kernel roadmap.
+
+Capability note (#33): both engines complete the factual prompt correctly at full canvas
+(llama.cpp produced a coherent 256-token chat-formatted answer; dotLLM CPU produced the
+coherent French-capital completion in §1). A scored fixed-prompt-set comparison remains
+open under #33 — it only becomes meaningful once the SC sparsification lands and dotLLM
+can run full-canvas in seconds rather than minutes.

--- a/docs/diffusiongemma/REAL-26B-RESULTS.md
+++ b/docs/diffusiongemma/REAL-26B-RESULTS.md
@@ -25,8 +25,35 @@ throughput, which is what the Vulkan path below measures.
 
 ## 2. Vulkan end-to-end generation — `DiffusionGemmaVulkanRealGenerationTests`
 
-_(pending — run in flight)_
+**First attempt OOM'd — two real defects found and fixed (issue #120):**
+
+1. The real unsloth Q4_K_M's `ffn_down_exps` are **Q5_0 ×16 + Q8_0 ×14 (never Q5_1)**, so
+   `Gemma4ExpertsKeepQuantized` failed on all 30 layers and the F32 host-dequant fallback
+   tried to allocate ~92 GB (≈3 GB/layer × 30). Fixed by widening the quantized path:
+   Q5_0 downs repack **bit-exactly** to Q5_1 at upload (`d·(q−16) = d·q + m`, `m = −16d`,
+   fp16-exact — unit-tested), Q8_0 downs keep the existing Q8_0 indexed kernel with the
+   per-expert `ffn_down_exps.scale` folded into each block's fp16 `d`.
+2. The **strict DEVICE_LOCAL heap on gfx1151 is 15.82 GiB** (budget 15.03) — smaller than
+   the model — while heap[1] exposes 96 GiB of DEVICE_LOCAL|HOST_VISIBLE UMA memory.
+   `AllocateDeviceLocal` now retries the UMA/GTT type on `VK_ERROR_OUT_OF_DEVICE_MEMORY`
+   (llama.cpp `GGML_VK_ALLOW_SYSMEM_FALLBACK` equivalent; opt-out
+   `DOTLLM_VULKAN_STRICT_DEVICE_LOCAL=1`, occurrences in `DeviceLocalFallbackCount`).
+
+**With the fix: PASSES on real weights** (canvas 32, ≤16 steps, SC + PKV on):
+
+| Metric | Value |
+|---|---|
+| Load (repack + upload, 15.65 GB) | 38.5 s |
+| Generation wall | 58.6 s, 15 steps (finish=Stop) |
+| Step latency | **3.9 s/step** (vs 12.9 s/step CPU → 3.3×) |
+| Effective | 0.29 tok/s (17 tokens, 15/17 distinct) |
+
+Decoded text carried the fact ("… France.") with rougher filler tokens than the CPU run —
+sampling is temperature-stochastic and the trajectory differs per backend/canvas; the
+CPU↔Vulkan numerical parity gate is the synthetic-fixture argmax test, not decoded text.
 
 ## 3. Relative throughput (#41) and capability (#33)
 
-_(pending)_
+_(bench battery: full-canvas 256 run, PKV A/B, same-session llama.cpp Vulkan diffusion
+baseline, and the LLaDA-8B (plain Llama backbone) cross-engine AR decode ratio — results
+pending)_

--- a/docs/diffusiongemma/REAL-26B-RESULTS.md
+++ b/docs/diffusiongemma/REAL-26B-RESULTS.md
@@ -64,6 +64,14 @@ build 74ade5274 / the PR-24423 `llama-diffusion-cli` Vulkan build.
 | 26B diffusion effective | 0.29 tok/s (canvas 32) | 34.8 tok/s (256 tok, 10 steps) | — |
 | PKV prompt-cache effect (canvas 32) | 3.90 s/step on vs 4.47 s/step off | n/a | −13 % per step |
 
+**Full-canvas (256) status.** With the heap-aware allocator fallback the 15.65 GB upload
+now succeeds (no OOM), but the run dies at the first forward with
+`VK_ERROR_DEVICE_LOST` — the Windows TDR watchdog (~2 s/dispatch) kills the monolithic
+dispatches a 263-row forward produces; the dense SC soft-embed alone is ~378 GFLOP in a
+single dispatch (tens of seconds on gfx1151). Canvas 32 stays under the watchdog and is
+the validated configuration. Fix belongs to #121 (sparsified SC + split dispatches), which
+shrinks exactly those dispatches.
+
 **Reading.** The AR ratio (0.63×, up from 0.23× pre-kernel-campaign) says the Vulkan
 GEMV/MMVQ kernels are within striking distance. The diffusion gap is structural, not
 kernel-level: dotLLM's self-conditioning computes the full soft-embed —

--- a/src/DotLLM.Models/SafeTensors/DiffusionGemmaConfigExtractor.cs
+++ b/src/DotLLM.Models/SafeTensors/DiffusionGemmaConfigExtractor.cs
@@ -41,12 +41,11 @@ namespace DotLLM.Models.SafeTensors;
 /// <see cref="DiffusionConfigExtractor.ResolveMaskTokenId(string)"/>.
 /// </para>
 /// <para>
-/// <b>Forward gate (#36).</b> The real 26B checkpoint has
+/// <b>Per-layer head_dim (#36).</b> The real 26B checkpoint has
 /// <c>global_head_dim = 512 != head_dim = 256</c>; this extractor parses that into a
-/// faithful <see cref="ModelConfig"/> (it does NOT throw), but the CPU forward path
-/// rejects a non-uniform head_dim at model-build time
-/// (<c>ValidateGemma4UniformHeadDim</c>, issue #36). Real-weight forward therefore
-/// awaits #36; synthetic fixtures with a uniform head_dim run end-to-end today.
+/// faithful <see cref="ModelConfig"/>, and the forward path supports the per-layer
+/// head dimension (the former <c>ValidateGemma4UniformHeadDim</c> guard was removed
+/// when #36 landed). Real-weight forward runs end-to-end.
 /// </para>
 /// </remarks>
 public static class DiffusionGemmaConfigExtractor

--- a/src/DotLLM.Vulkan/VulkanDevice.cs
+++ b/src/DotLLM.Vulkan/VulkanDevice.cs
@@ -1398,6 +1398,27 @@ public sealed class VulkanDevice : IDisposable
         return import is null ? null : new Buffer(this, import);
     }
 
+    /// <summary>VkResult VK_ERROR_OUT_OF_DEVICE_MEMORY.</summary>
+    private const int VkErrorOutOfDeviceMemory = -2;
+
+    /// <summary>
+    /// <c>DOTLLM_VULKAN_STRICT_DEVICE_LOCAL=1</c> disables the host-visible fallback
+    /// on device-local allocation failure (an exhausted strict heap then throws, the
+    /// pre-fallback behaviour).
+    /// </summary>
+    private static readonly bool s_strictDeviceLocal =
+        Environment.GetEnvironmentVariable("DOTLLM_VULKAN_STRICT_DEVICE_LOCAL") == "1";
+
+    private long _deviceLocalFallbacks;
+
+    /// <summary>
+    /// Number of device-local allocations that fell back to a host-visible memory
+    /// type because the strict DEVICE_LOCAL heap was exhausted. Non-zero means part
+    /// of the working set lives in the slower (on discrete GPUs) or GTT (on UMA)
+    /// heap — perf harnesses should report it alongside any measurement.
+    /// </summary>
+    public long DeviceLocalFallbackCount => Interlocked.Read(ref _deviceLocalFallbacks);
+
     private Buffer AllocateInternal(long bytes, bool deviceLocal)
     {
         if (bytes <= 0) throw new ArgumentOutOfRangeException(nameof(bytes));
@@ -1449,6 +1470,39 @@ public sealed class VulkanDevice : IDisposable
             memoryTypeIndex = typeIndex,
         };
         int allocResult = VulkanApi.vkAllocateMemory(_device, mai, 0, out nint memory);
+
+        // The strict device-local heap (discrete VRAM, or the UMA carve-out — e.g. a
+        // 16 GB heap[0] on Strix Halo while heap[1] exposes 96 GB of DEVICE_LOCAL +
+        // HOST_VISIBLE GTT) can be far smaller than what the device can actually
+        // address. When it is exhausted, retry on the combined DEVICE_LOCAL +
+        // HOST_VISIBLE type, then plain host-visible — the llama.cpp
+        // GGML_VK_ALLOW_SYSMEM_FALLBACK equivalent. On UMA parts the fallback reads
+        // the same DRAM; on discrete GPUs it is slower than VRAM but beats an OOM
+        // crash. Opt out with DOTLLM_VULKAN_STRICT_DEVICE_LOCAL=1; occurrences are
+        // counted in DeviceLocalFallbackCount for harness reporting.
+        if (allocResult == VkErrorOutOfDeviceMemory && deviceLocal && !s_strictDeviceLocal)
+        {
+            Span<(VkMemoryPropertyFlags required, VkMemoryPropertyFlags excluded)> ladder =
+            [
+                (VkMemoryPropertyFlags.DeviceLocal | VkMemoryPropertyFlags.HostVisible, default),
+                (VkMemoryPropertyFlags.HostVisible | VkMemoryPropertyFlags.HostCoherent, default),
+            ];
+            foreach (var (requiredFlags, excludedFlags) in ladder)
+            {
+                if (!TryFindMemoryType(req.memoryTypeBits, requiredFlags, excludedFlags, out uint fbIndex)
+                    || fbIndex == typeIndex)
+                    continue;
+                mai.memoryTypeIndex = fbIndex;
+                allocResult = VulkanApi.vkAllocateMemory(_device, mai, 0, out memory);
+                if (allocResult >= 0)
+                {
+                    typeIndex = fbIndex;
+                    Interlocked.Increment(ref _deviceLocalFallbacks);
+                    break;
+                }
+            }
+        }
+
         if (allocResult < 0)
         {
             VulkanApi.vkDestroyBuffer(_device, buffer, 0);

--- a/src/DotLLM.Vulkan/VulkanDevice.cs
+++ b/src/DotLLM.Vulkan/VulkanDevice.cs
@@ -1482,16 +1482,12 @@ public sealed class VulkanDevice : IDisposable
         // counted in DeviceLocalFallbackCount for harness reporting.
         if (allocResult == VkErrorOutOfDeviceMemory && deviceLocal && !s_strictDeviceLocal)
         {
-            Span<(VkMemoryPropertyFlags required, VkMemoryPropertyFlags excluded)> ladder =
-            [
-                (VkMemoryPropertyFlags.DeviceLocal | VkMemoryPropertyFlags.HostVisible, default),
-                (VkMemoryPropertyFlags.HostVisible | VkMemoryPropertyFlags.HostCoherent, default),
-            ];
-            foreach (var (requiredFlags, excludedFlags) in ladder)
+            // Heap-aware: on AMD APUs the FIRST type matching a fallback flag combo can
+            // sit on the same exhausted carve-out heap as the failed type, so ranking by
+            // flags alone re-fails. Try every eligible type, other heaps before the
+            // failed heap, larger heaps first, host-visible rungs after combined ones.
+            foreach (uint fbIndex in EnumerateDeviceLocalFallbackTypes(req.memoryTypeBits, typeIndex))
             {
-                if (!TryFindMemoryType(req.memoryTypeBits, requiredFlags, excludedFlags, out uint fbIndex)
-                    || fbIndex == typeIndex)
-                    continue;
                 mai.memoryTypeIndex = fbIndex;
                 allocResult = VulkanApi.vkAllocateMemory(_device, mai, 0, out memory);
                 if (allocResult >= 0)
@@ -1530,6 +1526,52 @@ public sealed class VulkanDevice : IDisposable
         uint* types = (uint*)mem.memoryTypes; // 8-byte entries: u32 propertyFlags, u32 heapIndex
         var flags = (VkMemoryPropertyFlags)types[typeIndex * 2];
         return (flags & VkMemoryPropertyFlags.HostVisible) != 0;
+    }
+
+    /// <summary>
+    /// Candidate memory types for the device-local OOM fallback, best first: for each
+    /// rung (DEVICE_LOCAL+HOST_VISIBLE, then HOST_VISIBLE+HOST_COHERENT) every eligible
+    /// type is yielded — types on a different heap than the exhausted one before types
+    /// sharing it, larger heaps before smaller. On a UMA APU this walks the allocation
+    /// off the small strict carve-out (e.g. 15.8 GiB on Strix Halo) onto the large
+    /// GTT heap that maps the same DRAM.
+    /// </summary>
+    private unsafe List<uint> EnumerateDeviceLocalFallbackTypes(uint typeBits, uint failedTypeIndex)
+    {
+        VulkanApi.vkGetPhysicalDeviceMemoryProperties(_physicalDevice, out var mem);
+        uint* types = (uint*)mem.memoryTypes;   // 8-byte entries: u32 propertyFlags, u32 heapIndex
+        byte* heaps = (byte*)mem.memoryHeaps;   // 16-byte entries: u64 size, u32 flags, padding
+        uint failedHeap = types[failedTypeIndex * 2 + 1];
+
+        var ordered = new List<uint>(8);
+        Span<VkMemoryPropertyFlags> rungs =
+        [
+            VkMemoryPropertyFlags.DeviceLocal | VkMemoryPropertyFlags.HostVisible,
+            VkMemoryPropertyFlags.HostVisible | VkMemoryPropertyFlags.HostCoherent,
+        ];
+        foreach (var required in rungs)
+        {
+            // Two passes per rung: other-heap types first, failed-heap types last.
+            for (int pass = 0; pass < 2; pass++)
+            {
+                var passList = new List<(uint Index, ulong HeapSize)>(4);
+                for (uint i = 0; i < mem.memoryTypeCount; i++)
+                {
+                    if ((typeBits & (1u << (int)i)) == 0 || i == failedTypeIndex) continue;
+                    var flags = (VkMemoryPropertyFlags)types[i * 2];
+                    if ((flags & required) != required) continue;
+                    uint heapIdx = types[i * 2 + 1];
+                    bool otherHeap = heapIdx != failedHeap;
+                    if (otherHeap != (pass == 0)) continue;
+                    passList.Add((i, *(ulong*)(heaps + heapIdx * 16)));
+                }
+                passList.Sort(static (a, b) => b.HeapSize.CompareTo(a.HeapSize));
+                foreach (var (idx, _) in passList)
+                    if (!ordered.Contains(idx))
+                        ordered.Add(idx);
+            }
+        }
+        return ordered;
     }
 
     /// <summary>

--- a/src/DotLLM.Vulkan/VulkanWeights.cs
+++ b/src/DotLLM.Vulkan/VulkanWeights.cs
@@ -1582,15 +1582,18 @@ internal sealed class VulkanWeights : IDisposable
     /// <summary>
     /// True when a Gemma-4 MoE layer's experts can stay QUANTIZED on device: the
     /// fused <c>gate_up</c> raw bank is Q4_K (and the contraction axis <c>hidden</c>
-    /// is a multiple of 256) and the <c>down</c> raw bank is Q5_1 (and the expert FF
-    /// width is a multiple of 32). When false the caller falls back to the F32
-    /// host-dequant path (<see cref="UploadGemma4MoeLayer"/>).
+    /// is a multiple of 256) and the <c>down</c> raw bank is Q5_1, Q5_0 or Q8_0 (and
+    /// the expert FF width is a multiple of 32). Q5_0 downs are repacked bit-exactly
+    /// to Q5_1 at upload; Q8_0 downs stay Q8_0 with the per-expert scale folded into
+    /// each block's fp16 <c>d</c> (real unsloth Q4_K_M conversions ship Q5_0/Q8_0
+    /// downs, not Q5_1). When false the caller falls back to the F32 host-dequant
+    /// path (<see cref="UploadGemma4MoeLayer"/>).
     /// </summary>
     private static bool Gemma4ExpertsKeepQuantized(MoeLayerWeights moe)
         => moe.GateExpsRaw != 0 && moe.UpExpsRaw != 0 && moe.DownExpsRaw != 0
         && moe.GateExpsRawQt == QuantizationType.Q4_K
         && moe.UpExpsRawQt == QuantizationType.Q4_K
-        && moe.DownExpsRawQt == QuantizationType.Q5_1
+        && moe.DownExpsRawQt is QuantizationType.Q5_1 or QuantizationType.Q5_0 or QuantizationType.Q8_0
         && (moe.HiddenSize % 256) == 0
         && (moe.IntermediateSize % 32) == 0;
 
@@ -1598,10 +1601,14 @@ internal sealed class VulkanWeights : IDisposable
     /// Uploads a Gemma-4 MoE layer's experts KEPT QUANTIZED on device. The fused
     /// <c>gate_up</c> Q4_K bank is REPACKED into two contiguous Q4_K banks — W1 (gate,
     /// rows <c>[0, Ie)</c> of each expert slab) and W3 (up, rows <c>[Ie, 2*Ie)</c>) —
-    /// and the <c>down</c> Q5_1 bank is copied contiguously into W2. The per-expert
-    /// down scale <c>ffn_down_exps.scale[e]</c> is uploaded as an F32 [numExperts]
-    /// buffer and folded by the Q5_1 indexed-matmul shader (NOT pre-multiplied into
-    /// the weight, since the bank stays quantized). The router gate stays F32.
+    /// and the <c>down</c> bank is copied contiguously into W2: Q5_1 verbatim, Q5_0
+    /// repacked bit-exactly to Q5_1 (<see cref="ConvertQ5_0BlocksToQ5_1"/>), Q8_0
+    /// verbatim with the per-expert scale folded into the block scales
+    /// (<see cref="CopyQ8_0BlocksScaled"/>). For the Q5_1-dispatched banks the
+    /// per-expert down scale <c>ffn_down_exps.scale[e]</c> is uploaded as an F32
+    /// [numExperts] buffer and folded by the Q5_1 indexed-matmul shader (NOT
+    /// pre-multiplied into the weight); Q8_0 banks are pre-folded and their dispatch
+    /// ignores that buffer. The router gate stays F32.
     ///
     /// <para>This is the memory-viable path for the real 26B: experts occupy their
     /// GGUF-quantized footprint (~Q4_K + Q5_1) instead of being dequantised to F32
@@ -1624,12 +1631,19 @@ internal sealed class VulkanWeights : IDisposable
         int numE = moe.NumExperts;
 
         // Per-expert quantized slab byte sizes (one projection each):
-        //   gate/up: Ie rows of hidden Q4_K  → Ie * rowBytes(Q4_K, hidden)
-        //   down:    hidden rows of Ie Q5_1   → hidden * rowBytes(Q5_1, Ie)
+        //   gate/up: Ie rows of hidden Q4_K       → Ie * rowBytes(Q4_K, hidden)
+        //   down:    hidden rows of Ie (src type)  → hidden * rowBytes(srcQt, Ie)
+        // Q5_0 downs are converted to Q5_1 on the way through staging (bit-exact:
+        // d·(q−16) = d·q + m with m = −16·d, same 5-bit payload), so the DEVICE bank
+        // size uses the device type, not the source type.
+        QuantizationType downSrcQt = moe.DownExpsRawQt;
+        QuantizationType downDevQt = downSrcQt == QuantizationType.Q5_0 ? QuantizationType.Q5_1 : downSrcQt;
         long gateUpRowBytes = Dequantize.RowByteSize(hidden, QuantizationType.Q4_K);
         long perGateUpBytes = (long)interm * gateUpRowBytes;
-        long downRowBytes = Dequantize.RowByteSize(interm, QuantizationType.Q5_1);
-        long perDownBytes = (long)hidden * downRowBytes;
+        long downSrcRowBytes = Dequantize.RowByteSize(interm, downSrcQt);
+        long perDownSrcBytes = (long)hidden * downSrcRowBytes;
+        long downDevRowBytes = Dequantize.RowByteSize(interm, downDevQt);
+        long perDownDevBytes = (long)hidden * downDevRowBytes;
         long gateRouterBytes = (long)numE * hidden * sizeof(float);
 
         // The fused gate_up per-expert stride must equal 2 * gate (gate + up halves).
@@ -1637,12 +1651,12 @@ internal sealed class VulkanWeights : IDisposable
             throw new InvalidOperationException(
                 $"Gemma-4 fused gate_up stride mismatch: GateUpExpsRowBytes={g4.GateUpExpsRowBytes} "
                 + $"!= 2*{perGateUpBytes} (Ie={interm}, hidden={hidden}, rowBytes={gateUpRowBytes}).");
-        if (g4.DownExpsRowBytes != perDownBytes)
+        if (g4.DownExpsRowBytes != perDownSrcBytes)
             throw new InvalidOperationException(
-                $"Gemma-4 down stride mismatch: DownExpsRowBytes={g4.DownExpsRowBytes} != {perDownBytes} "
-                + $"(hidden={hidden}, Ie={interm}, rowBytes={downRowBytes}).");
+                $"Gemma-4 down stride mismatch: DownExpsRowBytes={g4.DownExpsRowBytes} != {perDownSrcBytes} "
+                + $"(hidden={hidden}, Ie={interm}, srcQt={downSrcQt}, rowBytes={downSrcRowBytes}).");
 
-        long stageBytes = Math.Max(gateRouterBytes, Math.Max(perGateUpBytes, perDownBytes));
+        long stageBytes = Math.Max(gateRouterBytes, Math.Max(perGateUpBytes, perDownDevBytes));
         using var stage = device.Allocate(stageBytes);
 
         // ── Router gate (F32 [numExperts, hidden]) ───────────────────
@@ -1657,11 +1671,12 @@ internal sealed class VulkanWeights : IDisposable
         device.CopyBufferSynchronous(stage, gate, (ulong)gateRouterBytes);
         uploadedBytes += gateRouterBytes;
 
-        // ── Quantized expert banks (Q4_K gate/up, Q5_1 down) ─────────
+        // ── Quantized expert banks (Q4_K gate/up; Q5_1 or Q8_0 down) ─
         var w1Bank = device.AllocateDeviceLocal(perGateUpBytes * numE);   // gate Q4_K
         var w3Bank = device.AllocateDeviceLocal(perGateUpBytes * numE);   // up   Q4_K
-        var w2Bank = device.AllocateDeviceLocal(perDownBytes * numE);     // down Q5_1
+        var w2Bank = device.AllocateDeviceLocal(perDownDevBytes * numE);  // down Q5_1/Q8_0
 
+        long downBlocks = (long)hidden * (interm / 32);
         for (int e = 0; e < numE; e++)
         {
             nint gateSrc = moe.GateExpsRaw + (nint)(e * g4.GateUpExpsRowBytes);
@@ -1670,16 +1685,38 @@ internal sealed class VulkanWeights : IDisposable
 
             UploadRawBankSlot(device, stage, gateSrc, perGateUpBytes, w1Bank, (long)e * perGateUpBytes);
             UploadRawBankSlot(device, stage, upSrc, perGateUpBytes, w3Bank, (long)e * perGateUpBytes);
-            UploadRawBankSlot(device, stage, downSrc, perDownBytes, w2Bank, (long)e * perDownBytes);
+            switch (downSrcQt)
+            {
+                case QuantizationType.Q5_1:
+                    UploadRawBankSlot(device, stage, downSrc, perDownDevBytes, w2Bank, (long)e * perDownDevBytes);
+                    break;
+                case QuantizationType.Q5_0:
+                    // Bit-exact Q5_0 → Q5_1 repack; rides the validated Q5_1 shader
+                    // (per-expert scale folded by the shader via downScaleBuffer).
+                    UploadQ5_0SlotAsQ5_1(device, stage, downSrc, downBlocks, w2Bank, (long)e * perDownDevBytes);
+                    break;
+                case QuantizationType.Q8_0:
+                    // Q8_0 rides the generic Q8_0 indexed-matmul kernel, which has no
+                    // scale plumbing — fold ffn_down_exps.scale[e] (op #14) into each
+                    // block's fp16 d here (≤2⁻¹¹ relative rounding, inside the gemma4
+                    // GPU parity envelope). The forward MUST NOT apply the scale again.
+                    UploadQ8_0SlotScaled(device, stage, downSrc, downBlocks, g4.DownExpertScale[e],
+                        w2Bank, (long)e * perDownDevBytes);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unexpected gemma4 down quant type {downSrcQt}.");
+            }
         }
-        uploadedBytes += (perGateUpBytes * 2 + perDownBytes) * numE;
+        uploadedBytes += (perGateUpBytes * 2 + perDownDevBytes) * numE;
 
-        // ── Per-expert down scale (folded by the Q5_1 down shader, op #14) ──
+        // ── Per-expert down scale (folded by the Q5_1 down shader, op #14).
+        // For Q8_0 down banks the scale is already folded into the block scales
+        // above and the Q8_0 dispatch ignores this buffer — kept for diagnostics. ──
         downScaleBuffer = UploadNormVec(device, stage, g4.DownExpertScale);
         uploadedBytes += (long)numE * sizeof(float);
 
         return new MoeLayerBuffers(gate, QuantizationType.F32, w1Bank, w2Bank, w3Bank,
-            QuantizationType.Q4_K, QuantizationType.Q5_1, QuantizationType.Q4_K,
+            QuantizationType.Q4_K, downDevQt, QuantizationType.Q4_K,
             moe.NumExperts, moe.NumExpertsPerTok,
             moe.HiddenSize, moe.IntermediateSize, moe.NormTopKProb,
             sharedW1: null, sharedW2: null, sharedW3: null,
@@ -1846,6 +1883,95 @@ internal sealed class VulkanWeights : IDisposable
         {
             new ReadOnlySpan<byte>((void*)srcPtr, checked((int)bytes))
                 .CopyTo(new Span<byte>((void*)mapped, checked((int)bytes)));
+        }
+        finally
+        {
+            VulkanApi.vkUnmapMemory(device.Handle, staging.Memory);
+        }
+        device.CopyBufferRangeSynchronous(staging, bank, srcOffset: 0, dstOffset: (ulong)dstOffset, size: (ulong)bytes);
+    }
+
+    /// <summary>
+    /// Converts <paramref name="blockCount"/> Q5_0 blocks (22 B: fp16 <c>d</c>, 4 B <c>qh</c>,
+    /// 16 B <c>qs</c>; value = <c>d·(q−16)</c>) to Q5_1 blocks (24 B: fp16 <c>d</c>, fp16
+    /// <c>m</c>, <c>qh</c>, <c>qs</c>; value = <c>d·q + m</c>) with <c>d' = d</c> and
+    /// <c>m' = −16·d</c>. The 5-bit payload is copied verbatim and <c>−16·d</c> is exactly
+    /// representable in fp16 (pure exponent shift), so both blocks dequantise to identical
+    /// F32 values — a Q5_0 bank can ride the Q5_1 kernels with no dedicated Q5_0 shader.
+    /// </summary>
+    internal static unsafe void ConvertQ5_0BlocksToQ5_1(nint src, nint dst, long blockCount)
+    {
+        byte* s = (byte*)src;
+        byte* d = (byte*)dst;
+        for (long b = 0; b < blockCount; b++)
+        {
+            Half scale = *(Half*)s;
+            *(Half*)d = scale;
+            *(Half*)(d + 2) = (Half)(-16f * (float)scale);
+            new ReadOnlySpan<byte>(s + 2, 20).CopyTo(new Span<byte>(d + 4, 20)); // qh + qs verbatim
+            s += 22;
+            d += 24;
+        }
+    }
+
+    /// <summary>
+    /// Copies <paramref name="blockCount"/> Q8_0 blocks (34 B: fp16 <c>d</c> + 32×int8)
+    /// multiplying each block's <c>d</c> by <paramref name="scale"/> — folds the Gemma-4
+    /// per-expert <c>ffn_down_exps.scale</c> (op #14) into the weight so the scale-less
+    /// generic Q8_0 indexed-matmul kernel can serve the down projection. The fp16
+    /// re-rounding of <c>d·scale</c> is ≤ 2⁻¹¹ relative.
+    /// </summary>
+    internal static unsafe void CopyQ8_0BlocksScaled(nint src, nint dst, long blockCount, float scale)
+    {
+        byte* s = (byte*)src;
+        byte* d = (byte*)dst;
+        for (long b = 0; b < blockCount; b++)
+        {
+            *(Half*)d = (Half)((float)*(Half*)s * scale);
+            new ReadOnlySpan<byte>(s + 2, 32).CopyTo(new Span<byte>(d + 2, 32));
+            s += 34;
+            d += 34;
+        }
+    }
+
+    /// <summary>
+    /// Stages one per-expert Q5_0 down slab converted to Q5_1
+    /// (<see cref="ConvertQ5_0BlocksToQ5_1"/>) and copies it into
+    /// <paramref name="bank"/> at <paramref name="dstOffset"/>.
+    /// </summary>
+    private static unsafe void UploadQ5_0SlotAsQ5_1(
+        VulkanDevice device, VulkanDevice.Buffer staging,
+        nint srcPtr, long blockCount, VulkanDevice.Buffer bank, long dstOffset)
+    {
+        long bytes = blockCount * 24; // Q5_1 block size
+        VulkanApi.vkMapMemory(device.Handle, staging.Memory, 0, (ulong)bytes, 0, out nint mapped)
+            .ThrowOnError("vkMapMemory UploadQ5_0SlotAsQ5_1");
+        try
+        {
+            ConvertQ5_0BlocksToQ5_1(srcPtr, mapped, blockCount);
+        }
+        finally
+        {
+            VulkanApi.vkUnmapMemory(device.Handle, staging.Memory);
+        }
+        device.CopyBufferRangeSynchronous(staging, bank, srcOffset: 0, dstOffset: (ulong)dstOffset, size: (ulong)bytes);
+    }
+
+    /// <summary>
+    /// Stages one per-expert Q8_0 down slab with the per-expert scale folded into the
+    /// block scales (<see cref="CopyQ8_0BlocksScaled"/>) and copies it into
+    /// <paramref name="bank"/> at <paramref name="dstOffset"/>.
+    /// </summary>
+    private static unsafe void UploadQ8_0SlotScaled(
+        VulkanDevice device, VulkanDevice.Buffer staging,
+        nint srcPtr, long blockCount, float scale, VulkanDevice.Buffer bank, long dstOffset)
+    {
+        long bytes = blockCount * 34; // Q8_0 block size
+        VulkanApi.vkMapMemory(device.Handle, staging.Memory, 0, (ulong)bytes, 0, out nint mapped)
+            .ThrowOnError("vkMapMemory UploadQ8_0SlotScaled");
+        try
+        {
+            CopyQ8_0BlocksScaled(srcPtr, mapped, blockCount, scale);
         }
         finally
         {

--- a/tests/DotLLM.Tests.Integration/Backends/DiffusionGemmaVulkanRealGenerationTests.cs
+++ b/tests/DotLLM.Tests.Integration/Backends/DiffusionGemmaVulkanRealGenerationTests.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using DotLLM.Core.Configuration;
+using DotLLM.Engine;
+using DotLLM.Models.Gguf;
+using DotLLM.Vulkan;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Integration.Backends;
+
+/// <summary>
+/// Real-weight <b>DiffusionGemma-26B</b> end-to-end masked-diffusion GENERATION on the
+/// <b>Vulkan</b> backend — the #40 deliverable that the CPU-only
+/// <c>DiffusionGemmaGgufForwardTests</c> cannot provide at usable speed (a 26B MoE denoise
+/// loop on CPU is minutes per step; on the iGPU it is sub-second per step).
+/// Drives the full pipeline: real GGUF → <see cref="VulkanTransformerModel"/> (region embed,
+/// region scalar, self-conditioning, opt-in PKV) → <see cref="DiffusionTextGenerator"/>.
+/// Reports the #41/#33 headline numbers: denoise-steps/sec, per-step canvas latency and
+/// effective tokens/sec, alongside the decoded text for the coherence check.
+/// </summary>
+/// <remarks>
+/// Gated on <c>DOTLLM_DIFFUSIONGEMMA_GGUF</c> (path to the .gguf) and a Vulkan device; skips
+/// otherwise so the default sweep never depends on the multi-gig checkpoint. Canvas/steps/
+/// prompt are overridable (<c>DOTLLM_DG_CANVAS</c> / <c>DOTLLM_DG_STEPS</c> /
+/// <c>DOTLLM_DG_PROMPT</c> / <c>DOTLLM_DG_PKV</c>) so the same harness serves the quick
+/// correctness run (small canvas) and the full-canvas throughput measurement.
+/// </remarks>
+[Trait("Category", "GPU")]
+public sealed class DiffusionGemmaVulkanRealGenerationTests
+{
+    private const string ModelPathEnvVar = "DOTLLM_DIFFUSIONGEMMA_GGUF";
+
+    private readonly ITestOutputHelper _out;
+
+    public DiffusionGemmaVulkanRealGenerationTests(ITestOutputHelper output) => _out = output;
+
+    [SkippableFact]
+    public void DiffusionGemma_26B_Vulkan_DenoiseLoop_RealWeights()
+    {
+        Skip.If(Environment.GetEnvironmentVariable("DOTLLM_SKIP_VULKAN") == "1", "DOTLLM_SKIP_VULKAN=1");
+        Skip.IfNot(VulkanDevice.IsAvailable(), "No Vulkan loader or physical device available on this host.");
+        string? path = Environment.GetEnvironmentVariable(ModelPathEnvVar);
+        Skip.If(string.IsNullOrWhiteSpace(path) || !File.Exists(path),
+            $"Set {ModelPathEnvVar} to a diffusion-gemma GGUF (e.g. diffusiongemma-26B-A4B-it-Q4_K_M.gguf) to run this generation test.");
+
+        string spvDir = ResolveSpvDir();
+        using var gguf = GgufFile.Open(path!);
+        var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+        Assert.Equal(Architecture.DiffusionGemma, config.Architecture);
+        Assert.NotNull(config.DiffusionConfig);
+
+        var loadSw = Stopwatch.StartNew();
+        using var model = VulkanTransformerModel.LoadFromGguf(gguf, config, spvDir);
+        loadSw.Stop();
+        var tokenizer = GgufBpeTokenizerFactory.Load(gguf.Metadata);
+
+        // Small-canvas default keeps the quick run cheap; the throughput run overrides to the
+        // checkpoint's full canvas (256) and step budget (48, adaptive early-stop).
+        int canvas = EnvInt("DOTLLM_DG_CANVAS", 32);
+        int steps = EnvInt("DOTLLM_DG_STEPS", 16);
+        bool pkv = Environment.GetEnvironmentVariable("DOTLLM_DG_PKV") != "0";
+        var diff = config.DiffusionConfig! with
+        {
+            CanvasLength = canvas,
+            MaxDenoisingSteps = steps,
+            TemperatureMax = 0.6f,
+            TemperatureMin = 0.2f,
+        };
+
+        string prompt = Environment.GetEnvironmentVariable("DOTLLM_DG_PROMPT") ?? "The Eiffel Tower is located in";
+        int[] enc = tokenizer.Encode(prompt);
+        int[] promptIds = new int[enc.Length + 1];
+        promptIds[0] = tokenizer.BosTokenId;
+        Array.Copy(enc, 0, promptIds, 1, enc.Length);
+
+        var generator = new DiffusionTextGenerator(model, tokenizer, diffusionConfig: diff, enablePromptKv: pkv);
+        var sw = Stopwatch.StartNew();
+        DiffusionResult result = generator.Generate(promptIds);
+        sw.Stop();
+
+        double stepMs = sw.Elapsed.TotalMilliseconds / Math.Max(1, result.TotalDenoisingSteps);
+        _out.WriteLine($"[dg-26B vulkan] model={Path.GetFileName(path)}  pkv={pkv}");
+        _out.WriteLine($"  load          : {loadSw.Elapsed.TotalSeconds:F1} s");
+        _out.WriteLine($"  prompt        : '{prompt}'  promptLen(incl BOS)={promptIds.Length}  canvas={canvas}  maxSteps={steps}");
+        _out.WriteLine($"  gen wall      : {sw.Elapsed.TotalSeconds:F1} s  steps={result.TotalDenoisingSteps}  finish={result.FinishReason}");
+        _out.WriteLine($"  step latency  : {stepMs:F0} ms/step  denoise-steps/s={result.TotalDenoisingSteps / sw.Elapsed.TotalSeconds:F2}");
+        _out.WriteLine($"  effective     : {result.GeneratedTokenCount / sw.Elapsed.TotalSeconds:F2} tok/s  genToks={result.GeneratedTokenCount}");
+        _out.WriteLine($"  distinct toks : {result.GeneratedTokenIds.Distinct().Count()}/{result.GeneratedTokenCount}");
+        _out.WriteLine($"  token ids     : [{string.Join(",", result.GeneratedTokenIds)}]");
+        _out.WriteLine($"  text          : {result.Text}");
+
+        Assert.True(result.GeneratedTokenCount > 0, "Expected at least one generated token.");
+        Assert.DoesNotContain(diff.MaskTokenId, result.GeneratedTokenIds); // canvas fully materialised
+        foreach (int id in result.GeneratedTokenIds)
+            Assert.InRange(id, 0, config.VocabSize - 1);
+        Assert.False(string.IsNullOrWhiteSpace(result.Text), "Decoded text should be non-empty.");
+        // Same coherence bar as the CPU denoise-loop test: the self-conditioned canvas must
+        // not collapse to a single repeated low-information token.
+        Assert.True(result.GeneratedTokenIds.Distinct().Count() > 2,
+            $"Self-conditioned canvas must be non-degenerate; got text: '{result.Text}'.");
+    }
+
+    private static int EnvInt(string key, int fallback)
+        => int.TryParse(Environment.GetEnvironmentVariable(key), out int n) && n > 0 ? n : fallback;
+
+    private static string ResolveSpvDir()
+    {
+        string[] candidates =
+        {
+            Path.Combine(AppContext.BaseDirectory, "spv"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "vulkan", "spv"),
+        };
+        foreach (var cand in candidates)
+        {
+            string full = Path.GetFullPath(cand);
+            if (Directory.Exists(full) && Directory.GetFiles(full, "*.spv").Length > 0)
+                return full;
+        }
+        throw new InvalidOperationException(
+            "SPIR-V blobs not found. Run native/vulkan/build.sh (or build.ps1) with the Vulkan SDK installed.");
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Vulkan/VulkanWeightsQuantRepackTests.cs
+++ b/tests/DotLLM.Tests.Unit/Vulkan/VulkanWeightsQuantRepackTests.cs
@@ -1,0 +1,113 @@
+using System.Runtime.InteropServices;
+using DotLLM.Core.Configuration;
+using DotLLM.Cpu.Kernels;
+using DotLLM.Vulkan;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Vulkan;
+
+/// <summary>
+/// CPU-only exactness tests for the Gemma-4 down-expert bank repacks introduced for the
+/// real 26B GGUF (whose <c>ffn_down_exps</c> are Q5_0/Q8_0, not the synthetic fixture's
+/// Q5_1): <see cref="VulkanWeights.ConvertQ5_0BlocksToQ5_1"/> must be bit-exact
+/// (<c>d·(q−16) = d·q + m</c> with <c>m = −16·d</c> exactly representable in fp16), and
+/// <see cref="VulkanWeights.CopyQ8_0BlocksScaled"/> must fold the per-expert scale into
+/// each block's fp16 <c>d</c> within one fp16 rounding while leaving the int8 payload
+/// untouched. No GPU required.
+/// </summary>
+public sealed class VulkanWeightsQuantRepackTests
+{
+    private const int GroupSize = 32;
+    private const int Q5_0BlockBytes = 22;
+    private const int Q5_1BlockBytes = 24;
+    private const int Q8_0BlockBytes = 34;
+
+    [Fact]
+    public unsafe void ConvertQ5_0BlocksToQ5_1_DequantisesBitExact()
+    {
+        const int blocks = 257; // odd count, > several rows
+        const int elems = blocks * GroupSize;
+        var rng = new Random(40); // fixed seed — deterministic test
+
+        byte[] src = new byte[blocks * Q5_0BlockBytes];
+        rng.NextBytes(src);
+        for (int b = 0; b < blocks; b++)
+        {
+            // Realistic per-block scale: weights' d is small; include negatives, zero
+            // and a subnormal-half to cover the exponent-shift edge cases.
+            float d = b switch
+            {
+                0 => 0f,
+                1 => -0f,
+                2 => 5.96e-8f, // subnormal half
+                3 => -5.96e-8f,
+                _ => (rng.NextSingle() - 0.5f) * 0.25f,
+            };
+            MemoryMarshal.Write(src.AsSpan(b * Q5_0BlockBytes), (Half)d);
+        }
+
+        byte[] dst = new byte[blocks * Q5_1BlockBytes];
+        float[] fromQ5_0 = new float[elems];
+        float[] fromQ5_1 = new float[elems];
+        fixed (byte* sp = src, dp = dst)
+        {
+            VulkanWeights.ConvertQ5_0BlocksToQ5_1((nint)sp, (nint)dp, blocks);
+            Dequantize.ToFloat32((nint)sp, elems, QuantizationType.Q5_0, fromQ5_0);
+            Dequantize.ToFloat32((nint)dp, elems, QuantizationType.Q5_1, fromQ5_1);
+        }
+
+        // Bit-exact: d·q and 16·d are both exact in F32 (11-bit × 5-bit significands),
+        // so d·q − 16d and d·(q−16) round identically.
+        for (int i = 0; i < elems; i++)
+            Assert.True(fromQ5_0[i].Equals(fromQ5_1[i]),
+                $"elem {i}: Q5_0={fromQ5_0[i]:G9} != converted Q5_1={fromQ5_1[i]:G9}");
+    }
+
+    [Fact]
+    public unsafe void CopyQ8_0BlocksScaled_FoldsScaleWithinOneHalfRounding()
+    {
+        const int blocks = 129;
+        const int elems = blocks * GroupSize;
+        const float scale = 0.03127f; // deliberately not a power of two
+        var rng = new Random(41);
+
+        byte[] src = new byte[blocks * Q8_0BlockBytes];
+        rng.NextBytes(src);
+        for (int b = 0; b < blocks; b++)
+            MemoryMarshal.Write(src.AsSpan(b * Q8_0BlockBytes), (Half)((rng.NextSingle() - 0.5f) * 0.25f));
+
+        byte[] dst = new byte[blocks * Q8_0BlockBytes];
+        float[] original = new float[elems];
+        float[] scaled = new float[elems];
+        fixed (byte* sp = src, dp = dst)
+        {
+            VulkanWeights.CopyQ8_0BlocksScaled((nint)sp, (nint)dp, blocks, scale);
+            Dequantize.ToFloat32((nint)sp, elems, QuantizationType.Q8_0, original);
+            Dequantize.ToFloat32((nint)dp, elems, QuantizationType.Q8_0, scaled);
+        }
+
+        for (int b = 0; b < blocks; b++)
+        {
+            // Payload untouched.
+            Assert.True(src.AsSpan(b * Q8_0BlockBytes + 2, 32).SequenceEqual(
+                            dst.AsSpan(b * Q8_0BlockBytes + 2, 32)),
+                $"block {b}: int8 payload changed");
+            // d' == fp16(d · scale) exactly — the only rounding is the fold itself.
+            Half d = MemoryMarshal.Read<Half>(src.AsSpan(b * Q8_0BlockBytes));
+            Half expected = (Half)((float)d * scale);
+            Half actual = MemoryMarshal.Read<Half>(dst.AsSpan(b * Q8_0BlockBytes));
+            Assert.Equal(expected, actual);
+        }
+
+        // And the dequantised values are exactly fp16(d·scale) · q — an fp16 (11-bit)
+        // by int8 (8-bit) product is exact in F32, so equality is bitwise.
+        for (int i = 0; i < elems; i++)
+        {
+            int b = i / GroupSize;
+            Half foldedD = MemoryMarshal.Read<Half>(dst.AsSpan(b * Q8_0BlockBytes));
+            int q = (sbyte)src[b * Q8_0BlockBytes + 2 + (i % GroupSize)];
+            Assert.True(((float)foldedD * q).Equals(scaled[i]),
+                $"elem {i}: expected {(float)foldedD * q:G9}, got {scaled[i]:G9}");
+        }
+    }
+}


### PR DESCRIPTION
First real-weight DiffusionGemma-26B runs on the Vulkan backend, plus the fixes that made them possible. Closes #120.

## What happened
- **`DiffusionGemmaVulkanRealGenerationTests`** — env-gated (`DOTLLM_DIFFUSIONGEMMA_GGUF` + Vulkan device) end-to-end masked-diffusion generation on the real 26B GGUF, reporting denoise-steps/sec, canvas latency and effective tok/s (`DOTLLM_DG_CANVAS/STEPS/PROMPT/PKV` overridable). **Passes on Strix Halo**: 15 steps / 58.6 s at canvas 32, SC+PKV on, coherent factual completion.
- **Vulkan gemma4 MoE: real conversions load quantized now (#120).** The unsloth Q4_K_M ships `ffn_down_exps` as **Q5_0 ×16 + Q8_0 ×14 (never Q5_1)** — all 30 layers previously fell into the F32 host-dequant fallback (~92 GB → OOM). Now: Q5_0 downs repack **bit-exactly** to Q5_1 at upload (`d·(q−16) = d·q + m`, `m = −16d`, fp16-exact — unit-tested) and ride the validated Q5_1 scale-fold shader; Q8_0 downs keep the existing scale-less Q8_0 indexed kernel with `ffn_down_exps.scale[e]` folded into each block's fp16 `d`.
- **Heap-aware device-local OOM fallback.** gfx1151's strict DEVICE_LOCAL heap is 15.82 GiB (smaller than the model); heap[1] is 96 GiB DEVICE_LOCAL|HOST_VISIBLE UMA. On `VK_ERROR_OUT_OF_DEVICE_MEMORY`, `AllocateInternal` now retries every eligible type — other heaps before the failed heap, larger heaps first, combined rung before plain host-visible (llama.cpp `GGML_VK_ALLOW_SYSMEM_FALLBACK` equivalent). Opt-out `DOTLLM_VULKAN_STRICT_DEVICE_LOCAL=1`; occurrences surfaced via `VulkanDevice.DeviceLocalFallbackCount`.
- **Docs**: `REAL-26B-RESULTS.md` (CPU + Vulkan generation results, throughput matrix vs llama.cpp), SUPERSEDED header on the stale `GEMMA4-GPU-GAPS.md`, stale `#36` guard remark fixed in `DiffusionGemmaConfigExtractor`.

## Measured (Strix Halo, same session, GPU idle-checked)
| | dotLLM Vulkan | llama.cpp Vulkan | ratio |
|---|---|---|---|
| AR decode, LLaDA-8B Q4_K_M (same file) | 28.24 tok/s | 44.85 tok/s | **0.63×** |
| 26B diffusion step | 3.90 s @ canvas 32 | 0.736 s @ canvas 256 | ~36×/canvas-token |

The diffusion gap is the dense SC soft-embed (~47 GFLOP/step at canvas 32) + host-side sampling — follow-up filed as #121 (also covers the canvas-256 `VK_ERROR_DEVICE_LOST` TDR from monolithic dispatches).

## Tests
- `VulkanWeightsQuantRepackTests` (CPU-only): Q5_0→Q5_1 dequant bit-exactness incl. ±0/subnormal scales; Q8_0 scale-fold payload/rounding invariants. Green.
- `Gemma4DiffusionVulkanTests` + `Gemma4VulkanKvCacheTests` (GPU, synthetic): green on gfx1151.
- Real-weight: CPU `DiffusionGemmaGgufForwardTests` 3/3 green; Vulkan generation test green at canvas 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
