### PR TITLE
Fix bench --depth VRAM hang and -r N>1 KV-cache cursor stick (#185)

### DIFF
--- a/src/DotLLM.Cli/Benchmarking/BenchRunner.cs
+++ b/src/DotLLM.Cli/Benchmarking/BenchRunner.cs
@@ -78,10 +78,14 @@ public static class BenchRunner
         int[] positions = new int[promptLen];
         for (int i = 0; i < promptLen; i++) positions[i] = i;
 
-        // Timed prefill (argmax excluded from the stopwatch window).
+        // Timed prefill (argmax excluded from the stopwatch window). Only the last row is ever
+        // read below, so opt in to lastTokenLogitsOnly (issue #185) -- on the CUDA hybrid models
+        // this avoids allocating/computing a full [promptLen, vocabSize] logits tensor for a
+        // value nothing but the last row consumes; other models ignore the hint and behave as
+        // before.
         int nextToken;
         var prefillSw = Stopwatch.StartNew();
-        ITensor prefillLogits = model.Forward(promptTokens, positions, deviceId: -1, cache);
+        ITensor prefillLogits = model.Forward(promptTokens, positions, deviceId: -1, cache, lastTokenLogitsOnly: true);
         prefillSw.Stop();
         using (prefillLogits)
             nextToken = ArgmaxLastRow(prefillLogits);
@@ -89,7 +93,10 @@ public static class BenchRunner
         int nextPos = promptLen;
 
         // Untimed synthetic context extension: re-tile the prompt for `depth`
-        // extra tokens so the timed decode runs at depth promptLen + depth.
+        // extra tokens so the timed decode runs at depth promptLen + depth. Same
+        // lastTokenLogitsOnly reasoning as the prefill call above -- this is the call whose
+        // full-seqLen logits tensor was the dominant VRAM cost behind issue #185's
+        // `dotllm bench --depth` hang beyond ~650-768 on a 12GB card.
         if (depth > 0)
         {
             int[] extra = new int[depth];
@@ -99,7 +106,7 @@ public static class BenchRunner
                 extra[i] = promptTokens[i % promptLen];
                 extraPos[i] = nextPos + i;
             }
-            using (var logits = model.Forward(extra, extraPos, deviceId: -1, cache))
+            using (var logits = model.Forward(extra, extraPos, deviceId: -1, cache, lastTokenLogitsOnly: true))
                 nextToken = ArgmaxLastRow(logits);
             nextPos += depth;
         }

--- a/src/DotLLM.Core/Models/IModel.cs
+++ b/src/DotLLM.Core/Models/IModel.cs
@@ -35,6 +35,45 @@ public interface IModel : IDisposable
     ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions, int deviceId, IKvCache? kvCache);
 
     /// <summary>
+    /// Runs a forward pass with optional KV-cache, with an explicit hint about whether the caller
+    /// only needs the last input position's logits.
+    /// </summary>
+    /// <remarks>
+    /// <para>Some callers (e.g. <c>BenchRunner</c>'s untimed prefill / <c>--depth</c> context
+    /// extension) submit many tokens in one call purely to advance the KV-cache/hidden state, and
+    /// only ever read the LAST position's logits (via argmax) — never the intermediate positions'.
+    /// Others (e.g. speculative-decoding verification, which submits the last-accepted token plus
+    /// K draft tokens in one call and inspects EVERY position's logits to accept/reject each draft)
+    /// genuinely need every position. The model cannot tell these two cases apart from
+    /// <paramref name="tokenIds"/>/<paramref name="kvCache"/> alone, so callers that only want the
+    /// last row must say so explicitly via <paramref name="lastTokenLogitsOnly"/>.</para>
+    /// <para>The default implementation ignores the hint and forwards to
+    /// <see cref="Forward(ReadOnlySpan{int}, ReadOnlySpan{int}, int, IKvCache?)"/>, so every
+    /// existing implementor keeps its current behavior unless it explicitly overrides this
+    /// overload to act on the hint (currently the CUDA <c>Qwen3HybridDense</c> / <c>Qwen3MoeHybrid</c>
+    /// models, whose LM-head Logits scratch buffer scales with <c>seqLen × vocab_size</c> and can be
+    /// large enough at high <c>seqLen</c> to matter for VRAM headroom — see issue #185).</para>
+    /// </remarks>
+    /// <param name="tokenIds">Input token IDs for this step.</param>
+    /// <param name="positions">Position indices for each token.</param>
+    /// <param name="deviceId">Target device for computation.</param>
+    /// <param name="kvCache">Optional KV-cache. When null, behaves identically to the uncached forward pass.</param>
+    /// <param name="lastTokenLogitsOnly">
+    /// When true AND <paramref name="tokenIds"/> has more than one token, implementations MAY
+    /// return logits for only the last position (shape [1, vocab_size]) instead of every position.
+    /// Ignored (always full per-position logits) when false — the safe default for any caller that
+    /// hasn't been audited to only ever read the last row. Has no effect when
+    /// <paramref name="tokenIds"/>.Length is already 1.
+    /// </param>
+    /// <returns>
+    /// Logits tensor of shape [1, vocab_size] when <paramref name="lastTokenLogitsOnly"/> is honored,
+    /// otherwise [seq, vocab_size] for all input positions (same as the non-hinted overload).
+    /// </returns>
+    ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions, int deviceId,
+                    IKvCache? kvCache, bool lastTokenLogitsOnly)
+        => Forward(tokenIds, positions, deviceId, kvCache);
+
+    /// <summary>
     /// Runs a forward pass with optional KV-cache and an optional LoRA adapter.
     /// When <paramref name="adapter"/> is non-null and supplies <c>(layer, proj)</c>
     /// factor pairs that match the current model's projection sites, the runtime

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseForwardState.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseForwardState.cs
@@ -25,6 +25,7 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
     private readonly int _intermediateSize;
 
     private int _currentSeqLen;
+    private int _logitsCurrentRows;
     private bool _disposed;
 
     public long AllocatedBytes { get; private set; }
@@ -33,6 +34,19 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
     public nint HiddenState;
     public nint Residual;
     public nint NormOutput;
