### PR TITLE
perf(cuda): incremental KV F16->F32 staging for full-attention layers (#182)

### DIFF
--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
@@ -101,9 +101,25 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
 
     private nint _f16KvWriteStaging;
     private long _f16KvWriteStagingElems;
-    private nint _f32KvReadStagingK;
-    private nint _f32KvReadStagingV;
-    private long _f32KvReadStagingElems;
+
+    // Per-attention-layer-slot F32 KV read-staging buffers (issue #182). ONE pair per slot
+    // (not shared across the 16 full-attention layers, unlike the old single shared-buffer
+    // design) so each slot's incrementally-converted history survives from one layer's call
+    // to the next layer's call within the same decode step, and across decode steps.
+    // _f32KvValidLength[slot] tracks how many leading KV positions are already validly
+    // converted into _f32KvReadStagingK/V[slot] as of the last call for that slot -- see
+    // ForwardFullAttnBody's "incremental KV F16->F32 staging" block and EnsureF32KvReadStaging.
+    private nint[]? _f32KvReadStagingK;
+    private nint[]? _f32KvReadStagingV;
+    private long[]? _f32KvReadStagingElems;
+    private int[]? _f32KvValidLength;
+
+    // Test-only escape hatch (issue #182): forces every call to take the full-range
+    // reconversion path (pre-fix behavior) instead of the incremental append fast path. Used by
+    // CudaQwen3HybridDenseIncrementalKvDequantTest to assert the fast path is bit-exact against
+    // the old behavior across many consecutive decode steps and buffer growths. Never set on the
+    // production Forward path.
+    internal bool ForceFullKvReconvertForTest { get; set; }
 
     private bool _disposed;
 
@@ -1088,12 +1104,76 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
             int seqKv = _f16CacheCurrentLength;
             int kvLiveElems = seqKv * kvElems;
 
-            EnsureF32KvReadStaging(seqKv, kvElems);
-            _kernels.LaunchConvertF16ToF32(_f16KCache![slot], _f32KvReadStagingK, kvLiveElems, streamH);
-            _kernels.LaunchConvertF16ToF32(_f16VCache![slot], _f32KvReadStagingV, kvLiveElems, streamH);
+            // EnsureF32KvReadStaging may grow (and reset _f32KvValidLength[slot] to 0) --
+            // always read the valid-length AFTER this call so a fresh grow is observed below.
+            EnsureF32KvReadStaging(slot, seqKv, kvElems);
+            nint kStage = _f32KvReadStagingK![slot];
+            nint vStage = _f32KvReadStagingV![slot];
+
+            // Incremental KV F16->F32 staging (issue #182): the old code unconditionally
+            // reconverted the ENTIRE [0, seqKv) live range every call, even though ordinary
+            // prefill/decode only ever APPENDS rows (one row per decode step). Convert just the
+            // newly-written range when it is a plain contiguous append starting exactly where
+            // this slot's staging buffer left off; otherwise fall back to the old full-range
+            // reconversion, which is always correct (just not fast) and re-synchronizes
+            // _f32KvValidLength. The fallback also covers non-contiguous position batches, a
+            // freshly-grown/reallocated buffer (content lost, valid length reset to 0 above), and
+            // a KV-cache handle reused for an unrelated sequence without a growth-triggered reset
+            // (that case cannot be told apart here from ordinary appends by length alone, but ANY
+            // deviation from "starts exactly at the recorded valid length" -- including the
+            // shrink case the position range would otherwise imply -- is treated as untrusted and
+            // triggers the safe full reconversion).
+            //
+            // Result (issue #182, RTX 3060, real Bonsai-27B, single continuous decode sequence --
+            // NOT `dotllm bench -r N>1`, which was found during this work to be unsuitable for
+            // measuring this specific change: all reps but the discarded warmup share one model
+            // instance whose _f16CacheCurrentLength never resets when a same-size IKvCache is
+            // reused, so every REPORTED rep runs "stuck" at the previous rep's final depth for its
+            // entire duration -- a separate, pre-existing bench-methodology gap, not a correctness
+            // bug in this fix, see issue #182's PR description): bit-exact vs. the old full-range
+            // reconversion (dedicated correctness test, many consecutive steps incl. a mid-run F32
+            // staging buffer growth). End-to-end wall-clock across several full single-sequence
+            // decode runs (2048-4096 steps, single-token-decode-loop depth-building to avoid an
+            // unrelated pre-existing VRAM-ceiling issue in the batched --depth path -- also found
+            // this session, reproduces identically on unmodified pre-#182 code): a small, directionally
+            // positive but noise-comparable full-run win (roughly 0 to +4.5% across independent
+            // rounds, averaging ~+1.5%), consistent with the theoretical model (this eliminates a
+            // per-decode-step O(depth) cost, i.e. an O(depth^2) cumulative cost over a generation,
+            // replacing it with O(1) per step / O(depth) cumulative -- but attn-6b-kvdequant was
+            // always a small slice of total decode time next to the O(depth) naive-attention kernel
+            // itself, `attn-6c-core`, which this fix does not touch). Kept: zero added
+            // synchronization/round-trips, provably less work than before in every case, and no
+            // observed regression in any round (unlike this file's several genuine negative results,
+            // which all showed consistent, large regressions from added sync overhead).
+            int prevValid = _f32KvValidLength![slot];
+            bool contiguousAppend = !ForceFullKvReconvertForTest
+                && IsContiguousAscendingRun(positions) && positions[0] == prevValid;
+
+            if (contiguousAppend)
+            {
+                int newCount = positions.Length;
+                if (newCount > 0)
+                {
+                    long newFirstElems = (long)positions[0] * kvElems;
+                    int newElems = newCount * kvElems;
+                    nint kSrc = _f16KCache![slot] + (nint)(newFirstElems * sizeof(ushort));
+                    nint vSrc = _f16VCache![slot] + (nint)(newFirstElems * sizeof(ushort));
+                    nint kDst = kStage + (nint)(newFirstElems * sizeof(float));
+                    nint vDst = vStage + (nint)(newFirstElems * sizeof(float));
+                    _kernels.LaunchConvertF16ToF32(kSrc, kDst, newElems, streamH);
+                    _kernels.LaunchConvertF16ToF32(vSrc, vDst, newElems, streamH);
+                }
+                _f32KvValidLength[slot] = Math.Max(prevValid, positions[^1] + 1);
+            }
+            else
+            {
+                _kernels.LaunchConvertF16ToF32(_f16KCache![slot], kStage, kvLiveElems, streamH);
+                _kernels.LaunchConvertF16ToF32(_f16VCache![slot], vStage, kvLiveElems, streamH);
+                _f32KvValidLength[slot] = seqKv;
+            }
             ProfMark("attn-6b-kvdequant");
 
-            _kernels.LaunchAttentionF32(q, _f32KvReadStagingK, _f32KvReadStagingV, attnOut,
+            _kernels.LaunchAttentionF32(q, kStage, vStage, attnOut,
                 seqLen, seqKv, numHeads, numKvHeads, headDim,
                 positionOffset: positionOffset, slidingWindow: 0, streamH);
         }
@@ -1169,6 +1249,26 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         }
         _f16CacheMaxSeqLen = maxSeqLen;
         _f16CacheCurrentLength = 0;
