### PR TITLE
perf(cuda): document gdn_scan_step_f32 kernel-internal rewrite negative result (#173)

### DIFF
--- a/native/kernels/gated_delta_net_scan.cu
+++ b/native/kernels/gated_delta_net_scan.cu
@@ -47,6 +47,67 @@
 // independent multiply, so we can stride the work across threads freely without
 // affecting float results — multiplication of independent values is parity-safe
 // regardless of order. We use a grid-stride loop over the linearized S buffer.
+//
+// ─── NEGATIVE RESULT: fused decay+retrieve / write+read rewrite (issue #173) ──
+// Attempted a kernel-internal restructure: thread `col` touches EXCLUSIVELY
+// S[*, col] across every phase of this kernel (the decay grid-stride loop
+// above, for blockDim.x == d_state, reduces to exactly row = i / d_state,
+// colIndex = i % d_state == col — already only its own column). Since no
+// other thread ever reads/writes column `col`, there is no cross-thread
+// dependency on S once k_shared/q_shared are populated (the ONLY reason
+// EITHER existing __syncthreads() call is needed at all). This means:
+//   1. The second __syncthreads() (between write and read) is provably
+//      redundant — removable with zero correctness risk.
+//   2. Decay writes S[row,col], then retrieve immediately re-reads it in a
+//      separate pass; decay is a strictly order-independent per-element
+//      multiply, so fusing "decay S[row,col], then immediately accumulate
+//      that SAME value into the retrieve sum" into one loop iteration is
+//      bit-identical to the current two-pass version (verified against the
+//      CPU reference, GatedDeltaNetScan.Execute, row-by-row) while
+//      eliminating retrieve's redundant reload.
+//   3. Same argument fuses write+read into one loop, eliminating read's
+//      redundant reload.
+// This restructure — 4 full passes over the per-head [d_state,d_state] state
+// matrix collapsing to 2 fused passes, 1 of 2 __syncthreads() removed — was
+// implemented, proven bit-exact against the CPU oracle across multiple decode
+// steps (tests/DotLLM.Tests.Unit/Cuda/CudaGdnScanStepF32Tests.cs, kept — the
+// first focused CUDA test for this kernel, independent of this round's
+// outcome), and measured `ptxas -Xptxas -v`/`cuobjdump --dump-sass` clean:
+// register count and spill count UNCHANGED (40 regs/thread, 0 spills, so
+// occupancy — already 100% pre-change: 40*128=5120 regs/block,
+// floor(65536/5120)=12 blocks/SM = 48 warps/SM = the sm_86 1536-thread/SM
+// ceiling — was unaffected either way), BAR.SYNC count 2→1, and static SASS
+// instruction count for the function dropped ~11% (888→792 instructions).
+//
+// Despite that clean static signal, REAL `dotnet run ... bench` throughput
+// showed NO measurable improvement: two full A/B rounds (`-p 64 -n 48 -r 8`,
+// real Bonsai-27B GGUF, rebuilding PTX+CLI between each side, clean baseline
+// each time) gave modified=17.68/17.88 then 18.00/18.13 (median/best tok/s)
+// vs baseline=17.69/17.76 then 17.98/18.11 — i.e. round-to-round system noise
+// (~2-8% swings, occasionally with a slow outlier rep on EITHER side) was
+// larger than any modified-vs-baseline gap. Aggregating all 16 reps per side:
+// mean 17.738 (modified) vs 17.666 (baseline) tok/s — a ~0.4% average edge,
+// not distinguishable from noise at this sample size, nowhere near this
+// investigation's other confirmed wins (which cleared their baseline by
+// several times this margin). Most likely explanation: the kernel was
+// ALREADY at 100% occupancy pre-change, so the GPU already has enough
+// resident warps to hide the latency of the "redundant" loads this rewrite
+// removes; and the retrieve/read phases' accumulation is an inherently serial
+// 128-deep dependency chain (tmp_col/out_col each iteration depends on the
+// previous), a critical-path length this rewrite does not shorten — so
+// removing surrounding, already-hidden instructions doesn't move wall-clock
+// decode time. CONCLUSION: kernel-internal restructuring of this specific
+// recurrence step is a dead end absent a change that either (a) breaks the
+// 128-deep serial accumulation into a tree/warp-shuffle reduction (rejected
+// elsewhere in this file's history for breaking CPU bit-parity — accumulation
+// order changes results) or (b) reduces kernel LAUNCH count/overhead instead
+// (already exhausted — see the "Token-sequential design" section above; one
+// launch per (GDN layer, decode step) is already the floor for this design).
+// The functional code change was reverted (this file's kernel body is
+// unchanged from pre-#173); only this documentation and the new correctness
+// test were kept. Do not re-attempt this exact restructure without new `ncu`-
+// level occupancy/stall data (this session did not have elevated-PowerShell
+// access to gather it) or a fundamentally different parallelization strategy.
 
 #include <math.h>
 

--- a/tests/DotLLM.Tests.Unit/Cuda/CudaGdnScanStepF32Tests.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaGdnScanStepF32Tests.cs
@@ -1,0 +1,167 @@
+using System.Runtime.InteropServices;
+using DotLLM.Cpu.Kernels;
+using DotLLM.Cuda;
+using DotLLM.Cuda.Interop;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Unit.Cuda;
+
+/// <summary>
+/// Correctness anchor for <see cref="CudaKernels.LaunchGdnScanStepF32"/> (the <c>gdn_scan_step_f32</c>
+/// CUDA kernel, native/kernels/gated_delta_net_scan.cu) against its CPU oracle,
+/// <see cref="GatedDeltaNetScan.Execute"/>. No focused CUDA test existed for this kernel before
+/// issue #173's kernel-internal rewrite (fused decay+retrieve / write+read passes, one fewer
+/// __syncthreads()) — this test both validates that rewrite and gives the kernel permanent
+/// regression coverage against the CPU reference it claims bit-perfect parity with.
+/// </summary>
+[Trait("Category", "GPU")]
+public class CudaGdnScanStepF32Tests
+{
+    private readonly ITestOutputHelper _out;
+    public CudaGdnScanStepF32Tests(ITestOutputHelper output) => _out = output;
+
+    private static bool IsCudaDriverPresent()
+    {
+        string lib = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "nvcuda.dll" : "libcuda.so.1";
+        if (!NativeLibrary.TryLoad(lib, out nint h)) return false;
+        NativeLibrary.Free(h);
+        return CudaAvailableProbe();
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static bool CudaAvailableProbe() => CudaDevice.IsAvailable();
+
+    private static string? FindPtxDir()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "ptx"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "ptx"),
+        };
+        foreach (var dir in candidates)
+        {
+            var full = Path.GetFullPath(dir);
+            if (Directory.Exists(full) && Directory.GetFiles(full, "*.ptx").Length > 0)
+                return full;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="steps"/> consecutive decode steps (seqLen==1 per call, matching how
+    /// <c>ForwardGdnBody</c> drives this kernel) through BOTH the GPU kernel and the CPU reference,
+    /// feeding the SAME random per-step q/k/v/g/beta rows to both, and asserts bit-exact equality of
+    /// the output AND the evolving recurrence state after every step — not just the first. Both
+    /// implementations are documented as bit-perfect ports of the same reference algorithm (the
+    /// kernel's own header comment; -fmad=false; identical row-ordered accumulation), so exact
+    /// equality is the correct bar, matching e.g. <c>GdnDeinterleaveL2NormDecodeF32_MatchesSeparateDeinterleavePlusL2Norm</c>'s precedent.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(2, 1, 4, 5)]      // tiny shape, VHeadsPerKHead=2, several steps
+    [InlineData(32, 16, 128, 4)]  // real Bonsai-27B Qwen3HybridDense GDN shape
+    public void GdnScanStepF32_MatchesCpuReference_AcrossMultipleSteps(int nVHead, int nKHead, int dState, int steps)
+    {
+        Skip.IfNot(IsCudaDriverPresent(), "No CUDA GPU available");
+        string? ptxDir = FindPtxDir();
+        Skip.If(ptxDir == null, "PTX files not found");
+
+        using var ctx = CudaContext.Create(0);
+        using var stream = CudaStream.Create();
+        using var kernels = new CudaKernels(ptxDir!);
+
+        var rng = new Random(0xBEEF ^ nVHead ^ nKHead ^ (dState << 8) ^ (steps << 20));
+
+        int statePerHead = dState * dState;
+        int qkPerToken = nKHead * dState;
+        int vPerToken = nVHead * dState;
+
+        float[] cpuState = new float[nVHead * statePerHead];
+        for (int i = 0; i < cpuState.Length; i++) cpuState[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        float[] gpuStateInit = (float[])cpuState.Clone();
+
+        nint dState_ = 0, dQ = 0, dK = 0, dV = 0, dG = 0, dBeta = 0, dOut = 0;
+        try
+        {
+            long stateBytes = (long)cpuState.Length * sizeof(float);
+            long qkBytes = (long)qkPerToken * sizeof(float);
+            long vBytes = (long)vPerToken * sizeof(float);
+            long gbBytes = (long)nVHead * sizeof(float);
+
+            CudaDriverApi.cuMemAlloc_v2(out dState_, (nuint)stateBytes).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out dQ, (nuint)qkBytes).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out dK, (nuint)qkBytes).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out dV, (nuint)vBytes).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out dG, (nuint)gbBytes).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out dBeta, (nuint)gbBytes).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out dOut, (nuint)vBytes).ThrowOnError();
+
+            unsafe
+            {
+                fixed (float* p = gpuStateInit)
+                    CudaDriverApi.cuMemcpyHtoD_v2(dState_, (nint)p, (nuint)stateBytes).ThrowOnError();
+            }
+
+            nint s = stream.Handle;
+            float[] cpuOutput = new float[vPerToken];
+
+            for (int step = 0; step < steps; step++)
+            {
+                float[] q = new float[qkPerToken];
+                float[] k = new float[qkPerToken];
+                float[] v = new float[vPerToken];
+                float[] g = new float[nVHead];
+                float[] beta = new float[nVHead];
+                for (int i = 0; i < qkPerToken; i++) q[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+                for (int i = 0; i < qkPerToken; i++) k[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+                for (int i = 0; i < vPerToken; i++) v[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+                for (int i = 0; i < nVHead; i++) g[i] = (float)rng.NextDouble();          // decay in (0,1]
+                for (int i = 0; i < nVHead; i++) beta[i] = (float)rng.NextDouble();       // write-gate in [0,1]
+
+                // CPU reference: L2-norm is the caller's job (already applied upstream in the real
+                // pipeline); q/k here are treated as pre-normalized inputs to isolate the recurrence
+                // kernel itself, matching how gdn_scan_step_f32's own contract documents q_t/k_t as
+                // "already L2-normed by caller".
+                GatedDeltaNetScan.Execute(cpuState, q, k, v, g, beta, cpuOutput,
+                    nVHead, nKHead, dState, seqLen: 1);
+
+                unsafe
+                {
+                    fixed (float* pq = q) CudaDriverApi.cuMemcpyHtoD_v2(dQ, (nint)pq, (nuint)qkBytes).ThrowOnError();
+                    fixed (float* pk = k) CudaDriverApi.cuMemcpyHtoD_v2(dK, (nint)pk, (nuint)qkBytes).ThrowOnError();
+                    fixed (float* pv = v) CudaDriverApi.cuMemcpyHtoD_v2(dV, (nint)pv, (nuint)vBytes).ThrowOnError();
+                    fixed (float* pg = g) CudaDriverApi.cuMemcpyHtoD_v2(dG, (nint)pg, (nuint)gbBytes).ThrowOnError();
+                    fixed (float* pb = beta) CudaDriverApi.cuMemcpyHtoD_v2(dBeta, (nint)pb, (nuint)gbBytes).ThrowOnError();
+                }
+
+                kernels.LaunchGdnScanStepF32(dState_, dQ, dK, dV, dG, dBeta, dOut, nVHead, nKHead, dState, s);
+                stream.Synchronize();
+
+                float[] gpuOutput = new float[vPerToken];
+                float[] gpuState = new float[cpuState.Length];
+                unsafe
+                {
+                    fixed (float* p = gpuOutput) CudaDriverApi.cuMemcpyDtoH_v2((nint)p, dOut, (nuint)vBytes).ThrowOnError();
+                    fixed (float* p = gpuState) CudaDriverApi.cuMemcpyDtoH_v2((nint)p, dState_, (nuint)stateBytes).ThrowOnError();
+                }
+
+                Assert.True(cpuOutput.AsSpan().SequenceEqual(gpuOutput),
+                    $"step {step}: output mismatch (nVHead={nVHead}, nKHead={nKHead}, dState={dState}).");
+                Assert.True(cpuState.AsSpan().SequenceEqual(gpuState),
+                    $"step {step}: recurrence state mismatch after update (nVHead={nVHead}, nKHead={nKHead}, dState={dState}).");
+            }
+
+            _out.WriteLine($"nVHead={nVHead} nKHead={nKHead} dState={dState} steps={steps}: exact match every step, output and state.");
+        }
+        finally
+        {
+            if (dState_ != 0) CudaDriverApi.cuMemFree_v2(dState_);
+            if (dQ != 0) CudaDriverApi.cuMemFree_v2(dQ);
+            if (dK != 0) CudaDriverApi.cuMemFree_v2(dK);
+            if (dV != 0) CudaDriverApi.cuMemFree_v2(dV);
+            if (dG != 0) CudaDriverApi.cuMemFree_v2(dG);
+            if (dBeta != 0) CudaDriverApi.cuMemFree_v2(dBeta);
+            if (dOut != 0) CudaDriverApi.cuMemFree_v2(dOut);
+        }
+    }
+}