+
+    // Sized independently of the other per-token buffers above (issue #185) -- unlike
+    // HiddenState/NormOutput/etc., which every position's value feeds into the NEXT layer's
+    // computation for every OTHER position (via attention/GDN mixing) and so must stay sized to
+    // the full sequence length, Logits is a purely trailing projection nothing else reads back
+    // from within the same Forward call. The IKvCache-decode overload's documented contract
+    // (see IModel.Forward's XML doc) returns only the LAST token's logits, and every real caller
+    // (BenchRunner, TextGenerator) only ever reads the last row regardless of what shape comes
+    // back -- so sizing this cap*vocabSize*sizeof(float) (e.g. ~970 MiB at cap=1024 for a
+    // 248,320-vocab model) was pure waste for every kvCache-enabled call, and was the single
+    // largest contributor to the VRAM-ceiling hang `dotllm bench --depth` hit beyond ~650-768 on
+    // a 12GB card (confirmed via cuMemGetInfo instrumentation: EnsureCapacity's allocation for
+    // cap=1024 landed on EXACTLY 0 MiB free). See EnsureLogitsCapacity.
     public nint Logits;
 
     // ── GDN sub-layer ─────────────────────────────────────────────────────────
@@ -96,6 +110,7 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
 
         _currentSeqLen = 0;
         EnsureCapacity(1);
+        EnsureLogitsCapacity(1);
 
         // Fixed-size, seqLen-independent — allocated once, not part of FreeSequenceBuffers/EnsureCapacity.
         GdnScanPartialTmp = AllocDevice((long)_gdnHeads * 4 * dState * sizeof(float));
@@ -105,6 +120,7 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
     /// <summary>
     /// Grows all per-token buffers to cover at least <paramref name="seqLen"/> tokens,
     /// reallocating in power-of-two increments. No-op when capacity already suffices.
+    /// Does NOT size <see cref="Logits"/> -- see <see cref="EnsureLogitsCapacity"/>.
     /// </summary>
     public void EnsureCapacity(int seqLen)
     {
@@ -116,7 +132,6 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
         HiddenState = AllocDevice((long)cap * _hiddenSize * sizeof(float));
         Residual = AllocDevice((long)cap * _hiddenSize * sizeof(float));
         NormOutput = AllocDevice((long)cap * _hiddenSize * sizeof(float));
-        Logits = AllocDevice((long)cap * _vocabSize * sizeof(float));
 
         GdnConvInput = AllocDevice((long)(_dConv - 1 + cap) * _convDim * sizeof(float));
         GdnQkvBuf = AllocDevice((long)cap * _convDim * sizeof(float));
@@ -145,6 +160,22 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
         _currentSeqLen = cap;
     }
 
+    /// <summary>
+    /// Grows <see cref="Logits"/> to cover at least <paramref name="rows"/> rows (issue #185).
+    /// Sized independently of <see cref="EnsureCapacity"/>'s <c>cap</c> -- callers pass 1 for the
+    /// common kvCache-enabled decode/depth-extension path (only the last token's logits are ever
+    /// consumed) and the real row count for the uncached multi-token path. No power-of-two
+    /// rounding: the two regimes are wildly different scales and this buffer is never in a hot
+    /// per-token growth loop the way the other per-token buffers are.
+    /// </summary>
+    public void EnsureLogitsCapacity(int rows)
+    {
+        if (rows <= _logitsCurrentRows) return;
+        FreeIfNonZero(ref Logits);
+        Logits = AllocDevice((long)rows * _vocabSize * sizeof(float));
+        _logitsCurrentRows = rows;
+    }
+
     private nint AllocDevice(long bytes)
     {
         CudaDriverApi.cuMemAlloc_v2(out nint ptr, (nuint)bytes).ThrowOnError();
@@ -166,7 +197,6 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
         FreeIfNonZero(ref HiddenState);
         FreeIfNonZero(ref Residual);
         FreeIfNonZero(ref NormOutput);
-        FreeIfNonZero(ref Logits);
         FreeIfNonZero(ref GdnConvInput);
         FreeIfNonZero(ref GdnQkvBuf);
         FreeIfNonZero(ref GdnZBuf);
@@ -194,9 +224,11 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
     {
         if (_disposed) return;
         FreeSequenceBuffers();
+        FreeIfNonZero(ref Logits);
         FreeIfNonZero(ref GdnScanPartialTmp);
         FreeIfNonZero(ref GdnScanPartialOut);
         _currentSeqLen = 0;
+        _logitsCurrentRows = 0;
         _disposed = true;
         GC.SuppressFinalize(this);
     }
@@ -205,6 +237,7 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
     {
         if (_disposed) return;
         FreeSequenceBuffers();
+        FreeIfNonZero(ref Logits);
         FreeIfNonZero(ref GdnScanPartialTmp);
         FreeIfNonZero(ref GdnScanPartialOut);
     }

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
@@ -99,6 +99,20 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
     private int _f16CacheMaxSeqLen;
     private int _f16CacheCurrentLength;
 
+    // Identity of the IKvCache instance last seen by ForwardFullAttnBody (issue #185). A fresh
+    // Forward call whose kvCache is a DIFFERENT instance than last time means "new/unrelated
+    // sequence" even when its MaxLength happens to match the previous cache's -- EnsureF16KvCache's
+    // "maxSeqLen <= _f16CacheMaxSeqLen" guard only resets _f16CacheCurrentLength/_f32KvValidLength
+    // on a capacity-driven reallocation, so a same-size reused-instance-free sequence (e.g. every
+    // rep after the first in `dotllm bench -r N>1`, or a scheduler session rebuild that lands on an
+    // identical cacheSize) would otherwise leave the previous sequence's final depth "stuck" for the
+    // new sequence's entire duration. Reference identity is a reliable signal here because every
+    // caller (BenchRunner, ContinuousBatchScheduler, TextGenerator) allocates a brand-new IKvCache
+    // instance per logical sequence and only reuses the SAME instance across calls that belong to
+    // that one sequence (including legitimate mid-sequence speculative-decoding rollback, which must
+    // NOT reset this state).
+    private IKvCache? _lastForwardKvCache;
+
     private nint _f16KvWriteStaging;
     private long _f16KvWriteStagingElems;
 
@@ -120,6 +134,14 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
     // the old behavior across many consecutive decode steps and buffer growths. Never set on the
     // production Forward path.
     internal bool ForceFullKvReconvertForTest { get; set; }
+
+    /// <summary>
+    /// Test-only accessor for issue #185's regression test — exposes the F16 KV cache's current
+    /// -length cursor directly, since correctness (attention logits) is unaffected by the bug this
+    /// cursor's reset fixes (causal masking hides any stale over-length KV range regardless), so a
+    /// black-box logits comparison cannot discriminate broken vs. fixed here.
+    /// </summary>
+    internal int DebugF16CacheCurrentLengthForTest => _f16CacheCurrentLength;
 
     // Opt-in split-KV attention (issue #183) scratch: partial (max, sum, out) per (head, split).
     // Sized once for the model's fixed (numHeads, headDim) shape and reused every decode step.
@@ -1099,6 +1121,13 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         // ── 6. Attention (GQA with causal mask) ──
         if (kvCache is not null)
         {
+            if (!ReferenceEquals(kvCache, _lastForwardKvCache))
+            {
+                _lastForwardKvCache = kvCache;
+                _f16CacheCurrentLength = 0;
+                if (_f32KvValidLength is not null) Array.Clear(_f32KvValidLength);
+            }
+
             EnsureF16KvCache(kvCache.MaxLength, numKvHeads, headDim);
             int slot = _kvSlotForLayer[layer];
             if (slot < 0)
@@ -1133,11 +1162,11 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
             //
             // Result (issue #182, RTX 3060, real Bonsai-27B, single continuous decode sequence --
             // NOT `dotllm bench -r N>1`, which was found during this work to be unsuitable for
-            // measuring this specific change: all reps but the discarded warmup share one model
-            // instance whose _f16CacheCurrentLength never resets when a same-size IKvCache is
-            // reused, so every REPORTED rep runs "stuck" at the previous rep's final depth for its
-            // entire duration -- a separate, pre-existing bench-methodology gap, not a correctness
-            // bug in this fix, see issue #182's PR description): bit-exact vs. the old full-range
+            // measuring this specific change: all reps but the discarded warmup shared one model
+            // instance whose _f16CacheCurrentLength never reset when a same-size IKvCache was
+            // reused, so every REPORTED rep ran "stuck" at the previous rep's final depth for its
+            // entire duration -- a separate bench-methodology gap, not a correctness bug in this
+            // fix, tracked and FIXED by issue #185's reference-identity reset above): bit-exact vs. the old full-range
             // reconversion (dedicated correctness test, many consecutive steps incl. a mid-run F32
             // staging buffer growth). End-to-end wall-clock across several full single-sequence
             // decode runs (2048-4096 steps, single-token-decode-loop depth-building to avoid an

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseTransformerModel.cs
@@ -588,9 +588,14 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         => Forward(tokenIds, positions, deviceId, kvCache: null);
 
     /// <inheritdoc/>
-    [SkipLocalsInit]
     public ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions,
                            int deviceId, IKvCache? kvCache)
+        => Forward(tokenIds, positions, deviceId, kvCache, lastTokenLogitsOnly: false);
+
+    /// <inheritdoc/>
+    [SkipLocalsInit]
+    public ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions,
+                           int deviceId, IKvCache? kvCache, bool lastTokenLogitsOnly)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -621,7 +626,9 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
         // (~0.2% profiled) — not the dark matter some earlier hypotheses suspected.
         ProfStart();
         _context.MakeCurrent();
