### PR TITLE
test(cuda): fix too-tight tolerance in EagerVsGraphDecode_QuantizedKv_Match

### DIFF
--- a/tests/DotLLM.Tests.Unit/Cuda/CudaGraphCaptureEquivalenceTest.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaGraphCaptureEquivalenceTest.cs
@@ -251,10 +251,19 @@ public class CudaGraphCaptureEquivalenceTest
                 $"Argmax divergence at step {i}: eager={eagerTokens[i]}, graph={graphTokens[i]}");
         }
 
-        // Eager and graph paths invoke the SAME kernels — only the host-vs-device
-        // origin of the eviction counters differs. Logits should be bit-identical
-        // (all FP arithmetic is reproducible because the launch sequence is fixed).
-        Assert.True(maxDiff < 1e-3f,
+        // Argmax MUST match at every step — this is the real correctness gate (same
+        // reasoning as EagerVsGraphDecode_Match above). Logit VALUES are not actually
+        // bit-identical in practice: PTX-JIT cache state left behind by other tests in
+        // the same process (module/kernel registration order shifts SASS scheduling,
+        // which shifts FP accumulation order in identical arithmetic) perturbs them by
+        // up to ~0.2 max abs in the full suite, even though eager and graph invoke the
+        // same kernels — confirmed via a standalone rerun (diff exactly 0.0) vs. a
+        // full-suite rerun (diff ~0.20). This mirrors EagerVsGraphDecode_Match's own
+        // documented ~0.25 max-abs full-suite drift; use the same generous tolerance
+        // rather than the previous 1e-3f, which had this test intermittently fail only
+        // when run after other CUDA tests (never standalone) — a test-strictness bug,
+        // not a real eager-vs-graph divergence.
+        Assert.True(maxDiff < 5.0f,
             $"First-step logit divergence too large: max abs diff = {maxDiff}");
     }
 


### PR DESCRIPTION
Closes #174.

## Summary
Root-caused the documented pre-existing full-suite-only flake in
`CudaGraphCaptureEquivalenceTest.EagerVsGraphDecode_QuantizedKv_Match`. It asserted a 1e-3f logit
tolerance claiming eager/graph paths are bit-identical — but its sibling test in the same file
already documents and tolerates (5.0f) the real cause: benign PTX-JIT/kernel-registration-order FP
drift from other tests running first in the same process. Confirmed via direct repro: 0.0 diff
standalone, ~0.20 diff in the full suite — inside the sibling's tolerance, outside this test's.
Loosened to match (5.0f) and corrected the comment.

## Test plan
- [x] Standalone: passes (as it always did)
- [x] Full `DotLLM.Tests.Unit.Cuda` suite, same conditions that previously reproduced the failure:
      339 total / 303 passed / 36 skipped / **0 failed** (previously 1 failed — this test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)