### PR DESCRIPTION
Closes #173.

Continuation of the non-GEMV decode-overhead investigation (#157/#159/#161/#164/#166/#168/#170, all merged to `dev`). Post-#170 profile: `gdn-5-scan` is the single largest non-GEMV decode bucket, unchanged across #168/#170 because during decode (seqLen==1) `gdn_scan_step_f32` is already exactly one kernel launch per (GDN layer, decode step) — no launch-fusion win available. This round attempted a genuinely new angle for this investigation: a **kernel-internal** restructure of the kernel body itself.

## Analysis (SASS-first, per this investigation's discipline)

- `ptxas -Xptxas -v` on the pre-change kernel: 40 registers/thread, 0 spills, blockDim=128 (4 warps/block) → 5120 regs/block → floor(65536/5120)=12 blocks/SM = 48 warps/SM = the sm_86 1536-thread/SM ceiling. **Occupancy was already 100%** — unlike most wins in this investigation, there was no occupancy headroom left; any real win had to reduce per-thread instruction/memory-op count instead.
- `cuobjdump --dump-sass` confirmed 2 `BAR.SYNC` in the compiled kernel (matching its 2 source `__syncthreads()` calls).
- Re-derived the dependency structure against the CPU oracle (`GatedDeltaNetScan.Execute`) row-by-row: thread `col` touches **exclusively** `S[*, col]` across every phase (decay, retrieve, write, read) — the decay phase's grid-stride loop, for `blockDim.x == d_state`, already reduces to `row = i / d_state, colIndex = i % d_state == col`. No cross-thread dependency on `S` exists once `k_shared`/`q_shared` are populated. This means: (1) the second `__syncthreads()` (between write and read) is provably redundant; (2) decaying `S[row,col]` and immediately consuming that value for the retrieve accumulation in the same loop iteration is bit-identical to the current two-pass version (decay is an order-independent per-element multiply); (3) the same argument fuses write+read.

## What was implemented and tested

- Fused decay+retrieve and write+read into 2 passes (from 4), removed 1 of 2 `__syncthreads()`.
- Added `tests/DotLLM.Tests.Unit/Cuda/CudaGdnScanStepF32Tests.cs` — **no focused CUDA test existed for this kernel before this issue**. Multi-step bit-exact comparison against the CPU reference (tiny shape + real Bonsai-27B 32/16/128 shape). Both PASS against either kernel body — kept as permanent regression coverage regardless of this round's outcome.
- Post-change `ptxas -v`: unchanged 40 registers, 0 spills. `cuobjdump`: `BAR.SYNC` 2→1, static SASS instruction count 888→792 (~11% fewer), LDG 93→63, STG 31→59 (an unrolling-factor artifact, not a clean per-pass halving).

## Real bench result: NEGATIVE

Two full A/B rounds (`dotnet run ... bench`, real Bonsai-27B GGUF, `-p 64 -n 48 -r 8`, clean rebuild of PTX+CLI each side):

| | median tok/s | best tok/s |
|---|---|---|
| modified, round 1 | 17.68 | 17.88 |
| baseline, round 1 | 17.69 | 17.76 |
| modified, round 2 | 18.00 | 18.13 |
| baseline, round 2 | 17.98 | 18.11 |

Round-to-round system noise (2-8% swings, occasional slow outlier rep on **either** side) is larger than any modified-vs-baseline gap. Aggregating all 16 reps per side: mean 17.738 (modified) vs 17.666 (baseline) tok/s — a ~0.4% average edge, not distinguishable from noise, nowhere near this investigation's other confirmed wins. Likely explanation: the kernel was already at 100% occupancy pre-change (enough resident warps to hide the "redundant" loads removed), and the retrieve/read phases are an inherently serial 128-deep accumulation dependency chain this rewrite does not shorten.

**The functional kernel-body change was reverted in full** (kernel body unchanged from pre-#173; PTX confirmed byte-identical to the pre-#173 compile). This PR keeps only: (1) the header documentation of this negative result (matching the existing documented-negative-results convention in this file and `pq2_0_gemv.cu`), and (2) the new correctness test.

## Test plan
- [x] `CudaGdnScanStepF32Tests` (new): 2/2 pass, bit-exact vs CPU reference, both shapes
- [x] Full `DotLLM.Tests.Unit.Cuda` suite: 303 passed, 0 failed, 38 skipped (unrelated missing sidecar/model files) — no flakes observed this run
- [x] `git fetch origin` confirmed `dev` had not moved beyond the already-merged #175 (graph-capture flake fix), which this branch already contains via fast-forward merge