+
+        // Per-slot F32 KV read-staging (issue #182): reset alongside the F16 cache reallocation
+        // above. Freeing any previously-allocated staging buffers and re-zeroing the valid-length
+        // array here mirrors _f16CacheCurrentLength's own reset -- the next ForwardFullAttnBody
+        // call for every slot will see prevValid==0, take the "not a matching contiguous append"
+        // branch only if positions[0] != 0 (freshly-sized buffers still correctly fast-path a
+        // from-scratch prefill starting at position 0), and otherwise safely fall back to a full
+        // reconversion.
+        if (_f32KvReadStagingK is not null)
+        {
+            for (int i = 0; i < _f32KvReadStagingK.Length; i++)
+            {
+                if (_f32KvReadStagingK[i] != 0) CudaDriverApi.cuMemFree_v2(_f32KvReadStagingK[i]);
+                if (_f32KvReadStagingV![i] != 0) CudaDriverApi.cuMemFree_v2(_f32KvReadStagingV[i]);
+            }
+        }
+        _f32KvReadStagingK = new nint[_attentionLayerCount];
+        _f32KvReadStagingV = new nint[_attentionLayerCount];
+        _f32KvReadStagingElems = new long[_attentionLayerCount];
+        _f32KvValidLength = new int[_attentionLayerCount];
     }
 
     private void EnsureF16KvWriteStaging(int seqLen, int kvElems)
@@ -1184,19 +1284,38 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         _f16KvWriteStagingElems = grown;
     }
 