+        if (DebugTrace) LogVram($"before EnsureCapacity(seqLen={seqLen})");
         _state.EnsureCapacity(seqLen);
+        if (DebugTrace) LogVram($"after EnsureCapacity (state.AllocatedBytes={_state.AllocatedBytes:N0})");
 
         nint streamH = _stream.Handle;
 
@@ -660,23 +667,45 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
                 numHeads, numKvHeads, headDim, eps, kvCache);
         }
 
-        if (DebugTrace) { _stream.Synchronize(); Console.Error.WriteLine("[hybrid-debug] all layers done, starting lm_head"); Console.Error.Flush(); }
+        if (DebugTrace) { _stream.Synchronize(); Console.Error.WriteLine("[hybrid-debug] all layers done, starting lm_head"); Console.Error.Flush(); LogVram("before lm-head"); }
         ProfStart();
-        _kernels.LaunchRmsNormF32(_state.HiddenState, _outputNormDevice, _state.HiddenState,
-            hiddenSize, eps, seqLen, streamH);
-        Gemm(_outputDevice, _outputQt, _state.HiddenState, _state.Logits,
-             _outputOutputDim, _outputInputDim, seqLen);
+
+        // Issue #185: only compute/copy the LAST token's logits when the caller has explicitly
+        // opted in via lastTokenLogitsOnly (e.g. BenchRunner's untimed prefill / --depth context
+        // extension, which only ever reads the last row via argmax). This must NOT be inferred
+        // from kvCache alone -- speculative-decoding verification also submits multiple tokens
+        // through a kvCache-bearing Forward call but genuinely needs EVERY position's logits to
+        // accept/reject each draft token, so it correctly leaves the hint false (see IModel's XML
+        // doc on this overload). Restricting the final RmsNorm/LM-head-GEMM/D2H-copy to one row
+        // eliminates the single largest VRAM consumer in this Forward call when honored: the old
+        // code always sized and computed a full [seqLen, vocabSize] Logits tensor (e.g. ~970 MiB
+        // of scratch alone at seqLen=1024 for this model's 248,320-token vocabulary), which was
+        // the dominant term in the VRAM-ceiling hang `dotllm bench --depth` hit beyond ~650-768 on
+        // a 12GB card (confirmed via cuMemGetInfo instrumentation: EnsureCapacity's cap=1024
+        // allocation landed on EXACTLY 0 MiB free). Every caller that hasn't opted in (including
+        // ordinary seqLen==1 decode, where this is a no-op either way) keeps returning full
+        // per-position logits, unchanged from before this fix.
+        int logitsRows = lastTokenLogitsOnly ? 1 : seqLen;
+        _state.EnsureLogitsCapacity(logitsRows);
+        nint lmHeadInput = logitsRows == seqLen
+            ? _state.HiddenState
+            : _state.HiddenState + (nint)((long)(seqLen - 1) * hiddenSize * sizeof(float));
+        _kernels.LaunchRmsNormF32(lmHeadInput, _outputNormDevice, lmHeadInput,
+            hiddenSize, eps, logitsRows, streamH);
+        Gemm(_outputDevice, _outputQt, lmHeadInput, _state.Logits,
+             _outputOutputDim, _outputInputDim, logitsRows);
         ProfMark("lm-head");
