### PR TITLE
BitNet HF-safetensors loading + CLI HF-directory support (#126)

### DIFF
--- a/src/DotLLM.Cli/Commands/ChatCommand.cs
+++ b/src/DotLLM.Cli/Commands/ChatCommand.cs
@@ -9,6 +9,7 @@ using DotLLM.Core.Models;
 using DotLLM.Engine;
 using DotLLM.Engine.Constraints;
 using DotLLM.Engine.PromptCache;
+using DotLLM.Models;
 using DotLLM.Models.Architectures;
 using DotLLM.Models.Gguf;
 using DotLLM.Tokenizers;
@@ -204,19 +205,50 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
     /// <inheritdoc/>
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
-        var resolvedPath = GgufFileResolver.Resolve(settings.Model, settings.Quant);
-        if (resolvedPath is null)
-            return 1;
+        // HuggingFace safetensors directory (config.json + *.safetensors /
+        // index.json)? Auto-detected; loads via the safetensors path. The GGUF
+        // path is unchanged.
+        string? hfDir = RunCommand.TryResolveHfDirectory(settings.Model);
+
+        string resolvedPath;
+        if (hfDir is not null)
+        {
+            resolvedPath = hfDir;
+        }
+        else
+        {
+            var ggufPath = GgufFileResolver.Resolve(settings.Model, settings.Quant);
+            if (ggufPath is null)
+                return 1;
+            resolvedPath = ggufPath;
+        }
 
         GgufFile? gguf = null;
+        IDisposable? safetensorsSource = null;
         ModelConfig? config = null;
-        Tokenizers.Bpe.BpeTokenizer? tokenizer = null;
+        ITokenizer? tokenizer = null;
         IModel? model = null;
 
         AnsiConsole.Status()
             .Spinner(Spinner.Known.Dots)
             .Start("Loading model...", ctx =>
             {
+                if (hfDir is not null)
+                {
+                    ctx.Status("Opening HuggingFace safetensors checkpoint...");
+                    var threadingCfg = new ThreadingConfig(
+                        settings.Threads, settings.DecodeThreads, settings.NumaPin, settings.PCoreOnly);
+                    var (m, src, cfg) = ModelLoader.LoadFromSafetensors(hfDir, threadingCfg);
+                    model = m;
+                    safetensorsSource = src;
+                    config = cfg;
+                    ctx.Status("Loading tokenizer...");
+                    tokenizer = ModelLoader.LoadTokenizerFromHfDirectory(hfDir)
+                        ?? throw new InvalidOperationException(
+                            $"No tokenizer.json (or legacy vocab.json/merges.txt) found in '{hfDir}'.");
+                    return;
+                }
+
                 ctx.Status("Opening GGUF file...");
                 gguf = GgufFile.Open(resolvedPath);
 
@@ -258,7 +290,12 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
         if (vramWarning is not null)
             AnsiConsole.MarkupLine($"[yellow]WARNING: {Markup.Escape(vramWarning)}[/]");
 
-        var jinjaTemplate = GgufChatTemplateFactory.TryCreate(gguf!.Metadata, tokenizer!, config!.Architecture);
+        // GGUF checkpoints carry an embedded Jinja chat template; the HF
+        // safetensors path doesn't surface one here, so it falls back to the
+        // plain completion-style transcript.
+        var jinjaTemplate = gguf is not null
+            ? GgufChatTemplateFactory.TryCreate(gguf.Metadata, tokenizer!, config!.Architecture)
+            : null;
         IChatTemplate chatTemplate = jinjaTemplate ?? GgufChatTemplateFactory.CreatePlainFallback(tokenizer!);
         if (jinjaTemplate is null)
         {
@@ -267,9 +304,15 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
                 "This usually means the model is not instruction/chat tuned.[/]");
         }
 
-        // Parse tool definitions
+        // Parse tool definitions. Tool calling relies on the GGUF-embedded chat
+        // template, so it is unavailable on the HF safetensors path.
         ToolDefinition[]? tools = ParseToolDefinitions(settings.Tools);
-        IToolCallParser? toolCallParser = tools is { Length: > 0 }
+        if (tools is { Length: > 0 } && gguf is null)
+        {
+            AnsiConsole.MarkupLine("[yellow]WARNING: --tools is not supported for HuggingFace safetensors models; ignoring.[/]");
+            tools = null;
+        }
+        IToolCallParser? toolCallParser = tools is { Length: > 0 } && gguf is not null
             ? GgufChatTemplateFactory.CreateToolCallParser(gguf.Metadata, config!.Architecture)
             : null;
         ToolChoice toolChoice = ParseToolChoice(settings.ToolChoiceStr, tools);
@@ -403,6 +446,7 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
             pagedFactory?.Dispose();
             model?.Dispose();
             gguf?.Dispose();
+            safetensorsSource?.Dispose();
         }
 
         return 0;

--- a/src/DotLLM.Cli/Commands/RunCommand.cs
+++ b/src/DotLLM.Cli/Commands/RunCommand.cs
@@ -8,6 +8,7 @@ using DotLLM.Core.Lora;
 using DotLLM.Core.Models;
 using DotLLM.Engine;
 using DotLLM.Engine.Constraints;
+using DotLLM.Models;
 using DotLLM.Models.Architectures;
 using DotLLM.Models.Gguf;
 using DotLLM.Tokenizers;
@@ -197,17 +198,49 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
             return 1;
         }
 
-        var resolvedPath = GgufFileResolver.Resolve(settings.Model, settings.Quant);
-        if (resolvedPath is null)
-            return 1;
+        // HuggingFace safetensors directory? (config.json + *.safetensors /
+        // model.safetensors.index.json). Auto-detected; loads via the
+        // safetensors path instead of GGUF. The GGUF path is unchanged.
+        string? hfDir = TryResolveHfDirectory(settings.Model);
 
-        GgufFile gguf = null!;
+        string resolvedPath;
+        if (hfDir is not null)
+        {
+            resolvedPath = hfDir;
+        }
+        else
+        {
+            var ggufPath = GgufFileResolver.Resolve(settings.Model, settings.Quant);
+            if (ggufPath is null)
+                return 1;
+            resolvedPath = ggufPath;
+        }
+
+        GgufFile? gguf = null;
+        IDisposable? safetensorsSource = null;
         ModelConfig config = null!;
