### PR TITLE
perf(cuda): confirm layer-resid1-norm2/pre-norm1 RmsNorm fusion already active (#178)

### DIFF
--- a/native/kernels/copy_rmsnorm_f32.cu
+++ b/native/kernels/copy_rmsnorm_f32.cu
@@ -15,6 +15,20 @@
 // `input`'s aliasing (this kernel does NOT support in-place norm — the two RunSingleLayerBody
 // call sites it replaces always use 3 distinct buffers: input=HiddenState, residual_out=Residual,
 // output=NormOutput).
+//
+// Follow-up (issue #178, 2026-07-25): re-profiled fresh and re-confirmed this fused path is the
+// one actually executing at runtime (CudaCopyRmsNormF32Test passes for real, not skipped — PTX is
+// current, HasCopyRmsNormF32 is true). cuobjdump --dump-sass (sm_86) shows 24 registers/thread, 0
+// spill loads/stores — nothing left to trim inside the kernel body. The remaining decode-time cost
+// is structural: seqLen==1 means blockIdx.x (=row) only ever takes value 0, so every decode call
+// launches a single block — 1 of 28 SMs occupied. Extracting more grid parallelism would require
+// splitting the 5120-wide reduction itself across blocks, which needs either a second launch for
+// the cross-block reduce (reintroducing the exact launch this kernel was built to remove) or a
+// cooperative-groups grid-wide sync (unused elsewhere in this codebase; real portability/
+// oversubscription risk). Concluded: no further action without that materially riskier redesign.
+// Not attempted this session — flagged as a possible future thrust alongside gdn_scan_step_f32's
+// analogous small-grid-decode-step finding, not a duplicate of it (different kernel, same shape
+// of constraint).
 
 extern "C" __global__ void __launch_bounds__(256) copy_rmsnorm_f32(
     const float* __restrict__ input,

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
@@ -636,6 +636,24 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         return result;
     }
 
+    // Issue #178 (2026-07-25 profiling round): re-verified that HasCopyRmsNormF32 is actually
+    // true at runtime for both "layer-pre-norm1" and "layer-resid1-norm2" below (a real xUnit
+    // pass on CudaCopyRmsNormF32Test, not just the property returning true — confirms PTX isn't
+    // stale) — the fused single-launch path IS the one executing in production, not the 2-launch
+    // fallback. cuobjdump --dump-sass on copy_rmsnorm_f32 (sm_86) shows 24 registers/thread, 0
+    // spills — a lean kernel with nothing left to trim internally. The remaining cost is
+    // structural, not launch-count: decode always has seqLen==1, so blockIdx.x (=row) only ever
+    // takes value 0 — each call launches exactly ONE block, occupying 1 of 28 SMs. This is the
+    // same "grid too small to fill the device" shape the parallel gdn_scan_step_f32 ncu
+    // investigation found (see .docs/handoff.md), but here it's structural rather than tunable:
+    // there is only one row to normalize per decode step, so there is no more per-row parallelism
+    // to spread across blocks. Splitting the 5120-wide reduction itself across multiple blocks
+    // to raise occupancy would need either (a) a second kernel launch for the cross-block
+    // reduction — which gives back exactly the launch this fusion exists to remove — or (b) a
+    // cooperative-groups grid-wide sync (cuLaunchCooperativeKernel), which is not used anywhere
+    // else in this codebase and adds real portability/occupancy-oversubscription risk for a
+    // single-digit-percent theoretical upside. Concluded: no further action here without a
+    // materially different (riskier, cooperative-launch) redesign; not attempted this session.
     private void RunSingleLayerBody(int layerIdx, int seqLen, ReadOnlySpan<int> positions,
         int hiddenSize, int numHeads, int numKvHeads, int headDim, float eps, IKvCache? kvCache)
     {


### PR DESCRIPTION
Closes #178

## Summary
- Fresh `DOTLLM_HYBRID_PROFILE=1` re-profile against the real Bonsai-27B GGUF: category shape
  unchanged after this session's reverted #172/#173 attempts (full breakdown in the commit
  message / PR discussion below).
- Directly confirmed (not assumed) `HasCopyRmsNormF32` is true and the fused single-launch
  `copy_rmsnorm_f32` kernel is the path actually executing at runtime for both
  `layer-pre-norm1` and `layer-resid1-norm2` — `CudaCopyRmsNormF32Test` passes for real (not
  skipped) across all 3 shapes.
- `cuobjdump --dump-sass` (sm_86): 24 registers/thread, 0 spills — kernel body is already lean.
- Remaining cost is structural: decode's seqLen==1 means every call launches exactly one block
  (1 of 28 SMs). Further gains would need either a second launch for cross-block reduction
  (defeats the fusion's purpose) or a cooperative-groups grid-wide sync (unused elsewhere in
  this codebase, real risk for uncertain upside). **Concluded: no further action** without a
  materially riskier redesign — documented at the kernel header and call site.
- Real `dotllm bench` (8 reps): 18.19/18.27 tok/s median/best — consistent with (slightly above)
  the ~17.7-17.9 tok/s baseline, no regression.
- Full CUDA suite: 304 passed / 0 failed / 37 skipped.

No functional change — comment-only documentation of an already-shipped, already-optimal fusion.

## Test plan
- [x] `CudaCopyRmsNormF32Test` passes (3/3, not skipped) confirming the fused path is active
- [x] Full `DotLLM.Tests.Unit.Cuda` suite: 304 passed / 0 failed / 37 skipped
- [x] Real `dotllm bench` against Bonsai-27B: 18.19/18.27 tok/s median/best, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)