-        if (DebugTrace) { _stream.Synchronize(); Console.Error.WriteLine("[hybrid-debug] lm_head done"); Console.Error.Flush(); }
+        if (DebugTrace) { _stream.Synchronize(); Console.Error.WriteLine("[hybrid-debug] lm_head done"); Console.Error.Flush(); LogVram("after lm-head"); }
 
         _stream.Synchronize();
         ProfStart(); // measures result alloc + D2H logits copy
 
-        var shape = new TensorShape(seqLen, vocabSize);
+        var shape = new TensorShape(logitsRows, vocabSize);
         var result = UnmanagedTensor.Allocate(shape, DType.Float32, deviceId);
         CudaDriverApi.cuMemcpyDtoH_v2(result.DataPointer, _state.Logits,
-            (nuint)((long)seqLen * vocabSize * sizeof(float))).ThrowOnError();
+            (nuint)((long)logitsRows * vocabSize * sizeof(float))).ThrowOnError();
         ProfMark("output-copy");
+        if (DebugTrace) LogVram("after D2H logits copy");
 
         return result;
     }
@@ -769,6 +798,23 @@ public sealed unsafe class CudaQwen3HybridDenseTransformerModel : IModel
 
     private static readonly bool DebugTrace =
         Environment.GetEnvironmentVariable("DOTLLM_HYBRID_DEBUG") == "1";
+
+    /// <summary>
+    /// Issue #185 diagnostic: logs free/total device VRAM (via <c>cuMemGetInfo</c>) under the same
+    /// <see cref="DebugTrace"/> gate used by the existing hybrid-debug traces above — zero cost when
+    /// unset. Added to find the real allocation source of the VRAM-ceiling hang that
+    /// <c>dotllm bench --depth</c> hits beyond ~650-768 on a 12GB card (see the issue for the
+    /// original symptom description).
+    /// </summary>
+    private static void LogVram(string label)
+    {
+        CudaDriverApi.cuMemGetInfo_v2(out nuint free, out nuint total).ThrowOnError();
+        long usedMiB = (long)(total - free) / (1024 * 1024);
+        long freeMiB = (long)free / (1024 * 1024);
+        long totalMiB = (long)total / (1024 * 1024);
+        Console.Error.WriteLine($"[hybrid-debug][vram] {label}: used={usedMiB}MiB free={freeMiB}MiB total={totalMiB}MiB");
+        Console.Error.Flush();
+    }
 
     // ──────────────────────────────────────────────────────────────────────
     //  One-off category profiler (DOTLLM_HYBRID_PROFILE=1). Coarse (Stopwatch +

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridForwardState.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridForwardState.cs
@@ -37,6 +37,7 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
     private readonly long _moeW2ElemsPerExpert;
 
     private int _currentSeqLen;
+    private int _logitsCurrentRows;
     private bool _disposed;
 
     public long AllocatedBytes { get; private set; }
@@ -45,6 +46,9 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
     public nint HiddenState;
     public nint Residual;
     public nint NormOutput;
+
+    // Sized independently of the other per-token buffers above (issue #185) -- see
+    // CudaQwen3HybridDenseForwardState's identically-named field doc for the full rationale.
     public nint Logits;
 
     // ── GDN sub-layer ─────────────────────────────────────────────────────────
@@ -165,11 +169,13 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
 
         _currentSeqLen = 0;
         EnsureCapacity(1);
+        EnsureLogitsCapacity(1);
     }
 
     /// <summary>
     /// Grows all per-token buffers to cover at least <paramref name="seqLen"/> tokens,
     /// reallocating in power-of-two increments. No-op when capacity already suffices.
+    /// Does NOT size <see cref="Logits"/> -- see <see cref="EnsureLogitsCapacity"/>.
     /// </summary>
     public void EnsureCapacity(int seqLen)
     {
@@ -181,7 +187,6 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
         HiddenState = AllocDevice((long)cap * _hiddenSize * sizeof(float));
         Residual = AllocDevice((long)cap * _hiddenSize * sizeof(float));
         NormOutput = AllocDevice((long)cap * _hiddenSize * sizeof(float));
-        Logits = AllocDevice((long)cap * _vocabSize * sizeof(float));
 
         GdnConvInput = AllocDevice((long)(_dConv - 1 + cap) * _convDim * sizeof(float));
         GdnQkvBuf = AllocDevice((long)cap * _convDim * sizeof(float));
@@ -206,6 +211,18 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
         _currentSeqLen = cap;
     }
 
+    /// <summary>
+    /// Grows <see cref="Logits"/> to cover at least <paramref name="rows"/> rows (issue #185) --
+    /// see <see cref="CudaQwen3HybridDenseForwardState.EnsureLogitsCapacity"/> for the rationale.
+    /// </summary>
+    public void EnsureLogitsCapacity(int rows)
+    {
+        if (rows <= _logitsCurrentRows) return;
+        FreeIfNonZero(ref Logits);
+        Logits = AllocDevice((long)rows * _vocabSize * sizeof(float));
+        _logitsCurrentRows = rows;
+    }
+
     private nint AllocDevice(long bytes)
     {
         CudaDriverApi.cuMemAlloc_v2(out nint ptr, (nuint)bytes).ThrowOnError();
@@ -227,7 +244,6 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
         FreeIfNonZero(ref HiddenState);
         FreeIfNonZero(ref Residual);
         FreeIfNonZero(ref NormOutput);
-        FreeIfNonZero(ref Logits);
         FreeIfNonZero(ref GdnConvInput);
         FreeIfNonZero(ref GdnQkvBuf);
         FreeIfNonZero(ref GdnZBuf);
@@ -259,8 +275,10 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
     {
         if (_disposed) return;
         FreeSequenceBuffers();
+        FreeIfNonZero(ref Logits);
         FreeMoeScratch();
         _currentSeqLen = 0;
+        _logitsCurrentRows = 0;
         _disposed = true;
         GC.SuppressFinalize(this);
     }
@@ -269,6 +287,7 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
     {
         if (_disposed) return;
         FreeSequenceBuffers();
+        FreeIfNonZero(ref Logits);
         FreeMoeScratch();
     }
 }

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
@@ -119,6 +119,16 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
     private int _f16CacheMaxSeqLen;        // current allocated capacity
     private int _f16CacheCurrentLength;    // mirrors IKvCache.CurrentLength for the model-internal cache
 