-        Tokenizers.Bpe.BpeTokenizer tokenizer = null!;
+        ITokenizer tokenizer = null!;
         IModel model = null!;
 
         void LoadModel()
         {
+            if (hfDir is not null)
+            {
+                // HuggingFace safetensors checkpoint (e.g. BitNet b1.58 bf16).
+                // CPU load via the shared safetensors loader; GPU offload for
+                // this path is not wired through the CLI yet.
+                var threadingCfg = new ThreadingConfig(
+                    settings.Threads, settings.DecodeThreads, settings.NumaPin, settings.PCoreOnly);
+                var (m, src, cfg) = ModelLoader.LoadFromSafetensors(hfDir, threadingCfg);
+                model = m;
+                safetensorsSource = src;
+                config = cfg;
+                tokenizer = ModelLoader.LoadTokenizerFromHfDirectory(hfDir)
+                    ?? throw new InvalidOperationException(
+                        $"No tokenizer.json (or legacy vocab.json/merges.txt) found in '{hfDir}'.");
+                return;
+            }
+
             gguf = GgufFile.Open(resolvedPath);
             config = GgufModelConfigExtractor.Extract(gguf.Metadata);
             tokenizer = GgufBpeTokenizerFactory.Load(gguf.Metadata);
@@ -305,11 +338,22 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
         ToolDefinition[]? tools = ChatCommand.ParseToolDefinitions(settings.Tools);
         IToolCallParser? toolCallParser = null;
         string effectivePrompt = settings.Prompt;
+        if (tools is { Length: > 0 } && gguf is null)
+        {
+            // Tool calling relies on the GGUF-embedded chat template; the HF
+            // safetensors path doesn't surface one here. Fall back to the raw
+            // prompt so generation still runs.
+            if (settings.Json)
+                Console.Error.WriteLine("WARNING: --tools is not supported for HuggingFace safetensors models; ignoring.");
+            else
+                AnsiConsole.MarkupLine("[yellow]WARNING: --tools is not supported for HuggingFace safetensors models; ignoring.[/]");
+            tools = null;
+        }
         if (tools is { Length: > 0 })
         {
             string bosToken = tokenizer.DecodeToken(tokenizer.BosTokenId);
             string eosToken = tokenizer.DecodeToken(tokenizer.EosTokenId);
-            var chatTemplate = GgufChatTemplateFactory.TryCreate(gguf.Metadata, tokenizer, config.Architecture)
+            var chatTemplate = GgufChatTemplateFactory.TryCreate(gguf!.Metadata, tokenizer, config.Architecture)
                 ?? GgufChatTemplateFactory.CreatePlainFallback(tokenizer);
 
             var messages = new List<ChatMessage>
@@ -321,7 +365,7 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
                 AddGenerationPrompt = true,
                 Tools = tools
             });
-            toolCallParser = GgufChatTemplateFactory.CreateToolCallParser(gguf.Metadata, config.Architecture);
+            toolCallParser = GgufChatTemplateFactory.CreateToolCallParser(gguf!.Metadata, config.Architecture);
         }
         var toolChoice = ChatCommand.ParseToolChoice(settings.ToolChoiceStr, tools);
 
@@ -521,8 +565,19 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
             double totalTokPerSec = totalTokens > 0 ? totalTokens / (totalMs / 1000.0) : 0;
 
             // Memory metrics
-            long fileSize = new FileInfo(resolvedPath).Length;
-            long modelWeightsBytes = fileSize - gguf.DataSectionOffset;
+            long modelWeightsBytes;
+            if (gguf is not null)
+            {
+                long fileSize = new FileInfo(resolvedPath).Length;
+                modelWeightsBytes = fileSize - gguf.DataSectionOffset;
+            }
+            else
+            {
+                // HF safetensors: sum the on-disk shard sizes in the directory.
+                modelWeightsBytes = Directory
+                    .EnumerateFiles(resolvedPath, "*.safetensors", SearchOption.TopDirectoryOnly)
+                    .Sum(f => new FileInfo(f).Length);
+            }
             long computeBytes = model.ComputeMemoryBytes;
             int cacheSize = Math.Min(promptLen + settings.MaxTokens, config.MaxSequenceLength);
             // Use actual KV-cache bytes from engine timings (reflects quantization compression).
@@ -684,7 +739,8 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
                 inner.Dispose();
             pagedFactory?.Dispose();
             model.Dispose();
-            gguf.Dispose();
+            gguf?.Dispose();
+            safetensorsSource?.Dispose();
         }
 
         return 0;
@@ -746,6 +802,29 @@ internal sealed class RunCommand : AsyncCommand<RunCommand.Settings>
 
         var match = Regex.Match(Path.GetFileName(resolvedPath), @"\.(Q[\w]+)\.gguf$", RegexOptions.IgnoreCase);
         return match.Success ? match.Groups[1].Value : "unknown";
+    }
+
+    /// <summary>
+    /// Detects whether <paramref name="modelArg"/> points at a HuggingFace
+    /// safetensors checkpoint directory: an existing directory containing a
+    /// <c>config.json</c> alongside either a <c>*.safetensors</c> file or a
+    /// <c>model.safetensors.index.json</c> shard index. Returns the resolved
+    /// directory path, or <see langword="null"/> when it is not such a
+    /// directory (leaving the GGUF resolution path unchanged).
+    /// </summary>
+    internal static string? TryResolveHfDirectory(string modelArg)
+    {
+        if (string.IsNullOrEmpty(modelArg) || !Directory.Exists(modelArg))
+            return null;
+
+        if (!File.Exists(Path.Combine(modelArg, "config.json")))
+            return null;
+
+        bool hasWeights =
+            File.Exists(Path.Combine(modelArg, "model.safetensors.index.json"))
+            || Directory.EnumerateFiles(modelArg, "*.safetensors", SearchOption.TopDirectoryOnly).Any();
+
+        return hasWeights ? Path.GetFullPath(modelArg) : null;
     }
 
     private static int ResolveGpuLayers(Settings settings, ModelConfig config)