-    private void EnsureF32KvReadStaging(int seqKv, int kvElems)
+    /// <summary>
+    /// Ensures <paramref name="slot"/>'s F32 KV read-staging buffer pair can hold
+    /// <c>seqKv * kvElems</c> floats, growing (doubling) if needed. A grow reallocates the
+    /// buffer at a new address with unspecified content -- any previously-converted prefix for
+    /// this slot is gone, so <see cref="_f32KvValidLength"/>[<paramref name="slot"/>] is reset to
+    /// 0, forcing the caller (see the "incremental KV F16->F32 staging" block in
+    /// <c>ForwardFullAttnBody</c>) to fully reconvert on its next use of this slot.
+    /// </summary>
+    private void EnsureF32KvReadStaging(int slot, int seqKv, int kvElems)
     {
         long needed = (long)seqKv * kvElems;
-        if (needed <= _f32KvReadStagingElems) return;
+        if (needed <= _f32KvReadStagingElems![slot]) return;
 
-        long grown = _f32KvReadStagingElems == 0 ? 256L : _f32KvReadStagingElems;
+        long grown = _f32KvReadStagingElems[slot] == 0 ? 256L : _f32KvReadStagingElems[slot];
         while (grown < needed) grown *= 2;
 
-        FreeIfNonZero(ref _f32KvReadStagingK);
-        FreeIfNonZero(ref _f32KvReadStagingV);
-        _f32KvReadStagingK = AllocDevice(grown * sizeof(float));
-        _f32KvReadStagingV = AllocDevice(grown * sizeof(float));
-        _f32KvReadStagingElems = grown;
+        FreeIfNonZero(ref _f32KvReadStagingK![slot]);
+        FreeIfNonZero(ref _f32KvReadStagingV![slot]);
+        _f32KvReadStagingK[slot] = AllocDevice(grown * sizeof(float));
+        _f32KvReadStagingV![slot] = AllocDevice(grown * sizeof(float));
+        _f32KvReadStagingElems[slot] = grown;
+        _f32KvValidLength![slot] = 0;
+    }
+
+    /// <summary>True if <paramref name="positions"/> is a strictly-ascending run of consecutive
+    /// integers (e.g. <c>[5]</c>, <c>[5,6,7]</c>). Used to gate the incremental KV F16->F32
+    /// staging fast path -- see the call site in <c>ForwardFullAttnBody</c>.</summary>
+    private static bool IsContiguousAscendingRun(ReadOnlySpan<int> positions)
+    {
+        for (int i = 1; i < positions.Length; i++)
+            if (positions[i] != positions[i - 1] + 1) return false;
+        return true;
     }
 
     private void WriteF16KvRows(int layerSlot, nint kSrcF32, nint vSrcF32,
@@ -1565,8 +1684,16 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
             _f16VCache = null;
         }
         FreeIfNonZero(ref _f16KvWriteStaging);
-        FreeIfNonZero(ref _f32KvReadStagingK);
-        FreeIfNonZero(ref _f32KvReadStagingV);
+        if (_f32KvReadStagingK is not null)
+        {
+            for (int i = 0; i < _f32KvReadStagingK.Length; i++)
+            {
+                if (_f32KvReadStagingK[i] != 0) CudaDriverApi.cuMemFree_v2(_f32KvReadStagingK[i]);
+                if (_f32KvReadStagingV![i] != 0) CudaDriverApi.cuMemFree_v2(_f32KvReadStagingV[i]);
+            }
+            _f32KvReadStagingK = null;
+            _f32KvReadStagingV = null;
+        }
 
         _state.Dispose();
         _gdnCache.Dispose();