+    // Identity of the IKvCache instance last seen by ForwardFullAttnBody (issue #185) -- see
+    // CudaQwen3HybridDenseTransformerModel's field doc for the full rationale. A same-size fresh
+    // IKvCache instance (a new logical sequence) must reset _f16CacheCurrentLength even when
+    // EnsureF16KvCache's capacity-driven reallocation guard no-ops.
+    private IKvCache? _lastForwardKvCache;
+
+    /// <summary>Test-only accessor for issue #185's regression test — see the Dense hybrid
+    /// model's identically-named member for the full rationale.</summary>
+    internal int DebugF16CacheCurrentLengthForTest => _f16CacheCurrentLength;
+
     // Per-step staging for the cache-enabled full-attention path.
     //
     // _f16KvWriteStaging: F32→F16 conversion target for the freshly-projected
@@ -2000,6 +2010,12 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         //     dequant overwrites it) so the net savings is ~600 MB.
         if (kvCache is not null)
         {
+            if (!ReferenceEquals(kvCache, _lastForwardKvCache))
+            {
+                _lastForwardKvCache = kvCache;
+                _f16CacheCurrentLength = 0;
+            }
+
             EnsureF16KvCache(kvCache.MaxLength, numKvHeads, headDim);
             int slot = _kvSlotForLayer[layer];
             if (slot < 0)

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
@@ -1606,9 +1606,14 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         => Forward(tokenIds, positions, deviceId, kvCache: null);
 
     /// <inheritdoc/>
-    [SkipLocalsInit]
     public ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions,
                            int deviceId, IKvCache? kvCache)
+        => Forward(tokenIds, positions, deviceId, kvCache, lastTokenLogitsOnly: false);
+
+    /// <inheritdoc/>
+    [SkipLocalsInit]
+    public ITensor Forward(ReadOnlySpan<int> tokenIds, ReadOnlySpan<int> positions,
+                           int deviceId, IKvCache? kvCache, bool lastTokenLogitsOnly)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -1669,18 +1674,27 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         }
 
         // ── Final norm + lm_head ──
-        _kernels.LaunchRmsNormF32(_state.HiddenState, _outputNormDevice, _state.HiddenState,
-            hiddenSize, eps, seqLen, streamH);
-        Gemm(_outputDevice, _outputQt, _state.HiddenState, _state.Logits,
-             _outputOutputDim, _outputInputDim, seqLen);
+        // Issue #185: see CudaQwen3HybridDenseTransformerModel's identically-structured block for
+        // the full rationale -- only shrink to the last row when the caller explicitly opts in via
+        // lastTokenLogitsOnly (never inferred from kvCache alone: speculative-decoding verification
+        // also submits multiple tokens through a kvCache-bearing call and needs every position).
+        int logitsRows = lastTokenLogitsOnly ? 1 : seqLen;
+        _state.EnsureLogitsCapacity(logitsRows);
+        nint lmHeadInput = logitsRows == seqLen
+            ? _state.HiddenState
+            : _state.HiddenState + (nint)((long)(seqLen - 1) * hiddenSize * sizeof(float));
+        _kernels.LaunchRmsNormF32(lmHeadInput, _outputNormDevice, lmHeadInput,
+            hiddenSize, eps, logitsRows, streamH);
+        Gemm(_outputDevice, _outputQt, lmHeadInput, _state.Logits,
+             _outputOutputDim, _outputInputDim, logitsRows);
 
         // Sync and D2H the logits.
         _stream.Synchronize();
 
-        var shape = new TensorShape(seqLen, vocabSize);
+        var shape = new TensorShape(logitsRows, vocabSize);
         var result = UnmanagedTensor.Allocate(shape, DType.Float32, deviceId);
         CudaDriverApi.cuMemcpyDtoH_v2(result.DataPointer, _state.Logits,
-            (nuint)((long)seqLen * vocabSize * sizeof(float))).ThrowOnError();
+            (nuint)((long)logitsRows * vocabSize * sizeof(float))).ThrowOnError();
 
         return result;
     }