--- a/src/DotLLM.Cpu/Kernels/BitNetQuantize.cs
+++ b/src/DotLLM.Cpu/Kernels/BitNetQuantize.cs
@@ -1,0 +1,64 @@
+using System.Runtime.CompilerServices;
+
+namespace DotLLM.Cpu.Kernels;
+
+/// <summary>
+/// BitNet b1.58 weight quantization: converts full-precision (f32, typically up-cast from the HF
+/// bf16 checkpoint) weights into the I2_S ternary packed format consumed by
+/// <see cref="Dequantize.DequantizeI2_S"/>.
+/// <para>
+/// Mirrors transformers' per-tensor absmean <c>WeightQuant</c>: <c>scale = mean(|w|)</c> (clamped
+/// ≥ 1e-5), ternary <c>t = clamp(round(w / scale), -1, 1)</c>, dequantized value <c>t · scale</c>.
+/// Packing is the exact inverse of the dequant kernel: 128-element blocks → 32 bytes; within a
+/// block the byte at <c>gp</c> (0..31) holds elements {gp, +32, +64, +96} at bit offsets {6,4,2,0};
+/// the 2-bit code is <c>t + 1</c> (so decode <c>(code - 1) · scale</c>). A single f32 per-tensor
+/// scale is appended at byte offset <c>count / 4</c>.
+/// </para>
+/// </summary>
+public static class BitNetQuantize
+{
+    /// <summary>
+    /// Quantizes <paramref name="count"/> row-major f32 weights into I2_S packed bytes written to
+    /// <paramref name="dest"/>. <paramref name="count"/> must be a multiple of 128;
+    /// <paramref name="dest"/> length must be at least <c>count / 4 + sizeof(float)</c>.
+    /// </summary>
+    /// <param name="weights">Source f32 weights (length ≥ <paramref name="count"/>).</param>
+    /// <param name="count">Number of weights to quantize (multiple of 128).</param>
+    /// <param name="dest">Destination for packed codes (count/4 bytes) + trailing f32 scale.</param>
+    public static void QuantizeToI2S(ReadOnlySpan<float> weights, long count, Span<byte> dest)
+    {
+        if (count % Dequantize.I2SBlockSize != 0)
+            throw new ArgumentException(
+                $"I2_S element count must be a multiple of {Dequantize.I2SBlockSize}, got {count}",
+                nameof(count));
+        if (weights.Length < count)
+            throw new ArgumentException($"weights too small: {weights.Length} < {count}", nameof(weights));
+
+        int n = checked((int)count);
+        int packedBytes = n / 4;
+        if (dest.Length < packedBytes + sizeof(float))
+            throw new ArgumentException(
+                $"dest too small: {dest.Length} < {packedBytes + sizeof(float)}", nameof(dest));
+
+        // Per-tensor absmean scale (clamped like transformers WeightQuant).
+        double sum = 0;
+        for (int i = 0; i < n; i++) sum += Math.Abs(weights[i]);
+        float scale = (float)Math.Max(sum / count, 1e-5);
+
+        dest[..packedBytes].Clear(); // codes are OR-ed in, so start from zero
+
+        for (int i = 0; i < n; i++)
+        {
+            int ternary = Math.Clamp((int)MathF.Round(weights[i] / scale), -1, 1);
+            int code = ternary + 1; // {-1,0,+1} → {0,1,2}
+            int block = i / Dequantize.I2SBlockSize;
+            int p = i % Dequantize.I2SBlockSize;
+            int gp = p % 32;
+            int slot = p / 32;            // 0..3
+            int bitOffset = 6 - 2 * slot; // {6,4,2,0}
+            dest[block * 32 + gp] |= (byte)(code << bitOffset);
+        }
+
+        Unsafe.WriteUnaligned(ref dest[packedBytes], scale);
+    }
+}

--- a/src/DotLLM.Models/Architectures/TransformerWeightsSafetensors.cs
+++ b/src/DotLLM.Models/Architectures/TransformerWeightsSafetensors.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using DotLLM.Core.Configuration;
 using DotLLM.Core.Models;
+using DotLLM.Cpu.Kernels;
 using DotLLM.Models.SafeTensors;
 using static DotLLM.Models.Architectures.SafetensorsTensorResolver;
 
@@ -56,11 +57,14 @@ internal static class TransformerWeightsSafetensorsLoader
                                    is DotLLM.Core.Configuration.Architecture.DeepSeekV2
                                    or DotLLM.Core.Configuration.Architecture.DeepSeekV3
                                  && config.MlaConfig is not null;
+            bool isBitNet = config.Architecture is DotLLM.Core.Configuration.Architecture.BitNet;
             for (int i = 0; i < config.NumLayers; i++)
             {
                 layers[i] = isDeepSeekMla
                     ? LoadDeepSeekMlaLayer(i, file, config, owned)
-                    : LoadLayer(i, file, config, owned);
+                    : isBitNet
+                        ? LoadBitNetLayer(i, file, config, owned)
+                        : LoadLayer(i, file, config, owned);
             }
 
             // Final RMSNorm
@@ -254,6 +258,129 @@ internal static class TransformerWeightsSafetensorsLoader
             moe: null,
             mla: null,
             postAttnNormWeight: postAttnNorm, postFfnNormWeight: postFfnNorm);