--- a/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridDenseIncrementalKvDequantTest.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridDenseIncrementalKvDequantTest.cs
@@ -1,0 +1,196 @@
+using System.Runtime.InteropServices;
+using DotLLM.Core.Tensors;
+using DotLLM.Cuda;
+using DotLLM.Cuda.Architectures;
+using DotLLM.Models.Gguf;
+using Xunit;
+using Xunit.Abstractions;
+using Architecture = DotLLM.Core.Configuration.Architecture;
+
+namespace DotLLM.Tests.Unit.Cuda;
+
+/// <summary>
+/// Bit-exact regression test for issue #182: incremental KV F16-&gt;F32 read-staging in
+/// <see cref="CudaQwen3HybridDenseTransformerModel"/>'s <c>ForwardFullAttnBody</c>. Before the
+/// fix, every decode step reconverted the ENTIRE cached KV range from F16 to F32 from scratch
+/// (an O(depth) cost paid every step, even though ordinary prefill/decode only ever appends
+/// rows); the fix converts only the newly-appended row(s) each call, keeping previously-converted
+/// values in place across calls (per attention-layer slot).
+///
+/// Since F16-&gt;F32 conversion is a pure per-element function of immutable source bytes,
+/// converting a row now vs. later from the same F16 content must produce IDENTICAL F32 values --
+/// so the fast (incremental) and reference (forced full-reconversion, mirroring pre-fix behavior
+/// via <see cref="CudaQwen3HybridDenseTransformerModel.ForceFullKvReconvertForTest"/>) paths must
+/// agree bit-for-bit at every step of a real prefill + untimed depth-extension + many-decode-step
+/// run against the real Bonsai-27B weights, including across at least one F32 staging buffer
+/// growth event triggered mid-run (growth resets that slot's valid-length bookkeeping -- see
+/// <c>EnsureF32KvReadStaging</c> -- and this test's final depth of 152 is chosen to make at least
+/// one such growth event very likely for any realistic per-layer kvElems size).
+///
+/// The two model instances are run SEQUENTIALLY, not concurrently: Bonsai's ~7.2GB PQ2_0 weight
+/// set would not fit twice on a 12GB RTX 3060 (loading both at once risks the WDDM-silent-paging
+/// hang this investigation has hit before -- see the prismml-bonsai-model project memory).
+/// </summary>
+[Trait("Category", "GPU")]
+[Collection(CudaCollection.Name)]
+public class CudaQwen3HybridDenseIncrementalKvDequantTest
+{
+    private const string ModelPathEnvVar = "DOTLLM_BONSAI_PQ2_0_GGUF";
+    private const string FileName = "Ternary-Bonsai-27B-Q2_0.gguf";
+    private const int SliceLen = 48;
+
+    private readonly ITestOutputHelper _out;
+    public CudaQwen3HybridDenseIncrementalKvDequantTest(ITestOutputHelper output) => _out = output;
+
+    private static bool IsCudaDriverPresent()
+    {
+        string lib = OperatingSystem.IsWindows() ? "nvcuda.dll" : "libcuda.so.1";
+        if (!NativeLibrary.TryLoad(lib, out nint h)) return false;
+        NativeLibrary.Free(h);
+        return CudaDevice.IsAvailable();
+    }
+
+    [SkippableFact]
+    public void IncrementalKvDequant_MatchesForcedFullReconversion_AcrossManyDecodeSteps()
+    {
+        Skip.IfNot(IsCudaDriverPresent(), "No CUDA GPU available");
+        string? path = ResolveFixturePath();
+        Skip.If(path is null,
+            $"Bonsai PQ2_0 GGUF fixture not found. Set {ModelPathEnvVar}, or place {FileName} under "
+            + "~/.dotllm/models/PrismML/Ternary-Bonsai-27B-GGUF/ or ~/.dotllm/test-cache/PrismML/Ternary-Bonsai-27B-GGUF/.");
+        string? ptxDir = FindPtxDir();
+        Skip.If(ptxDir is null, "PTX files not found");
+
+        // Sequential, not concurrent -- see class doc. Reference (pre-fix-equivalent) run first,
+        // then the fast (incremental) run; the two model instances never coexist on the GPU.
+        _out.WriteLine("Running reference (forced full KV reconversion, pre-fix behavior)...");
+        float[][] refLogits = RunSequenceCaptureLogits(path!, ptxDir!, forceFullReconvert: true);
+
+        _out.WriteLine("Running fast (incremental KV reconversion, this fix)...");
+        float[][] fastLogits = RunSequenceCaptureLogits(path!, ptxDir!, forceFullReconvert: false);
+
+        Assert.Equal(refLogits.Length, fastLogits.Length);
+        for (int step = 0; step < refLogits.Length; step++)
+        {
+            for (int i = 0; i < SliceLen; i++)
+            {
+                float a = refLogits[step][i];
+                float b = fastLogits[step][i];
+                Assert.True(BitConverter.SingleToInt32Bits(a) == BitConverter.SingleToInt32Bits(b),
+                    $"step {step}, logits[{i}]: reference(full-reconvert)={a}, fast(incremental)={b} -- " +
+                    "not bit-identical; the incremental KV F16->F32 staging path has diverged from " +
+                    "the old full-reconversion behavior.");
+            }
+        }
+
+        _out.WriteLine($"{refLogits.Length} steps compared, {SliceLen} logits each -- all bit-identical.");
+    }
+
+    /// <summary>
+    /// Deterministic prefill (8 tokens) + untimed depth-extension (120 tokens, re-tiling the
+    /// prompt, mirroring <c>BenchRunner</c>'s <c>--depth</c> handling) + 24 single-token decode
+    /// steps. Final depth 152.
+    /// </summary>
+    private static (int[][] tokens, int[][] positions) BuildDeterministicSequence()
+    {
+        int[] promptTokens = [1, 100, 2000, 30000, 5, 777, 42, 9001];
+        int[] promptPositions = [0, 1, 2, 3, 4, 5, 6, 7];
+
+        const int depth = 120;
+        int[] extraTokens = new int[depth];
+        int[] extraPositions = new int[depth];
+        for (int i = 0; i < depth; i++)
+        {
+            extraTokens[i] = promptTokens[i % promptTokens.Length];
+            extraPositions[i] = promptTokens.Length + i;
+        }
+
+        const int decodeSteps = 24;
+        var tokens = new int[2 + decodeSteps][];
+        var positions = new int[2 + decodeSteps][];
+        tokens[0] = promptTokens;
+        positions[0] = promptPositions;
+        tokens[1] = extraTokens;
+        positions[1] = extraPositions;
+
+        int nextPos = promptTokens.Length + depth;
+        for (int step = 0; step < decodeSteps; step++)
+        {
+            tokens[2 + step] = [(7 + step * 13) % 40000];
+            positions[2 + step] = [nextPos];
+            nextPos++;
+        }
+
+        return (tokens, positions);
+    }
+
+    private static float[][] RunSequenceCaptureLogits(string path, string ptxDir, bool forceFullReconvert)
+    {
+        var (tokenSteps, positionSteps) = BuildDeterministicSequence();
+
+        using var gguf = GgufFile.Open(path);
+        var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+        Assert.Equal(Architecture.Qwen3HybridDense, config.Architecture);
+
+        using var model = CudaQwen3HybridDenseTransformerModel.LoadFromGguf(gguf, config, deviceId: 0, ptxDir);
+        model.ForceFullKvReconvertForTest = forceFullReconvert;
+
+        using var kvCache = model.CreateKvCache(maxSeqLen: 256);
+
+        var results = new float[tokenSteps.Length][];
+        for (int step = 0; step < tokenSteps.Length; step++)
+        {
+            using var logits = model.Forward(tokenSteps[step], positionSteps[step], deviceId: -1, kvCache);
+            results[step] = ExtractLastRowSlice(logits, SliceLen);
+        }
+        return results;
+    }
+
+    private static unsafe float[] ExtractLastRowSlice(ITensor logits, int sliceLen)
+    {
+        int rank = logits.Shape.Rank;
+        int vocab = logits.Shape[rank - 1];
+        long rows = 1;
+        for (int d = 0; d < rank - 1; d++) rows *= logits.Shape[d];
+
+        float* basePtr = (float*)logits.DataPointer + (rows - 1) * vocab;
+        var slice = new float[sliceLen];
+        for (int i = 0; i < sliceLen; i++) slice[i] = basePtr[i];
+        return slice;
+    }
+
+    private static string? ResolveFixturePath()
+    {
+        string? envPath = Environment.GetEnvironmentVariable(ModelPathEnvVar);
+        if (!string.IsNullOrWhiteSpace(envPath) && File.Exists(envPath))
+            return envPath;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string[] candidates =
+        [
+            Path.Combine(home, ".dotllm", "models", "PrismML", "Ternary-Bonsai-27B-GGUF", FileName),
+            Path.Combine(home, ".dotllm", "test-cache", "PrismML", "Ternary-Bonsai-27B-GGUF", FileName),
+        ];
+        foreach (string candidate in candidates)
+            if (File.Exists(candidate))
+                return candidate;
+
+        return null;
+    }
+
+    private static string? FindPtxDir()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "ptx"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "ptx"),
+        };
+        foreach (var dir in candidates)
+        {
+            var full = Path.GetFullPath(dir);
+            if (Directory.Exists(full) && Directory.GetFiles(full, "*.ptx").Length > 0)
+                return full;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the seqLen/depth characterization documented in `.docs/handoff.md`'s "Depth-dependent
attention finding, precisely localized". Profiling `DOTLLM_HYBRID_PROFILE=1` at `--depth 0` vs
`256` found `attn-6b-kvdequant` grows +11% (0.065->0.073ms/call) with context depth: every decode
step in `ForwardFullAttnBody` reconverted the ENTIRE cached `[0, seqKv)` KV range from F16 to F32,
even though ordinary prefill/decode only ever appends rows -- an O(depth) cost per step (O(depth^2)
cumulative over a generation) for what should be an O(1) update.

- Converted the single shared F32 KV read-staging buffer pair (confirmed reused across all 16
  full-attention layers within one decode step) into per-slot buffer arrays with a new
  `_f32KvValidLength[slot]` tracking how much of each slot's buffer is already validly converted.
- Fast path: convert only the newly-written positions when they're a contiguous ascending run
  starting exactly at the slot's recorded valid length. Any deviation (non-contiguous positions,
  a just-grown buffer, a KV-cache handle reused for an unrelated sequence) safely falls back to
  the old full-range reconversion.