--- a/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridDenseKvCacheReuseResetTest.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridDenseKvCacheReuseResetTest.cs
@@ -1,0 +1,139 @@
+using System.Runtime.InteropServices;
+using DotLLM.Cuda;
+using DotLLM.Cuda.Architectures;
+using DotLLM.Models.Gguf;
+using Xunit;
+using Xunit.Abstractions;
+using Architecture = DotLLM.Core.Configuration.Architecture;
+
+namespace DotLLM.Tests.Unit.Cuda;
+
+/// <summary>
+/// Regression test for issue #185, Finding 2: <see cref="CudaQwen3HybridDenseTransformerModel"/>'s
+/// internal F16 KV-cache "current length" cursor must reset when <c>Forward</c> is called with a
+/// DIFFERENT (but same-<see cref="DotLLM.Core.Attention.IKvCache.MaxLength"/>) <see
+/// cref="DotLLM.Core.Attention.IKvCache"/> instance -- i.e. a new logical sequence reusing an
+/// identically-sized cache slot, exactly the pattern <c>BenchRunner</c>'s <c>-r N&gt;1</c> repeats
+/// and <c>ContinuousBatchScheduler</c>'s session-rebuild path can also produce.
+///
+/// Before the fix, <c>EnsureF16KvCache</c>'s "already allocated and big enough" guard
+/// (<c>maxSeqLen &lt;= _f16CacheMaxSeqLen</c>) skipped resetting <c>_f16CacheCurrentLength</c>
+/// whenever the new cache's capacity did not force a reallocation, so a second, unrelated sequence
+/// sharing that capacity would see the model's cursor "stuck" at the first sequence's final depth.
+/// This does NOT corrupt attention logits (causal masking is position-based, not
+/// cursor-based -- see the issue) so a black-box logits comparison cannot discriminate broken vs.
+/// fixed; this test asserts directly on the internal cursor via
+/// <see cref="CudaQwen3HybridDenseTransformerModel.DebugF16CacheCurrentLengthForTest"/>.
+/// </summary>
+[Trait("Category", "GPU")]
+[Collection(CudaCollection.Name)]
+public class CudaQwen3HybridDenseKvCacheReuseResetTest
+{
+    private const string ModelPathEnvVar = "DOTLLM_BONSAI_PQ2_0_GGUF";
+    private const string FileName = "Ternary-Bonsai-27B-Q2_0.gguf";
+
+    private readonly ITestOutputHelper _out;
+    public CudaQwen3HybridDenseKvCacheReuseResetTest(ITestOutputHelper output) => _out = output;
+
+    private static bool IsCudaDriverPresent()
+    {
+        string lib = OperatingSystem.IsWindows() ? "nvcuda.dll" : "libcuda.so.1";
+        if (!NativeLibrary.TryLoad(lib, out nint h)) return false;
+        NativeLibrary.Free(h);
+        return CudaDevice.IsAvailable();
+    }
+
+    [SkippableFact]
+    public void FreshSameSizeKvCache_ResetsCursor_InsteadOfStickingAtPriorSequenceDepth()
+    {
+        Skip.IfNot(IsCudaDriverPresent(), "No CUDA GPU available");
+        string? path = ResolveFixturePath();
+        Skip.If(path is null,
+            $"Bonsai PQ2_0 GGUF fixture not found. Set {ModelPathEnvVar}, or place {FileName} under "
+            + "~/.dotllm/models/PrismML/Ternary-Bonsai-27B-GGUF/ or ~/.dotllm/test-cache/PrismML/Ternary-Bonsai-27B-GGUF/.");
+        string? ptxDir = FindPtxDir();
+        Skip.If(ptxDir is null, "PTX files not found");
+
+        using var gguf = GgufFile.Open(path!);
+        var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+        Assert.Equal(Architecture.Qwen3HybridDense, config.Architecture);
+
+        using var model = CudaQwen3HybridDenseTransformerModel.LoadFromGguf(gguf, config, deviceId: 0, ptxDir!);
+
+        const int cacheSize = 256;
+        int[] promptTokens = [1, 100, 2000, 30000, 5, 777, 42, 9001];
+        int[] promptPositions = [0, 1, 2, 3, 4, 5, 6, 7];
+        const int decodeSteps = 32;
+
+        // Sequence A: fresh cache, prefill + decode to a real final depth well past promptLen.
+        using (var cacheA = model.CreateKvCache(cacheSize))
+        {
+            using (model.Forward(promptTokens, promptPositions, deviceId: -1, cacheA)) { }
+
+            int nextPos = promptTokens.Length;
+            for (int i = 0; i < decodeSteps; i++)
+            {
+                int[] single = [(7 + i * 13) % 40000];
+                int[] singlePos = [nextPos];
+                using (model.Forward(single, singlePos, deviceId: -1, cacheA)) { }
+                nextPos++;
+            }
+
+            int expectedDepthA = promptTokens.Length + decodeSteps;
+            Assert.Equal(expectedDepthA, model.DebugF16CacheCurrentLengthForTest);
+            _out.WriteLine($"Sequence A: cursor == {model.DebugF16CacheCurrentLengthForTest} (expected {expectedDepthA}).");
+        }
+
+        // Sequence B: a BRAND NEW IKvCache instance, same MaxLength (cacheSize) as sequence A's --
+        // exactly the shape BenchRunner's rep loop and a same-size scheduler rebuild produce. Its
+        // own prefill is shallower than sequence A's final depth: if the cursor is stuck (pre-fix
+        // bug), it will still read as sequence A's final depth instead of this prefill's own length.
+        using (var cacheB = model.CreateKvCache(cacheSize))
+        {
+            using (model.Forward(promptTokens, promptPositions, deviceId: -1, cacheB)) { }
+
+            int expectedDepthB = promptTokens.Length;
+            int actualDepthB = model.DebugF16CacheCurrentLengthForTest;
+            _out.WriteLine($"Sequence B: cursor == {actualDepthB} (expected {expectedDepthB}).");
+            Assert.True(actualDepthB == expectedDepthB,
+                $"Sequence B's KV-cache cursor is {actualDepthB}, expected {expectedDepthB} -- " +
+                "the cursor did not reset for the new same-size IKvCache instance and is still " +
+                "reflecting sequence A's prior final depth (issue #185, Finding 2).");
+        }
+    }
+
+    private static string? ResolveFixturePath()
+    {
+        string? envPath = Environment.GetEnvironmentVariable(ModelPathEnvVar);
+        if (!string.IsNullOrWhiteSpace(envPath) && File.Exists(envPath))
+            return envPath;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string[] candidates =
+        [
+            Path.Combine(home, ".dotllm", "models", "PrismML", "Ternary-Bonsai-27B-GGUF", FileName),
+            Path.Combine(home, ".dotllm", "test-cache", "PrismML", "Ternary-Bonsai-27B-GGUF", FileName),
+        ];
+        foreach (string candidate in candidates)
+            if (File.Exists(candidate))
+                return candidate;
+
+        return null;
+    }
+
+    private static string? FindPtxDir()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "ptx"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "ptx"),
+        };
+        foreach (var dir in candidates)
+        {
+            var full = Path.GetFullPath(dir);
+            if (Directory.Exists(full) && Directory.GetFiles(full, "*.ptx").Length > 0)
+                return full;
+        }
+        return null;
+    }
+}