+    }
+
+    /// <summary>
+    /// Loads one BitNet b1.58 transformer layer from an HF safetensors
+    /// checkpoint. Unlike <see cref="LoadLayer"/> (which keeps linears at
+    /// F32/F16), every linear projection here is quantized to ternary
+    /// <see cref="QuantizationType.I2_S"/> at load via
+    /// <see cref="DotLLM.Cpu.Kernels.BitNetQuantize.QuantizeToI2S"/> — mirroring
+    /// what the GGUF BitNet path receives pre-quantized from Microsoft's
+    /// converter. The two BitNet Sub-LN norms
+    /// (<c>self_attn.attn_sub_norm.weight</c> over the attention output before
+    /// <c>o_proj</c>, and <c>mlp.ffn_sub_norm.weight</c> over the gated
+    /// intermediate before <c>down_proj</c>) are wired into
+    /// <see cref="TransformerLayerWeights.AttnSubNormWeight"/> /
+    /// <see cref="TransformerLayerWeights.FfnSubNormWeight"/> so the forward
+    /// pass applies Sub-LN exactly as it does for GGUF. The squared-ReLU FFN is
+    /// selected by <see cref="ModelConfig.ActivationFunction"/> = ReluSquared.
+    /// </summary>
+    private static TransformerLayerWeights LoadBitNetLayer(
+        int layerIdx, ISafetensorsTensorSource file, ModelConfig config, List<nint> owned)
+    {
+        string prefix = $"model.layers.{layerIdx}";
+        int hiddenSize = config.HiddenSize;
+        int intermediateSize = config.IntermediateSize;
+        int qDim = config.NumAttentionHeads * config.HeadDim;
+        int kvDim = config.NumKvHeads * config.HeadDim;
+
+        // Pre-attention RMSNorm.
+        float[] attnNorm = ResolveNorm(file, $"{prefix}.input_layernorm.weight", hiddenSize);
+
+        // Attention projections — quantized to ternary I2_S.
+        var (qPtr, qQt, qM, qK) = ResolveLinearAsI2S(file, $"{prefix}.self_attn.q_proj.weight", owned);
+        var (kPtr, kQt, kM, kK) = ResolveLinearAsI2S(file, $"{prefix}.self_attn.k_proj.weight", owned);
+        var (vPtr, vQt, vM, vK) = ResolveLinearAsI2S(file, $"{prefix}.self_attn.v_proj.weight", owned);
+        var (oPtr, oQt, oM, oK) = ResolveLinearAsI2S(file, $"{prefix}.self_attn.o_proj.weight", owned);
+        ValidateProjectionShape(qM, qK, qDim, hiddenSize, $"{prefix}.self_attn.q_proj.weight");
+        ValidateProjectionShape(kM, kK, kvDim, hiddenSize, $"{prefix}.self_attn.k_proj.weight");
+        ValidateProjectionShape(vM, vK, kvDim, hiddenSize, $"{prefix}.self_attn.v_proj.weight");
+        ValidateProjectionShape(oM, oK, hiddenSize, qDim, $"{prefix}.self_attn.o_proj.weight");
+
+        // BitNet attention Sub-LN — RMSNorm over the attention output [hidden]
+        // before o_proj.
+        float[] attnSubNorm = ResolveNorm(file, $"{prefix}.self_attn.attn_sub_norm.weight", hiddenSize);
+
+        // Pre-FFN RMSNorm.
+        float[] ffnNorm = ResolveNorm(file, $"{prefix}.post_attention_layernorm.weight", hiddenSize);
+
+        // BitNet FFN Sub-LN — RMSNorm over the gated intermediate [intermediate]
+        // before down_proj.
+        float[] ffnSubNorm = ResolveNorm(file, $"{prefix}.mlp.ffn_sub_norm.weight", intermediateSize);
+
+        // Dense SwiGLU-shaped FFN projections — quantized to ternary I2_S.
+        var (gatePtr, gateQt, gateM, gateK) = ResolveLinearAsI2S(file, $"{prefix}.mlp.gate_proj.weight", owned);
+        var (upPtr, upQt, upM, upK) = ResolveLinearAsI2S(file, $"{prefix}.mlp.up_proj.weight", owned);
+        var (downPtr, downQt, downM, downK) = ResolveLinearAsI2S(file, $"{prefix}.mlp.down_proj.weight", owned);
+        ValidateProjectionShape(gateM, gateK, intermediateSize, hiddenSize, $"{prefix}.mlp.gate_proj.weight");
+        ValidateProjectionShape(upM, upK, intermediateSize, hiddenSize, $"{prefix}.mlp.up_proj.weight");
+        ValidateProjectionShape(downM, downK, hiddenSize, intermediateSize, $"{prefix}.mlp.down_proj.weight");
+
+        return new TransformerLayerWeights(
+            attnNorm,
+            qPtr, qQt, qM, qK,
+            kPtr, kQt, kM, kK,
+            vPtr, vQt, vM, vK,
+            oPtr, oQt, oM, oK,
+            ffnNorm,
+            gatePtr, gateQt, gateM, gateK,
+            upPtr, upQt, upM, upK,
+            downPtr, downQt, downM, downK,
+            qBias: null, kBias: null, vBias: null, oBias: null,
+            gateBias: null, upBias: null, downBias: null,
+            qNormWeight: null, kNormWeight: null,
+            moe: null,
+            mla: null,
+            postAttnNormWeight: null, postFfnNormWeight: null,
+            gemma4: null,
+            attnSubNormWeight: attnSubNorm, ffnSubNormWeight: ffnSubNorm);
+    }
+
+    /// <summary>
+    /// Resolves a rank-2 projection weight and quantizes it to ternary
+    /// <see cref="QuantizationType.I2_S"/> for BitNet. The source tensor is
+    /// first upcast to F32 (BF16/F16 → owned scratch, F32 → zero-copy mmap),
+    /// then <see cref="DotLLM.Cpu.Kernels.BitNetQuantize.QuantizeToI2S"/>
+    /// packs it into a fresh 64-byte-aligned buffer of
+    /// <c>m*k/4 + sizeof(float)</c> bytes (registered in
+    /// <paramref name="owned"/>). Any temporary F32 upcast buffer is freed
+    /// once the packed I2_S buffer exists. The element count (<c>m*k</c>) must
+    /// be a multiple of 128 — always true for real BitNet dims.
+    /// </summary>
+    private static unsafe (nint ptr, QuantizationType qt, int m, int k) ResolveLinearAsI2S(
+        ISafetensorsTensorSource file, string name, List<nint> owned)
+    {
+        // Upcast to F32 first (temporary — freed below once packed).
+        var temp = new List<nint>();
+        var (f32Ptr, _, m, k) = ResolveLinearAsF32(file, name, temp);
+        try
+        {
+            long count = (long)m * k;
+            if (count % 128 != 0)
+                throw new InvalidDataException(
+                    $"BitNet linear '{name}' element count {count} (shape [{m},{k}]) is not a "
+                    + "multiple of 128; I2_S ternary quantization requires 128-element blocks.");
+
+            long packedBytes = count / 4;
+            nuint destBytes = checked((nuint)(packedBytes + sizeof(float)));
+            nint dst = (nint)NativeMemory.AlignedAlloc(destBytes, 64);
+            owned.Add(dst);
+
+            BitNetQuantize.QuantizeToI2S(
+                new ReadOnlySpan<float>((void*)f32Ptr, checked((int)count)),
+                count,
+                new Span<byte>((void*)dst, checked((int)destBytes)));
+
+            return (dst, QuantizationType.I2_S, m, k);
+        }
+        finally
+        {
+            // Free any temporary F32 upcast scratch (BF16/F16 source). An F32
+            // source is a zero-copy mmap view and won't be in `temp`.
+            foreach (var p in temp)
+                NativeMemory.AlignedFree((void*)p);
+        }
     }
 
     /// <summary>

--- a/src/DotLLM.Models/ModelLoader.cs
+++ b/src/DotLLM.Models/ModelLoader.cs
@@ -127,6 +127,13 @@ public static class ModelLoader
                     or Architecture.SmolLM3
                     or Architecture.Gemma3 or Architecture.Gemma4
                     or Architecture.DiffusionGemma
+                    // BitNet b1.58 reuses the standard TransformerModel tower: the
+                    // safetensors loader quantizes each linear projection to ternary
+                    // I2_S (BitNetQuantize) and wires the attention/FFN Sub-LN weights,
+                    // while the forward pass honours the squared-ReLU FFN + Sub-LN from
+                    // the ModelConfig (ActivationFunction.ReluSquared + the Sub-LN
+                    // weights being present) — exactly as the GGUF BitNet path does.
+                    or Architecture.BitNet
                     // DiffusionGemma reuses the Gemma-4 MoE transformer tower verbatim
                     // (same forward path, same safetensors loader). The diffusion decode
                     // seam is NOT a model concern — it lives in DiffusionTextGenerator,
@@ -138,7 +145,7 @@ public static class ModelLoader
                     => Mamba3TransformerModel.LoadFromSafetensors(source, config),
                 _ => throw new NotSupportedException(
                     $"Safetensors loader does not yet dispatch architecture {config.Architecture}. "
-                    + "Supported today: Llama, Mistral, Phi, Qwen, Mixtral, QwenMoe, GraniteMoe, DeepSeekV2, DeepSeekV3, SmolLM3, Gemma3, Gemma4, DiffusionGemma, Mamba3."),
+                    + "Supported today: Llama, Mistral, Phi, Qwen, Mixtral, QwenMoe, GraniteMoe, DeepSeekV2, DeepSeekV3, SmolLM3, Gemma3, Gemma4, DiffusionGemma, BitNet, Mamba3."),
             };
 
             return (model, source, config);

--- a/src/DotLLM.Models/SafeTensors/HfConfigExtractor.cs
+++ b/src/DotLLM.Models/SafeTensors/HfConfigExtractor.cs
@@ -110,6 +110,9 @@ public static class HfConfigExtractor
         float? finalLogitSoftcap = null;
         float? queryPreAttnScalar = null;
         ActivationFunction activation = ActivationFunction.SiLU;