- New `CudaQwen3HybridDenseIncrementalKvDequantTest`: real Bonsai-27B prefill + depth-extension +
  24 decode steps (crossing a staging-buffer growth boundary), asserting BIT-IDENTICAL logits
  between the fast path and the old full-reconversion path (kept reachable via a test-only
  `ForceFullKvReconvertForTest` flag). Passes, along with the existing real-GGUF smoke test and
  CPU/GPU LM-head parity test (3/3 real-weight CUDA tests).

## Real-bench result and two pre-existing findings

Small, directionally positive but noise-comparable end-to-end win. While validating this I found
`dotllm bench -r N>1` is unsuitable for measuring ANY context-depth-growing behavior on this
model: `BenchRunner` reuses one model instance across reps with a fresh `IKvCache` each rep, but
the model's own `_f16CacheCurrentLength` never resets when `EnsureF16KvCache`'s realloc guard
no-ops (identical `cacheSize` every rep) -- every REPORTED rep after the discarded warmup runs
"stuck" at the previous rep's final depth for its whole duration. Confirmed this reproduces
identically on unmodified `origin/dev` (not caused by this PR); attention's causal masking still
hides the stale tail correctly (no wrong logits), it just means reps don't exercise depth growth.
Also found (also pre-existing, also reproduces on unmodified `origin/dev`): `--depth` beyond
roughly 650-750 on this 12GB RTX 3060 hits a VRAM-oversubscription/WDDM-paging hang during the
batched depth-extension call (100% util, ~55-70W power, exit 127) -- unrelated to this change,
out of scope here, flagged for a follow-up issue.