--- a/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridDenseLastTokenLogitsOnlyTest.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridDenseLastTokenLogitsOnlyTest.cs
@@ -1,0 +1,178 @@
+using System.Runtime.InteropServices;
+using DotLLM.Cuda;
+using DotLLM.Cuda.Architectures;
+using DotLLM.Models.Gguf;
+using Xunit;
+using Xunit.Abstractions;
+using Architecture = DotLLM.Core.Configuration.Architecture;
+
+namespace DotLLM.Tests.Unit.Cuda;
+
+/// <summary>
+/// Regression test for issue #185, Finding 1: the <c>lastTokenLogitsOnly</c> hint on
+/// <see cref="CudaQwen3HybridDenseTransformerModel"/>'s <c>Forward</c> overload must (a) return a
+/// <c>[1, vocabSize]</c> tensor instead of <c>[seqLen, vocabSize]</c>, and (b) that one row must
+/// closely match (within the tolerance below -- NOT bit-identical, see remark) the last row a full
+/// (non-hinted) call over the same tokens/positions would produce.
+///
+/// This matters because the old code always computed a full <c>[seqLen, vocabSize]</c> Logits
+/// tensor even when a caller (e.g. <c>BenchRunner</c>'s untimed prefill / <c>--depth</c> context
+/// extension) only ever read the last row -- at this model's 248,320-token vocabulary, that
+/// scratch buffer alone was ~970 MiB at seqLen=1024, the dominant term in the VRAM-ceiling hang
+/// `dotllm bench --depth` hit beyond ~650-768 on a 12GB card. lastTokenLogitsOnly lets an opted-in
+/// caller skip that waste; this test guards against a future regression grossly corrupting the one
+/// row that IS still computed.
+/// </summary>
+/// <remarks>
+/// NOT bit-exact by design: lastTokenLogitsOnly's seqLen=1 output routes the lm_head GEMM through
+/// <c>Gemm</c>'s dedicated GEMV fast path (an F32-native kernel -- see <c>pq2_0_gemv.cu</c>'s
+/// "F32-native activations" section), while the seqLen&gt;1 output routes through the general
+/// path (dequant-to-F16 + a cuBLAS F16 GEMM). These are two independently-implemented numerical
+/// kernels for the same logical projection -- exactly the class of benign kernel-routing
+/// floating-point drift this project already documented and tolerated in the
+/// <c>CudaGraphCaptureEquivalenceTest</c> fix (issues #174/#175), not a correctness bug. This
+/// exact same drift already exists, unrelated to this fix, between any ordinary decode step
+/// (always seqLen=1, always the GEMV path) and any prefill call (seqLen&gt;1, the general path)
+/// for a shared position -- lastTokenLogitsOnly just lets --depth's context-extension call also
+/// take the GEMV path decode already uses, instead of always taking the general path.
+/// </remarks>
+[Trait("Category", "GPU")]
+[Collection(CudaCollection.Name)]
+public class CudaQwen3HybridDenseLastTokenLogitsOnlyTest
+{
+    private const string ModelPathEnvVar = "DOTLLM_BONSAI_PQ2_0_GGUF";
+    private const string FileName = "Ternary-Bonsai-27B-Q2_0.gguf";
+    private const int SliceLen = 64;
+
+    private readonly ITestOutputHelper _out;
+    public CudaQwen3HybridDenseLastTokenLogitsOnlyTest(ITestOutputHelper output) => _out = output;
+
+    private static bool IsCudaDriverPresent()
+    {
+        string lib = OperatingSystem.IsWindows() ? "nvcuda.dll" : "libcuda.so.1";
+        if (!NativeLibrary.TryLoad(lib, out nint h)) return false;
+        NativeLibrary.Free(h);
+        return CudaDevice.IsAvailable();
+    }
+
+    [SkippableFact]
+    public void LastTokenLogitsOnly_MatchesLastRowOfFullCall_AndReturnsSingleRowShape()
+    {
+        Skip.IfNot(IsCudaDriverPresent(), "No CUDA GPU available");
+        string? path = ResolveFixturePath();
+        Skip.If(path is null,
+            $"Bonsai PQ2_0 GGUF fixture not found. Set {ModelPathEnvVar}, or place {FileName} under "
+            + "~/.dotllm/models/PrismML/Ternary-Bonsai-27B-GGUF/ or ~/.dotllm/test-cache/PrismML/Ternary-Bonsai-27B-GGUF/.");
+        string? ptxDir = FindPtxDir();
+        Skip.If(ptxDir is null, "PTX files not found");
+
+        var config = GgufModelConfigExtractor.Extract(GgufFile.Open(path!).Metadata);
+        Assert.Equal(Architecture.Qwen3HybridDense, config.Architecture);
+
+        // A multi-token, multi-position call (mirrors BenchRunner's --depth context extension) --
+        // large enough that a full [seqLen, vocab] tensor would be sizeable, small enough to keep
+        // the test fast.
+        const int seqLen = 40;
+        int[] tokens = new int[seqLen];
+        int[] positions = new int[seqLen];
+        for (int i = 0; i < seqLen; i++)
+        {
+            tokens[i] = (11 + i * 37) % 40000;
+            positions[i] = i;
+        }
+
+        // Two SEPARATE model instances, run SEQUENTIALLY (not concurrently -- see class doc on
+        // the #182 sibling test for why: Bonsai's ~7.2GB weight set would not fit twice on a 12GB
+        // RTX 3060). This model has GatedDeltaNet (recurrent-state) layers whose state is owned by
+        // the model instance itself, not the IKvCache -- reusing ONE model instance for both calls
+        // would carry GDN state over from the first call into the second regardless of which
+        // IKvCache is passed, making the two calls' outputs incomparable. Fresh model instances
+        // give each call its own zero-initialized recurrent state, isolating the comparison to
+        // exactly what lastTokenLogitsOnly changes: the LM-head row count.
+        _out.WriteLine("Running full (lastTokenLogitsOnly: false) on a fresh model instance...");
+        float[] fullLastRow;
+        using (var gguf1 = GgufFile.Open(path!))
+        using (var model1 = CudaQwen3HybridDenseTransformerModel.LoadFromGguf(gguf1, config, deviceId: 0, ptxDir!))
+        using (var cacheFull = model1.CreateKvCache(maxSeqLen: 256))
+        using (var fullLogits = model1.Forward(tokens, positions, deviceId: -1, cacheFull, lastTokenLogitsOnly: false))
+        {
+            Assert.Equal(seqLen, fullLogits.Shape[0]);
+            fullLastRow = ExtractRow(fullLogits, seqLen - 1, SliceLen);
+        }
+
+        _out.WriteLine("Running lastTokenLogitsOnly: true on a second fresh model instance...");
+        float[] hintedRow;
+        using (var gguf2 = GgufFile.Open(path!))
+        using (var model2 = CudaQwen3HybridDenseTransformerModel.LoadFromGguf(gguf2, config, deviceId: 0, ptxDir!))
+        using (var cacheHinted = model2.CreateKvCache(maxSeqLen: 256))
+        using (var hintedLogits = model2.Forward(tokens, positions, deviceId: -1, cacheHinted, lastTokenLogitsOnly: true))
+        {
+            Assert.Equal(1, hintedLogits.Shape[0]);
+            hintedRow = ExtractRow(hintedLogits, 0, SliceLen);
+        }
+
+        // AbsTol(1e-4)+RelTol(1e-3) matches this codebase's standard CUDA fixture-parity bar
+        // (e.g. CudaQwen3MoeHybridParityTests) -- appropriate here because the two rows come from
+        // genuinely different kernels (GEMV fast path vs. dequant+cuBLAS-F16 general path, see the
+        // class remark above), not because either computation is imprecise on its own.
+        const float AbsTol = 1e-4f;
+        const float RelTol = 1e-3f;
+        for (int i = 0; i < SliceLen; i++)
+        {
+            float a = fullLastRow[i];
+            float b = hintedRow[i];
+            float diff = MathF.Abs(a - b);
+            float tol = AbsTol + RelTol * MathF.Abs(a);
+            Assert.True(diff <= tol,
+                $"logits[{i}]: full-call last row={a}, lastTokenLogitsOnly row={b}, diff={diff} " +
+                $"exceeds tolerance {tol} -- shrinking the LM-head to one row changed the computed " +
+                "value by more than the expected GEMV-vs-general-path kernel drift.");
+        }
+
+        _out.WriteLine($"{SliceLen} logits compared -- full-call last row vs. lastTokenLogitsOnly row: within tolerance.");
+    }
+
+    private static unsafe float[] ExtractRow(DotLLM.Core.Tensors.ITensor logits, int row, int sliceLen)
+    {
+        int vocab = logits.Shape[logits.Shape.Rank - 1];
+        float* basePtr = (float*)logits.DataPointer + (long)row * vocab;
+        var slice = new float[sliceLen];
+        for (int i = 0; i < sliceLen; i++) slice[i] = basePtr[i];
+        return slice;
+    }
+
+    private static string? ResolveFixturePath()
+    {
+        string? envPath = Environment.GetEnvironmentVariable(ModelPathEnvVar);
+        if (!string.IsNullOrWhiteSpace(envPath) && File.Exists(envPath))
+            return envPath;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string[] candidates =
+        [
+            Path.Combine(home, ".dotllm", "models", "PrismML", "Ternary-Bonsai-27B-GGUF", FileName),
+            Path.Combine(home, ".dotllm", "test-cache", "PrismML", "Ternary-Bonsai-27B-GGUF", FileName),
+        ];
+        foreach (string candidate in candidates)
+            if (File.Exists(candidate))
+                return candidate;
+
+        return null;
+    }
+
+    private static string? FindPtxDir()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "ptx"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "native", "ptx"),
+        };
+        foreach (var dir in candidates)
+        {
+            var full = Path.GetFullPath(dir);
+            if (Directory.Exists(full) && Directory.GetFiles(full, "*.ptx").Length > 0)
+                return full;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes both findings from #185:

1. **KV-cache cursor stuck across same-size sequence reuse.** `EnsureF16KvCache`'s
   early-return guard only reset `_f16CacheCurrentLength`/`_f32KvValidLength` on a
   capacity-driven reallocation, so a fresh `IKvCache` instance reusing the same cache
   size (every `dotllm bench -r N>1` rep after the first, or a scheduler session rebuild
   landing on an identical `cacheSize`) left the previous sequence's final depth "stuck"
   as the attention `seqKv` for the new sequence's entire duration. Fixed by tracking the
   last-seen `IKvCache` instance by reference identity in `ForwardFullAttnBody` and
   resetting the cursor(s) when it changes. Applied to both
   `CudaQwen3HybridDenseTransformerModel` and `CudaQwen3MoeHybridTransformerModel`
   (duplicated logic, per this project's cross-backend-bug rule).

2. **VRAM-ceiling hang at depth >= ~650-768.** Root-caused via `cuMemGetInfo`
   instrumentation: the forward-state's `EnsureCapacity` sized every per-token scratch
   buffer — including `Logits` — to `seqLen` rounded up to the next power of two. At
   Bonsai-27B's 248,320-token vocabulary, the `Logits` buffer alone was ~970 MiB at
   `cap=1024`, the dominant term in a single allocation that measurably drove free VRAM
   to **exactly 0 MiB** on a 12GB RTX 3060 during `bench --depth`'s single large batched
   depth-extension `Forward` call. Every real caller only reads the LAST row of a
   multi-token call's logits — except speculative-decoding verification, which
   genuinely needs every position. Added an explicit `lastTokenLogitsOnly` hint to
   `IModel.Forward` (default `false`, forwarding to the existing overload — every other
   implementor/caller is unaffected) that `BenchRunner` opts into for its prefill and
   `--depth` calls.

## Verification

- The issue's own repro command (`-p 8 --depth 1024 -n 48 -r 8`) now completes cleanly
  end-to-end where it previously hung indefinitely.
- depth=768 and depth=1024 individually re-verified via VRAM instrumentation (peak usage
  drops from exactly 0 MiB free to several hundred MiB free).
- Full existing Dense/MoE hybrid GPU test suite passes unchanged.
- New regression tests: KV-cache reuse-reset (fails pre-fix, passes post-fix, confirmed
  by temporarily reverting the fix), and `lastTokenLogitsOnly` shape+value correctness
  (tolerance-based per this codebase's standard fixture-parity bar — the two code paths
  route through genuinely different kernels, a known class of benign drift already
  documented in #174/#175).

## Test plan

- [x] `dotnet build` across affected projects
- [x] New unit tests pass (GPU-gated, real Bonsai-27B fixture)
- [x] Existing Dense/MoE hybrid GPU test suite passes with no regressions
- [x] Manual repro of the issue's exact `bench` command now completes successfully

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)