+        // BitNet b1.58 uses the squared-ReLU FFN (relu2), mirroring the GGUF path.
+        if (architecture == Architecture.BitNet)
+            activation = ActivationFunction.ReluSquared;
         if (architecture == Architecture.Gemma3)
         {
             // Default sliding_window for Gemma3 if not specified (HF default is 4096).
@@ -666,6 +669,9 @@ public static class HfConfigExtractor
             (_, "mistral") => Architecture.Mistral,
             (_, "phi" or "phi3" or "phi2") => Architecture.Phi,
             (_, "qwen" or "qwen2" or "qwen3") => Architecture.Qwen,
+            // Microsoft BitNet b1.58 — `BitNetForCausalLM` / `model_type=bitnet`.
+            (var a, _) when a is not null && a.Contains("bitnet") => Architecture.BitNet,
+            (_, "bitnet") => Architecture.BitNet,
             _ => throw new InvalidDataException(
                 $"Unsupported HF architecture: architectures[0]='{archName}', model_type='{modelType}'.")
         };

--- a/tests/DotLLM.Tests.Integration/Models/Loaders/SyntheticBitNetSafetensorsLoadTests.cs
+++ b/tests/DotLLM.Tests.Integration/Models/Loaders/SyntheticBitNetSafetensorsLoadTests.cs
@@ -1,0 +1,227 @@
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Tensors;
+using DotLLM.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Integration.Models.Loaders;
+
+/// <summary>
+/// End-to-end verification that <see cref="ModelLoader.LoadFromSafetensors(string, System.Nullable{ThreadingConfig})"/>
+/// can open a synthetic BitNet b1.58 HuggingFace checkpoint directory
+/// (<c>config.json</c> + <c>model.safetensors</c>) and run a forward pass that
+/// produces finite vocab-sized logits.
+/// </summary>
+/// <remarks>
+/// <para>
+/// No download — the fixture is written in-code (mirroring the byte-accurate
+/// safetensors layout: LE u64 header length, UTF-8 JSON header, raw row-major
+/// data region). The linear projections are bf16 (as in the real
+/// <c>microsoft/bitnet-b1.58-2B-4T-bf16</c> checkpoint); the loader quantizes
+/// each of them to ternary I2_S at load. Norms + Sub-LN weights are F32.
+/// </para>
+/// <para>
+/// We are proving the loading plumbing end-to-end — HfConfigExtractor detects
+/// BitNet + squared-ReLU, the tensor names resolve, every linear becomes I2_S,
+/// the attn/ffn Sub-LN wire up, tie_word_embeddings aliases the LM head, and
+/// the forward returns <c>[seq, vocab]</c> logits without NaN/Inf. We are NOT
+/// asserting semantic output quality (random weights → random logits).
+/// Numerical parity against the real bf16 checkpoint is out of scope here and
+/// must be validated separately with the cached
+/// <c>microsoft/bitnet-b1.58-2B-4T-bf16</c>.
+/// </para>
+/// </remarks>
+public sealed class SyntheticBitNetSafetensorsLoadTests : IDisposable
+{
+    // hidden=128 keeps every linear's element count a multiple of 128, which
+    // the I2_S ternary packer requires (128-element blocks).
+    private const int Hidden = 128;
+    private const int NumHeads = 4;
+    private const int NumKvHeads = 2;
+    private const int HeadDim = 32;
+    private const int Intermediate = 256;
+    private const int Vocab = 64;
+    private const int NumLayers = 2;
+
+    private readonly string _scratch;
+    private readonly ITestOutputHelper _output;
+
+    public SyntheticBitNetSafetensorsLoadTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _scratch = Path.Combine(Path.GetTempPath(), $"dotllm-bitnet-it-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void LoadAndForwardPass_ProducesFiniteVocabLogits()
+    {
+        WriteSafetensors();
+        WriteConfigJson();
+
+        var (model, source, config) = ModelLoader.LoadFromSafetensors(_scratch);
+        try
+        {
+            _output.WriteLine(
+                $"Config: arch={config.Architecture} act={config.ActivationFunction} "
+              + $"vocab={config.VocabSize} hidden={config.HiddenSize} layers={config.NumLayers} "
+              + $"heads={config.NumAttentionHeads} kv_heads={config.NumKvHeads} head_dim={config.HeadDim} "
+              + $"intermediate={config.IntermediateSize} tied={config.TiedEmbeddings}");
+
+            Assert.Equal(Architecture.BitNet, config.Architecture);
+            Assert.Equal(ActivationFunction.ReluSquared, config.ActivationFunction);
+            Assert.Equal(Vocab, config.VocabSize);
+            Assert.Equal(Hidden, config.HiddenSize);
+            Assert.Equal(NumLayers, config.NumLayers);
+            Assert.True(config.TiedEmbeddings);
+
+            int[] tokenIds = [0, 1, 2];
+            int[] positions = [0, 1, 2];
+            using ITensor logits = model.Forward(tokenIds, positions, deviceId: -1);
+
+            Assert.Equal(2, logits.Shape.Rank);
+            Assert.Equal(tokenIds.Length, logits.Shape[0]);
+            Assert.Equal(config.VocabSize, logits.Shape[1]);
+            AssertAllFinite(logits);
+        }
+        finally
+        {
+            model.Dispose();
+            source.Dispose();
+        }
+    }
+
+    private void WriteConfigJson()
+    {
+        string json = $$"""
+        {
+          "architectures": ["BitNetForCausalLM"],
+          "model_type": "bitnet",
+          "hidden_act": "relu2",
+          "hidden_size": {{Hidden}},
+          "intermediate_size": {{Intermediate}},
+          "num_hidden_layers": {{NumLayers}},
+          "num_attention_heads": {{NumHeads}},
+          "num_key_value_heads": {{NumKvHeads}},
+          "head_dim": {{HeadDim}},
+          "vocab_size": {{Vocab}},
+          "max_position_embeddings": 128,
+          "rms_norm_eps": 1e-5,
+          "rope_theta": 500000.0,
+          "tie_word_embeddings": true
+        }
+        """;
+        File.WriteAllText(Path.Combine(_scratch, "config.json"), json);
+    }
+
+    private void WriteSafetensors()
+    {
+        var rng = new Random(126);
+        var tensors = new List<(string Name, string DType, int[] Shape, byte[] Bytes)>();
+
+        tensors.Add(("model.embed_tokens.weight", "F32", [Vocab, Hidden], F32(rng, Vocab * Hidden, 0.05f)));
+        tensors.Add(("model.norm.weight", "F32", [Hidden], Ones(Hidden)));
+
+        for (int i = 0; i < NumLayers; i++)
+        {
+            string p = $"model.layers.{i}";
+            tensors.Add(($"{p}.input_layernorm.weight", "F32", [Hidden], Ones(Hidden)));
+            tensors.Add(($"{p}.post_attention_layernorm.weight", "F32", [Hidden], Ones(Hidden)));
+
+            tensors.Add(($"{p}.self_attn.q_proj.weight", "BF16", [NumHeads * HeadDim, Hidden], Bf16(rng, NumHeads * HeadDim * Hidden)));
+            tensors.Add(($"{p}.self_attn.k_proj.weight", "BF16", [NumKvHeads * HeadDim, Hidden], Bf16(rng, NumKvHeads * HeadDim * Hidden)));
+            tensors.Add(($"{p}.self_attn.v_proj.weight", "BF16", [NumKvHeads * HeadDim, Hidden], Bf16(rng, NumKvHeads * HeadDim * Hidden)));
+            tensors.Add(($"{p}.self_attn.o_proj.weight", "BF16", [Hidden, NumHeads * HeadDim], Bf16(rng, Hidden * NumHeads * HeadDim)));
+            tensors.Add(($"{p}.self_attn.attn_sub_norm.weight", "F32", [Hidden], Ones(Hidden)));
+
+            tensors.Add(($"{p}.mlp.gate_proj.weight", "BF16", [Intermediate, Hidden], Bf16(rng, Intermediate * Hidden)));
+            tensors.Add(($"{p}.mlp.up_proj.weight", "BF16", [Intermediate, Hidden], Bf16(rng, Intermediate * Hidden)));
+            tensors.Add(($"{p}.mlp.down_proj.weight", "BF16", [Hidden, Intermediate], Bf16(rng, Hidden * Intermediate)));
+            tensors.Add(($"{p}.mlp.ffn_sub_norm.weight", "F32", [Intermediate], Ones(Intermediate)));
+        }
+
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = false }))
+        {
+            w.WriteStartObject();
+            long offset = 0;
+            foreach (var (name, dtype, shape, bytes) in tensors)
+            {
+                w.WriteStartObject(name);
+                w.WriteString("dtype", dtype);
+                w.WritePropertyName("shape");
+                w.WriteStartArray();
+                foreach (var d in shape) w.WriteNumberValue(d);
+                w.WriteEndArray();
+                w.WritePropertyName("data_offsets");
+                w.WriteStartArray();
+                w.WriteNumberValue(offset);
+                w.WriteNumberValue(offset + bytes.Length);
+                w.WriteEndArray();
+                w.WriteEndObject();
+                offset += bytes.Length;
+            }
+            w.WriteEndObject();
+        }
+
+        byte[] headerJson = ms.ToArray();
+        using var fs = new FileStream(
+            Path.Combine(_scratch, "model.safetensors"), FileMode.Create, FileAccess.Write, FileShare.None);
+        Span<byte> prefix = stackalloc byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(prefix, (ulong)headerJson.Length);
+        fs.Write(prefix);
+        fs.Write(headerJson);
+        foreach (var (_, _, _, bytes) in tensors)
+            fs.Write(bytes);
+    }
+
+    private static byte[] F32(Random rng, int n, float scale)
+    {
+        var bytes = new byte[(long)n * sizeof(float)];
+        for (int i = 0; i < n; i++)
+        {
+            float v = (float)((rng.NextDouble() * 2.0 - 1.0) * scale);
+            BinaryPrimitives.WriteSingleLittleEndian(bytes.AsSpan(i * 4, 4), v);
+        }
+        return bytes;
+    }
+
+    private static byte[] Ones(int n)
+    {
+        var bytes = new byte[(long)n * sizeof(float)];
+        for (int i = 0; i < n; i++)
+            BinaryPrimitives.WriteSingleLittleEndian(bytes.AsSpan(i * 4, 4), 1.0f);
+        return bytes;
+    }
+
+    private static byte[] Bf16(Random rng, int n)
+    {
+        var bytes = new byte[(long)n * 2];
+        for (int i = 0; i < n; i++)
+        {
+            float v = (float)((rng.NextDouble() * 2.0 - 1.0) * 0.05);
+            uint bits = Unsafe.As<float, uint>(ref v);
+            ushort bf16 = (ushort)(bits >> 16); // truncate to high 16 bits
+            bytes[i * 2] = (byte)(bf16 & 0xFF);
+            bytes[i * 2 + 1] = (byte)(bf16 >> 8);
+        }
+        return bytes;
+    }
+
+    private static unsafe void AssertAllFinite(ITensor logits)
+    {
+        int n = 1;
+        for (int i = 0; i < logits.Shape.Rank; i++) n *= logits.Shape[i];
+        var span = new ReadOnlySpan<float>((void*)logits.DataPointer, n);
+        for (int i = 0; i < span.Length; i++)
+            Assert.True(float.IsFinite(span[i]), $"Logit index {i} is non-finite ({span[i]}).");
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/BitNetQuantizeI2STests.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/BitNetQuantizeI2STests.cs
@@ -1,0 +1,69 @@
+using System;
+using DotLLM.Core.Configuration;
+using DotLLM.Cpu.Kernels;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Cpu.Kernels;
+
+/// <summary>
+/// Verifies BitNet I2_S quantization (f32 → ternary I2_S) round-trips through the production
+/// <see cref="Dequantize.DequantizeI2_S"/> kernel, matching transformers' absmean WeightQuant
+/// semantics (scale = mean(|w|); q = clamp(round(w/scale), -1, 1); dequant = q·scale) and the
+/// exact interleaved 128-element block bit-packing (byte gp holds elements {gp,+32,+64,+96}).
+/// </summary>
+public sealed unsafe class BitNetQuantizeI2STests
+{
+    [Fact]
+    public void QuantizeToI2S_RoundTripsThroughDequantize_MatchesAbsmeanTernary()
+    {
+        const int count = 256; // 2 I2_S blocks
+        var rng = new Random(unchecked((int)0xB17BE7));
+        var w = new float[count];
+        for (int i = 0; i < count; i++) w[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+
+        // Reference: transformers BitNet WeightQuant (per-tensor absmean).
+        double mean = 0;
+        for (int i = 0; i < count; i++) mean += Math.Abs(w[i]);
+        mean /= count;
+        float scale = (float)Math.Max(mean, 1e-5);
+        var expected = new float[count];
+        for (int i = 0; i < count; i++)
+            expected[i] = Math.Clamp((float)Math.Round(w[i] / scale), -1f, 1f) * scale;
+
+        var packed = new byte[count / 4 + sizeof(float)];
+        BitNetQuantize.QuantizeToI2S(w, count, packed);
+
+        var got = new float[count];
+        fixed (byte* p = packed)
+            Dequantize.ToFloat32((nint)p, count, QuantizationType.I2_S, got);
+
+        for (int i = 0; i < count; i++)
+            Assert.Equal(expected[i], got[i], 4);
+    }
+
+    [Fact]
+    public void QuantizeToI2S_PacksElementsAtCorrectInterleavedPositions()
+    {
+        // One 128-element block. The kernel decodes byte 0 → elements {0,+32,+64,+96}
+        // at bit offsets {6,4,2,0}; this test pins that interleaving.
+        const int count = 128;
+        var w = new float[count];
+        w[0] = 2.0f;   // → +1 ternary
+        w[32] = -2.0f; // → -1 ternary
+        w[96] = 2.0f;  // → +1 ternary
+        float scale = 6f / 128f; // mean(|w|) = (2+2+2)/128
+
+        var packed = new byte[count / 4 + sizeof(float)];
+        BitNetQuantize.QuantizeToI2S(w, count, packed);
+
+        var got = new float[count];
+        fixed (byte* p = packed)
+            Dequantize.ToFloat32((nint)p, count, QuantizationType.I2_S, got);
+
+        Assert.Equal(scale, got[0], 5);
+        Assert.Equal(-scale, got[32], 5);
+        Assert.Equal(scale, got[96], 5);
+        Assert.Equal(0f, got[1], 5);
+        Assert.Equal(0f, got[64], 5);
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Models/SafeTensors/BitNetSafetensorsLoadTests.cs
+++ b/tests/DotLLM.Tests.Unit/Models/SafeTensors/BitNetSafetensorsLoadTests.cs
@@ -1,0 +1,188 @@
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Models;
+using DotLLM.Core.Tensors;
+using DotLLM.Models;
+using DotLLM.Models.SafeTensors;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Models.SafeTensors;
+
+/// <summary>
+/// Synthetic-fixture tests for the BitNet b1.58 HuggingFace safetensors load
+/// path, driven end-to-end through <see cref="ModelLoader.LoadFromSafetensors(string, System.Nullable{ThreadingConfig})"/>.
+/// A tiny BitNet-shaped checkpoint (bf16 linears, F32 norms + Sub-LN weights)
+/// plus a <c>config.json</c> (<c>model_type=bitnet</c>, <c>hidden_act=relu2</c>)
+/// is written to a scratch directory, then loaded via the public dispatch.
+/// Verifies that:
+/// <list type="bullet">
+///   <item><see cref="HfConfigExtractor"/> detects <see cref="Architecture.BitNet"/>
+///     and sets the squared-ReLU FFN;</item>
+///   <item>the loader quantizes every linear projection to
+///     <see cref="QuantizationType.I2_S"/> (ternary) instead of NotSupported-ing;</item>
+///   <item>tie_word_embeddings aliases the embedding matrix as the LM head; and</item>
+///   <item>a forward pass produces finite <c>[seq, vocab]</c> logits.</item>
+/// </list>
+/// </summary>
+public sealed class BitNetSafetensorsLoadTests : IDisposable
+{
+    // hidden=128 makes every linear's element count a multiple of 128 (I2_S
+    // requires 128-element blocks) — at least one dim of every projection is
+    // the hidden size.
+    private const int Hidden = 128;
+    private const int NumHeads = 4;
+    private const int NumKvHeads = 2;
+    private const int HeadDim = 32;
+    private const int Intermediate = 256;
+    private const int Vocab = 64;
+    private const int NumLayers = 2;
+
+    private readonly string _scratch;
+
+    public BitNetSafetensorsLoadTests()
+    {
+        _scratch = Path.Combine(Path.GetTempPath(), $"dotllm-bitnet-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void LoadAndForward_ProducesFiniteVocabLogits_WithI2SAndSubLn()
+    {
+        BuildBitNetFixture();
+        WriteConfigJson();
+
+        var (model, source, config) = ModelLoader.LoadFromSafetensors(_scratch);
+        try
+        {
+            Assert.Equal(Architecture.BitNet, config.Architecture);
+            Assert.Equal(ActivationFunction.ReluSquared, config.ActivationFunction);
+            Assert.Equal(Vocab, config.VocabSize);
+            Assert.Equal(Hidden, config.HiddenSize);
+            Assert.Equal(NumLayers, config.NumLayers);
+            Assert.True(config.TiedEmbeddings);
+
+            using var logits = model.Forward(
+                tokenIds: [0, 1, 2],
+                positions: [0, 1, 2],
+                deviceId: -1);
+
+            Assert.Equal(2, logits.Shape.Rank);
+            Assert.Equal(3, logits.Shape[0]);
+            Assert.Equal(Vocab, logits.Shape[1]);
+            AssertAllFinite(logits);
+        }
+        finally
+        {
+            model.Dispose();
+            source.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Writes a tiny BitNet fixture: bf16 linears (q/k/v/o + gate/up/down),
+    /// F32 norms and Sub-LN weights, tied embeddings (no lm_head).
+    /// </summary>
+    private void BuildBitNetFixture()
+    {
+        var rng = new Random(58);
+        var b = new SafetensorsFixtureBuilder();
+
+        b.AddFloat32("model.embed_tokens.weight", [Vocab, Hidden], RandomVec(rng, Vocab * Hidden, 0.05f));
+        b.AddFloat32("model.norm.weight", [Hidden], Ones(Hidden));
+
+        for (int i = 0; i < NumLayers; i++)
+        {
+            string p = $"model.layers.{i}";
+            b.AddFloat32($"{p}.input_layernorm.weight", [Hidden], Ones(Hidden));
+            b.AddFloat32($"{p}.post_attention_layernorm.weight", [Hidden], Ones(Hidden));
+
+            AddBf16($"{p}.self_attn.q_proj.weight", [NumHeads * HeadDim, Hidden], b, rng);
+            AddBf16($"{p}.self_attn.k_proj.weight", [NumKvHeads * HeadDim, Hidden], b, rng);
+            AddBf16($"{p}.self_attn.v_proj.weight", [NumKvHeads * HeadDim, Hidden], b, rng);
+            AddBf16($"{p}.self_attn.o_proj.weight", [Hidden, NumHeads * HeadDim], b, rng);
+            // BitNet Sub-LN over the attention output before o_proj.
+            b.AddFloat32($"{p}.self_attn.attn_sub_norm.weight", [Hidden], Ones(Hidden));
+
+            AddBf16($"{p}.mlp.gate_proj.weight", [Intermediate, Hidden], b, rng);
+            AddBf16($"{p}.mlp.up_proj.weight", [Intermediate, Hidden], b, rng);
+            AddBf16($"{p}.mlp.down_proj.weight", [Hidden, Intermediate], b, rng);
+            // BitNet Sub-LN over the gated intermediate before down_proj.
+            b.AddFloat32($"{p}.mlp.ffn_sub_norm.weight", [Intermediate], Ones(Intermediate));
+        }
+
+        b.WriteTo(Path.Combine(_scratch, "model.safetensors"));
+    }
+
+    private void WriteConfigJson()
+    {
+        string json = $$"""
+        {
+          "architectures": ["BitNetForCausalLM"],
+          "model_type": "bitnet",
+          "hidden_act": "relu2",
+          "hidden_size": {{Hidden}},
+          "intermediate_size": {{Intermediate}},
+          "num_hidden_layers": {{NumLayers}},
+          "num_attention_heads": {{NumHeads}},
+          "num_key_value_heads": {{NumKvHeads}},
+          "head_dim": {{HeadDim}},
+          "vocab_size": {{Vocab}},
+          "max_position_embeddings": 128,
+          "rms_norm_eps": 1e-5,
+          "rope_theta": 500000.0,
+          "tie_word_embeddings": true
+        }
+        """;
+        File.WriteAllText(Path.Combine(_scratch, "config.json"), json);
+    }
+
+    private static void AddBf16(string name, int[] shape, SafetensorsFixtureBuilder b, Random rng)
+    {
+        long n = 1;
+        for (int i = 0; i < shape.Length; i++) n *= shape[i];
+        var bytes = new byte[n * 2];
+        for (long i = 0; i < n; i++)
+        {
+            // Small-amplitude values so the absmean ternary scale is well
+            // conditioned; encoded as bf16 (high 16 bits of the f32 bit pattern).
+            float v = (float)((rng.NextDouble() * 2.0 - 1.0) * 0.05);
+            uint bits = System.Runtime.CompilerServices.Unsafe.As<float, uint>(ref v);
+            ushort bf16 = (ushort)(bits >> 16);
+            bytes[i * 2] = (byte)(bf16 & 0xFF);
+            bytes[i * 2 + 1] = (byte)(bf16 >> 8);
+        }
+        b.AddRaw(name, "BF16", shape, bytes);
+    }
+
+    private static float[] RandomVec(Random rng, int n, float scale)
+    {
+        var v = new float[n];
+        for (int i = 0; i < n; i++)
+            v[i] = (float)((rng.NextDouble() * 2.0 - 1.0) * scale);
+        return v;
+    }
+
+    private static float[] Ones(int n)
+    {
+        var v = new float[n];
+        for (int i = 0; i < n; i++) v[i] = 1.0f;
+        return v;
+    }
+
+    private static unsafe void AssertAllFinite(ITensor logits)
+    {
+        int n = 1;
+        for (int i = 0; i < logits.Shape.Rank; i++)
+            n *= logits.Shape[i];
+        var span = new ReadOnlySpan<float>((void*)logits.DataPointer, n);
+        for (int i = 0; i < span.Length; i++)
+        {
+            float v = span[i];
+            Assert.True(float.IsFinite(v), $"Logit index {i} is non-finite ({v}).");
+        }
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Models/SafeTensors/HfConfigExtractorBitNetTests.cs
+++ b/tests/DotLLM.Tests.Unit/Models/SafeTensors/HfConfigExtractorBitNetTests.cs
@@ -1,0 +1,61 @@
+using DotLLM.Core.Configuration;
+using DotLLM.Models.SafeTensors;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Models.SafeTensors;
+
+/// <summary>
+/// BitNet detection + config mapping for the HF <c>config.json</c> parser: <c>model_type=bitnet</c>
+/// / <c>architectures=[BitNetForCausalLM]</c> → <see cref="Architecture.BitNet"/> with the
+/// squared-ReLU FFN activation, mirroring the GGUF path.
+/// </summary>
+public sealed class HfConfigExtractorBitNetTests
+{
+    private const string BitNetConfig = """
+    {
+        "architectures": ["BitNetForCausalLM"],
+        "model_type": "bitnet",
+        "hidden_size": 2560,
+        "num_hidden_layers": 30,
+        "num_attention_heads": 20,
+        "num_key_value_heads": 5,
+        "intermediate_size": 6912,
+        "vocab_size": 128256,
+        "max_position_embeddings": 4096,
+        "rope_theta": 500000.0,
+        "rms_norm_eps": 1e-5,
+        "hidden_act": "relu2",
+        "tie_word_embeddings": true
+    }
+    """;
+
+    [Fact]
+    public void BitNet_ResolvesArchitectureAndReluSquaredActivation()
+    {
+        var cfg = HfConfigExtractor.Extract(BitNetConfig);
+
+        Assert.Equal(Architecture.BitNet, cfg.Architecture);
+        Assert.Equal(ActivationFunction.ReluSquared, cfg.ActivationFunction);
+        Assert.Equal(2560, cfg.HiddenSize);
+        Assert.Equal(30, cfg.NumLayers);
+        Assert.Equal(20, cfg.NumAttentionHeads);
+        Assert.Equal(5, cfg.NumKvHeads);
+        Assert.Equal(6912, cfg.IntermediateSize);
+        Assert.Equal(128256, cfg.VocabSize);
+        Assert.True(cfg.TiedEmbeddings);
+    }
+
+    [Fact]
+    public void BitNet_DetectedByModelTypeAlone()
+    {
+        const string json = """
+        {
+            "model_type": "bitnet",
+            "hidden_size": 256, "num_hidden_layers": 2, "num_attention_heads": 4,
+            "intermediate_size": 512, "vocab_size": 100, "hidden_act": "relu2"
+        }
+        """;
+
+        Assert.Equal(Architecture.BitNet, HfConfigExtractor.Extract(json).Architecture);
+    }
+}


### PR DESCRIPTION
## Summary
Adds **HuggingFace-format BitNet loading** to dotLLM: load a HF `bitnet-b1.58-2B-4T` safetensors directory directly (no GGUF conversion), converting bf16 weights to the I2_S ternary format at load so the existing `BitNetTransformerModel` (via `TransformerModel`) + I2_S kernels run unchanged. Extends the HF safetensors loader (#25) and BitNet GGUF support (#77).

Closes #126.

## What's included
- **I2_S weight quantizer** (`BitNetQuantize.QuantizeToI2S`): f32 → ternary I2_S with per-tensor absmean scale (transformers `WeightQuant` parity), the exact inverse of `DequantizeI2_S`'s interleaved 128-element block packing. Round-trip unit-verified against the production dequant kernel.
- **Config detection** (`HfConfigExtractor`): `model_type=bitnet` / `BitNetForCausalLM` → `Architecture.BitNet` + squared-ReLU (`relu2`) activation, mirroring the GGUF path.
- **Loader** (`ModelLoader` dispatch + `TransformerWeightsSafetensors.LoadBitNetLayer` / `ResolveLinearAsI2S`): quantizes q/k/v/o + gate/up/down to I2_S at load, wires BitNet Sub-LN (`attn_sub_norm` [hidden] / `ffn_sub_norm` [intermediate]), handles tie-embeddings; embeddings + `lm_head` stay full precision.
- **CLI**: `run`/`chat` auto-detect a HF directory (`config.json` + `*.safetensors`/index) and load via `LoadFromSafetensors` + `LoadTokenizerFromHfDirectory`; the GGUF path is unchanged.

## Verification
- **9 BitNet unit tests green** (quantizer round-trip + interleaving positions, config detection, synthetic load+forward → finite vocab logits). Integration synthetic BitNet load+forward test added.
- Targeted regression subsets pass: SafeTensors 84, Models 356, Cli 8, Cpu.BitNet/Tokenizers.Hf 36 — no failures.
- **End-to-end parity**: CLI on the real `microsoft/bitnet-b1.58-2B-4T-bf16` (30L/2560H, CPU greedy) produces coherent output — *"The capital of France is Paris, and it is known for its iconic landmarks such as the Eiffel Tower and the Lou…"* — confirming I2_S + Sub-LN + tie-embeddings + squared-ReLU are correct against the real model.

## Notes / follow-ups
- GPU offload for the HF-dir path is not wired (loads CPU); `CudaModelLoader.LoadFromSafetensors` exists for a follow-up.
- Tool-calling chat template needs GGUF metadata; the HF path uses the plain-fallback template (warned).
- MoE/MoTE-on-BitNet from HF (routed ternary experts) is a separate future extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
