### PR TITLE
perf(cuda): document GDN normgate (RmsNorm+SwiGLU) fusion negative result

### DIFF
--- a/native/kernels/rmsnorm_f32.cu
+++ b/native/kernels/rmsnorm_f32.cu
@@ -4,6 +4,36 @@
 //   * float2 vectorized loads/stores
 //   * __shfl_xor_sync warp reduction (symmetric)
 //   * Pre-folds 1/n into the rsqrt argument via fmaf
+//
+// ─── Investigated (#172): fusing this + swiglu_f32 for the GDN normgate call site — NEGATIVE ───
+// The Qwen3HybridDense/Qwen3MoeHybrid GDN body (ForwardGdnBody step 6, "gdn-6-normgate" in the
+// DOTLLM_HYBRID_PROFILE category profiler) calls this kernel immediately followed by swiglu_f32
+// (see swiglu_f32.cu for the matching note) — a per-head RMSNorm(x, ssm_norm) then silu(z)-gate,
+// ~9.56ms per 4 decode steps in the post-#170 profile (48 GDN layers x 4 steps). Implemented and
+// SASS-verified a fused rmsnorm_swiglu_f32 kernel (one block per (token, v-head) row, same
+// float2/shfl_xor reduction as this kernel, gate fused into pass 2 — structurally the same idea as
+// copy_rmsnorm_f32.cu's residual-copy fusion, just fusing the *next* op instead of the *previous*
+// one). ptxas -v showed a clean compile (32 registers, 0 spill, vs. 24 for this kernel alone — no
+// occupancy concern). A bit-exact-on-the-norm/~3e-7-relative-on-the-gate correctness test passed
+// for all tested shapes (decode-realistic nVHead=48/dState=128, prefill-shaped seqLen>1, small
+// dims), confirming the fusion was implemented correctly.
+//
+// MEASURED REAL BONSAI-27B DECODE THROUGHPUT SHOWED NO REPRODUCIBLE IMPROVEMENT: five `bench
+// -p 64 -n 48` runs (2 baseline, 3 fused, RTX 3060) all landed in the same ~17.5-18.3 tok/s band
+// regardless of which kernel path was active — differences between fused and baseline were smaller
+// than the run-to-run spread (itself dominated by within-run thermal drift: decode time on this
+// card visibly rises rep-over-rep within a single `bench` invocation as the GPU heats up, e.g.
+// 2646ms -> 2885ms across 12 reps in one run). "Best" (least-throttled) reps clustered at
+// 17.97-18.25 tok/s for BOTH baseline and fused with no consistent ordering. Consistent with this
+// investigation's own prediction going in: this bucket's absolute time share (~9.56ms/4 steps,
+// smaller than #170's ~16ms target which itself only moved the needle ~0.7-1%) was expected to
+// yield a small result if any — in practice it was too small to separate from this machine's
+// thermal-noise floor. NOT reverted due to a regression (no regression was observed either) — this
+// is a "correctly implemented, real-world benefit unmeasurable" negative result. Reverted in full
+// (no rmsnorm_swiglu_f32 kernel/wiring/test shipped) to avoid carrying unused code for a change
+// that cannot be shown to help. Don't re-attempt this exact fusion without either a lower-noise
+// benching setup (e.g. a dedicated cool-GPU environment) or a larger-absolute-time-share motivation
+// (e.g. if a future model config makes nVHead or dState much larger).
 
 extern "C" __global__ void __launch_bounds__(256) rmsnorm_f32(
     const float* __restrict__ input,

--- a/native/kernels/swiglu_f32.cu
+++ b/native/kernels/swiglu_f32.cu
@@ -1,4 +1,14 @@
 // Fused SwiGLU with FP32 data.
+//
+// Investigated (#172): fusing this kernel with the preceding rmsnorm_f32 call at the GDN normgate
+// call site (ForwardGdnBody step 6) — implemented, SASS-verified, correctness-tested, but showed
+// NO reproducible real-bench decode throughput improvement on Bonsai-27B (differences smaller than
+// this machine's run-to-run thermal-drift noise). Reverted in full. See rmsnorm_f32.cu's header
+// for the full writeup (measured numbers, root-cause reasoning, and why nothing shipped here).
+// Note this kernel compiles with --use_fast_math (see native/build_ptx.bat's FAST_MATH list) — its
+// SiLU sigmoid lowers to MUFU.EX2 (approximate hardware exp2) + MUFU.RCP, not precise expf(); any
+// future fusion attempt touching this kernel's math must account for that precision difference
+// (measured ~2-4e-7 relative error vs. precise expf() in the #172 correctness test, not ULP-scale).
 
 #include <math.h>
 

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
@@ -936,6 +936,10 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         ProfMark("gdn-5-scan");
 
         // ── 6. Per-head RMSNorm(out, ssm_norm) * silu(z) gating ──
+        // Investigated fusing these two launches (issue #172): implemented, SASS-verified,
+        // correctness-tested, but showed no reproducible real-bench decode win (within this
+        // machine's thermal-drift noise floor) — see rmsnorm_f32.cu's header for the full
+        // writeup. Left as two separate calls.
         _kernels.LaunchRmsNormF32(gdnOut, gdnW.SsmNormDevice, gdnOut,
             dState, eps, seqLen * nVHead, streamH);
         _kernels.LaunchSwiGLUF32(zBuf, gdnOut, gdnOut, vDim, seqLen, streamH);

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
@@ -1885,6 +1885,10 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         // Reuse the existing RMSNorm-F32 kernel as a per-head normaliser:
         //   rows = seqLen * nVHead, hiddenSize = dState. The weight is dState floats
         //   shared across all rows — exactly what LaunchRmsNormF32 does.
+        // Investigated fusing these two launches (issue #172, same pattern as
+        // CudaQwen3HybridDenseTransformerModel's ForwardGdnBody step 6): implemented,
+        // SASS-verified, correctness-tested, but showed no reproducible real-bench decode win
+        // (within this machine's thermal-drift noise floor) — see rmsnorm_f32.cu's header.
         _kernels.LaunchRmsNormF32(gdnOut, gdnW.SsmNormDevice, gdnOut,
             dState, eps, seqLen * nVHead, streamH);
         // gdnOut *= silu(z). silu(z) = z * sigmoid(z); SwiGLU(gate=z, up=gdnOut) = silu(z)*up.


### PR DESCRIPTION
Closes #172

## Summary

Continuation of the non-GEMV decode-overhead investigation (#157/#159/#161/#162/#164/#166/#168/#170,
all merged to `dev`). Investigated fusing `ForwardGdnBody`'s per-head RMSNorm + SwiGLU-gate pair
(step 6, "gdn-6-normgate" in the profiler, ~9.56ms/4 decode steps) into one launch.

- `cuobjdump --dump-sass` confirmed both existing kernels do real, distinct work (no no-op
  surprise): `rmsnorm_f32.cu` is precise (plain nvcc defaults); `swiglu_f32.cu` is
  `--use_fast_math` (SASS shows `MUFU.EX2`/`MUFU.RCP` — hardware-approximate exp/reciprocal, not
  the precise `expf()` the norm side uses).
- Implemented a fused `rmsnorm_swiglu_f32` kernel (one block per (token, v-head) row, same
  float2/`shfl_xor` reduction as `rmsnorm_f32`, gate folded into pass 2 — same idea as
  `copy_rmsnorm_f32.cu`'s residual-copy fusion, fusing the *next* op instead of the *previous*
  one), deliberately built without `--use_fast_math` so the norm half stays bit-exact. `ptxas -v`:
  32 registers, 0 spill (vs 24 for `rmsnorm_f32` alone) — no occupancy concern.
- Correctness test passed for decode-realistic (nVHead=48/dState=128), prefill-shaped (seqLen>1),
  and small-dims shapes: bit-exact on the norm, ~2-4e-7 relative on the gate term (measured, not
  the "few ULP" ballpark the fast-math/precise mismatch might suggest).

## Result: no reproducible real-bench win

Five `bench -p 64 -n 48` runs (2 baseline, 3 fused, RTX 3060) all landed in the same ~17.5-18.3
tok/s band regardless of which path was active. The difference between fused and baseline was
smaller than the run-to-run spread, which is itself dominated by within-run thermal drift (decode
time visibly rises rep-over-rep within a single `bench` invocation, e.g. 2646ms → 2885ms across 12
reps as the GPU heats up). "Best" (least-throttled) reps clustered at 17.97-18.25 tok/s for both
baseline and fused with no consistent ordering.

This matches the investigation's own prediction going in: this bucket's absolute time share
(~9.56ms/4 steps, smaller than #170's ~16ms target which itself only moved the needle ~0.7-1%) was
expected to yield a small result if any — in practice it was too small to separate from this
machine's thermal-noise floor.

**Reverted in full** — no `rmsnorm_swiglu_f32` kernel/wiring/test ships. This is a "correctly
implemented, real-world benefit unmeasurable" result, not a regression, so nothing is carried
forward except documentation (in `rmsnorm_f32.cu`, `swiglu_f32.cu`, and short breadcrumbs at both
GDN body call sites — Qwen3HybridDense and the sibling Qwen3MoeHybrid, which shares the identical
pattern).

## Test plan

- [x] `cuobjdump --dump-sass` on both existing kernels before implementing
- [x] New xUnit correctness test (bit-exact norm, measured ~2-4e-7 relative gate tolerance) — passed
      for all 3 shapes, then reverted along with the rest of the experiment
- [x] Real `dotllm bench` A/B (2 baseline + 3 fused runs, RTX 3060) — no reproducible separation
- [x] Full `DotLLM.Tests.Unit.Cuda` suite after merging latest `dev` (which landed the parallel
      `gdn-scan-internal` negative result #173 and a graph-capture tolerance fix #174): **303
      passed, 0 failed, 38 skipped** (skips are real-model/sidecar tests gated on unrelated fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)