Worked around both with a standalone single-token-decode-loop harness (depth built via many small
`Forward` calls, avoiding the VRAM spike; one continuous sequence per process, avoiding the rep
staleness) comparing several full-generation runs at depth 1024-4096 against unmodified
`origin/dev`:
- 2048 steps: 15.13 -> 15.81 tok/s (+4.5%)
- 2048 steps (round 2): 14.89 -> 14.91 tok/s (+0.1%)
- 4096 steps: 13.79 -> 14.16 tok/s (+2.7%)
- 1024 steps: 16.15 -> 15.96 tok/s (-1.2%)

Average +1.5%, positive in 3 of 4 rounds, no round outside this hardware's observed ~5% run-to-run
noise band. Consistent with the theoretical model: `attn-6b-kvdequant` was always a small slice of
decode time next to the much larger, architecturally-inherent `attn-6c-core` (naive attention
kernel itself, +151% over the same depth range, already tracked in `docs/CUDA.md`'s Future Work,
out of scope for a launch-fusion-style fix).

**Kept, not reverted**: zero added synchronization/round-trips, strictly less work than before in
every case, bit-exact correctness proven, no round showed a clear regression -- unlike this
investigation's several genuine negative results (all large, consistent regressions traceable to
added sync overhead).

Full `DotLLM.Tests.Unit.Cuda` suite: 309 passed / 0 failed / 37 skipped / 346 total.

Closes #182

## Test plan
- [x] New `CudaQwen3HybridDenseIncrementalKvDequantTest`: bit-identical fast-vs-reference across
      many consecutive decode steps + a mid-run buffer growth (real Bonsai-27B GGUF)
- [x] Existing `CudaQwen3HybridDenseRealGgufSmokeTest` (finite logits) still passes
- [x] Existing `CudaQwen3HybridDenseLmHeadCpuParityTest` (CPU/GPU parity) still passes
- [x] Full `DotLLM.Tests.Unit.Cuda` suite: 309/0/37/346
- [x] Real `dotllm bench`-style A/B at depth 1024-4096 (see above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>