### PR TITLE
perf(cuda): bound EnsureCapacity rounding waste + chunk bench depth extension (#188)

### DIFF
--- a/src/DotLLM.Cli/Benchmarking/BenchRunner.cs
+++ b/src/DotLLM.Cli/Benchmarking/BenchRunner.cs
@@ -15,6 +15,16 @@ namespace DotLLM.Cli.Benchmarking;
 public static class BenchRunner
 {
     /// <summary>
+    /// Max token count fed to <see cref="IModel.Forward(System.ReadOnlySpan{int}, System.ReadOnlySpan{int}, int, DotLLM.Core.Attention.IKvCache?, bool)"/>
+    /// per call while walking the untimed <c>--depth</c> synthetic context extension (issue
+    /// #188) -- see the call site's remarks for the full rationale. Matches the
+    /// <c>CapacityGranularity</c> the CUDA hybrid models' <c>EnsureCapacity</c> now rounds to
+    /// (issue #188) so a chunk never itself crosses a granularity-rounding boundary mid-chunk,
+    /// though the two constants are independent and don't need to stay in lockstep.
+    /// </summary>
+    private const int DepthExtensionChunkSize = 256;
+
+    /// <summary>
     /// Runs <paramref name="reps"/> measured repetitions (plus one discarded warm-up)
     /// of prefill + greedy decode against <paramref name="model"/>.
     /// </summary>
@@ -97,6 +107,22 @@ public static class BenchRunner
         // lastTokenLogitsOnly reasoning as the prefill call above -- this is the call whose
         // full-seqLen logits tensor was the dominant VRAM cost behind issue #185's
         // `dotllm bench --depth` hang beyond ~650-768 on a 12GB card.
+        //
+        // Issue #188: fed in bounded DepthExtensionChunkSize-token chunks rather than one single
+        // Forward call spanning the entire `depth`. Even after the CUDA hybrid models'
+        // EnsureCapacity switched from power-of-two to granularity-bounded rounding (issue #188),
+        // a single Forward call of length `depth` still forces those models' per-token scratch
+        // buffers to grow to (at minimum) `depth` tokens -- that's a real requirement of a call
+        // that size, not rounding waste, so no EnsureCapacity policy can shrink it. Splitting the
+        // untimed extension into fixed-size chunks appended incrementally to the same kvCache
+        // caps the peak single-call scratch requirement at DepthExtensionChunkSize tokens
+        // regardless of how large --depth gets, which is what actually let `--depth 2048` (exact
+        // power-of-two, so already zero rounding waste either way) complete cleanly instead of
+        // hanging at ~0 MiB free. This mirrors real serving, which chunks large prefills rather
+        // than ever submitting one multi-thousand-token Forward call; only intermediate chunks'
+        // logits are discarded here (the re-tiled extension tokens are fixed ahead of time, not
+        // sampled, so nothing downstream depends on them) -- the last chunk's argmax still seeds
+        // the timed decode loop exactly as before.
         if (depth > 0)
         {
             int[] extra = new int[depth];
@@ -106,8 +132,17 @@ public static class BenchRunner
                 extra[i] = promptTokens[i % promptLen];
                 extraPos[i] = nextPos + i;
             }
-            using (var logits = model.Forward(extra, extraPos, deviceId: -1, cache, lastTokenLogitsOnly: true))
-                nextToken = ArgmaxLastRow(logits);
+
+            int offset = 0;
+            while (offset < depth)
+            {
+                int chunkLen = Math.Min(DepthExtensionChunkSize, depth - offset);
+                using var logits = model.Forward(
+                    extra.AsSpan(offset, chunkLen), extraPos.AsSpan(offset, chunkLen),
+                    deviceId: -1, cache, lastTokenLogitsOnly: true);
+                offset += chunkLen;
+                if (offset == depth) nextToken = ArgmaxLastRow(logits);
+            }
             nextPos += depth;
         }
 

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseForwardState.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3HybridDenseForwardState.cs
@@ -118,15 +118,62 @@ internal sealed unsafe class CudaQwen3HybridDenseForwardState : IDisposable
     }
 
     /// <summary>
-    /// Grows all per-token buffers to cover at least <paramref name="seqLen"/> tokens,
-    /// reallocating in power-of-two increments. No-op when capacity already suffices.
-    /// Does NOT size <see cref="Logits"/> -- see <see cref="EnsureLogitsCapacity"/>.
+    /// Rounding granularity (in tokens) <see cref="EnsureCapacity"/> switches to once its
+    /// requested length exceeds this size -- see the method's remarks for the full issue #188
+    /// rationale. 256 is a round number comfortably larger than typical single-token
+    /// decode churn, so ordinary serving still amortizes reallocation across small prompt-length
+    /// variation, while bounding the worst-case waste at any depth to at most
+    /// <c>CapacityGranularity - 1</c> tokens' worth of buffers instead of the up-to-2x waste
+    /// power-of-two rounding produces right after crossing a pow2 boundary.
     /// </summary>
+    internal const int CapacityGranularity = 256;
+
+    /// <summary>
+    /// Rounds <paramref name="seqLen"/> up to the next allocation-worthy capacity for
+    /// <see cref="EnsureCapacity"/>. See <see cref="CapacityGranularity"/> and
+    /// <see cref="EnsureCapacity"/>'s remarks for the issue #188 rationale behind the two-regime
+    /// split.
+    /// </summary>
+    internal static int RoundUpCapacity(int seqLen)
+    {
+        if (seqLen <= CapacityGranularity)
+            return (int)BitOperations.RoundUpToPowerOf2((uint)seqLen);
+
+        return (seqLen + CapacityGranularity - 1) / CapacityGranularity * CapacityGranularity;
+    }
+
+    /// <summary>
+    /// Grows all per-token buffers to cover at least <paramref name="seqLen"/> tokens.
+    /// No-op when capacity already suffices. Does NOT size <see cref="Logits"/> -- see
+    /// <see cref="EnsureLogitsCapacity"/>.
+    /// </summary>
+    /// <remarks>
+    /// Issue #188: below <see cref="CapacityGranularity"/> tokens, capacity still rounds up to
+    /// the next power of two (unchanged from the original scheme) -- at this scale the absolute
+    /// byte cost of over-allocating is small, and pow2 rounding gives cheap amortization for the
+    /// common case of many small, differently-sized calls (e.g. varying prompt lengths in normal
+    /// serving) without reallocating on every single-token-different request. Above the
+    /// granularity threshold, capacity instead rounds up to the next multiple of
+    /// <see cref="CapacityGranularity"/> tokens -- this bounds the worst-case waste to at most
+    /// <c>CapacityGranularity - 1</c> tokens' worth of buffers REGARDLESS of how large seqLen
+    /// gets, instead of the up-to-2x waste power-of-two rounding produces right after crossing a
+    /// pow2 boundary (e.g. seqLen=1025 previously rounded to cap=2048, wasting ~1023 tokens'
+    /// worth of every per-token buffer this class owns). That 2x-at-scale behavior is exactly
+    /// what let `dotllm bench --depth` land on EXACTLY 0 MiB free VRAM at depth 1536 (rounds to
+    /// cap=2048 under pure pow2) on a 12 GB card -- see issue #188, a recurrence of #185's
+    /// original Logits-buffer finding but for every OTHER per-token buffer in this class, which
+    /// #185 deliberately left alone (unlike Logits, they're live in ordinary variable-length
+    /// prefill too, so unconditionally exact-sizing them like Logits would defeat the
+    /// reallocation-amortization these buffers exist for in real serving). A fixed-granularity
+    /// step still reallocates only when a call's seqLen crosses into a new granularity bucket
+    /// (same amortization property as pow2, just with smaller, constant-size buckets instead of
+    /// buckets that double forever), while capping the worst case that made #188 possible.
+    /// </remarks>
     public void EnsureCapacity(int seqLen)
     {
         if (seqLen <= _currentSeqLen) return;
 
-        int cap = (int)BitOperations.RoundUpToPowerOf2((uint)seqLen);
+        int cap = RoundUpCapacity(seqLen);
         FreeSequenceBuffers();
 
         HiddenState = AllocDevice((long)cap * _hiddenSize * sizeof(float));

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridForwardState.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridForwardState.cs
@@ -173,15 +173,51 @@ internal sealed unsafe class CudaQwen3MoeHybridForwardState : IDisposable
     }
 
     /// <summary>
-    /// Grows all per-token buffers to cover at least <paramref name="seqLen"/> tokens,
-    /// reallocating in power-of-two increments. No-op when capacity already suffices.
-    /// Does NOT size <see cref="Logits"/> -- see <see cref="EnsureLogitsCapacity"/>.
+    /// Rounding granularity (in tokens) <see cref="EnsureCapacity"/> switches to once its
+    /// requested length exceeds this size -- mirrors
+    /// <see cref="CudaQwen3HybridDenseForwardState.CapacityGranularity"/>; see that type's
+    /// identically-named member and <see cref="EnsureCapacity"/>'s remarks for the full
+    /// issue #188 rationale.
     /// </summary>
+    internal const int CapacityGranularity = 256;
+
+    /// <summary>
+    /// Rounds <paramref name="seqLen"/> up to the next allocation-worthy capacity for
+    /// <see cref="EnsureCapacity"/>. See <see cref="CapacityGranularity"/> and
+    /// <see cref="EnsureCapacity"/>'s remarks for the issue #188 rationale behind the two-regime
+    /// split.
+    /// </summary>
+    internal static int RoundUpCapacity(int seqLen)
+    {
+        if (seqLen <= CapacityGranularity)
+            return (int)BitOperations.RoundUpToPowerOf2((uint)seqLen);
+
+        return (seqLen + CapacityGranularity - 1) / CapacityGranularity * CapacityGranularity;
+    }
+
+    /// <summary>
+    /// Grows all per-token buffers to cover at least <paramref name="seqLen"/> tokens.
+    /// No-op when capacity already suffices. Does NOT size <see cref="Logits"/> -- see
+    /// <see cref="EnsureLogitsCapacity"/>.
+    /// </summary>
+    /// <remarks>
+    /// Issue #188: below <see cref="CapacityGranularity"/> tokens, capacity still rounds up to
+    /// the next power of two (unchanged from the original scheme) -- at this scale the absolute
+    /// byte cost of over-allocating is small, and pow2 rounding gives cheap amortization for the
+    /// common case of many small, differently-sized calls (e.g. varying prompt lengths in normal
+    /// serving) without reallocating on every single-token-different request. Above the
+    /// granularity threshold, capacity instead rounds up to the next multiple of
+    /// <see cref="CapacityGranularity"/> tokens -- this bounds the worst-case waste to at most
+    /// <c>CapacityGranularity - 1</c> tokens' worth of buffers REGARDLESS of how large seqLen
+    /// gets, instead of the up-to-2x waste power-of-two rounding produces right after crossing a
+    /// pow2 boundary. See <see cref="CudaQwen3HybridDenseForwardState.EnsureCapacity"/> for the
+    /// full issue #188 finding this mirrors.
+    /// </remarks>
     public void EnsureCapacity(int seqLen)
     {
         if (seqLen <= _currentSeqLen) return;
 
-        int cap = (int)BitOperations.RoundUpToPowerOf2((uint)seqLen);
+        int cap = RoundUpCapacity(seqLen);
         FreeSequenceBuffers();
 
         HiddenState = AllocDevice((long)cap * _hiddenSize * sizeof(float));

--- a/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/Architectures/CudaQwen3MoeHybridTransformerModel.cs
@@ -1637,7 +1637,9 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         }
 
         _context.MakeCurrent();
+        if (DebugTrace) LogVram($"before EnsureCapacity(seqLen={seqLen})");
         _state.EnsureCapacity(seqLen);
+        if (DebugTrace) LogVram($"after EnsureCapacity (state.AllocatedBytes={_state.AllocatedBytes:N0})");
 
         nint streamH = _stream.Handle;
 
@@ -1678,6 +1680,7 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         // the full rationale -- only shrink to the last row when the caller explicitly opts in via
         // lastTokenLogitsOnly (never inferred from kvCache alone: speculative-decoding verification
         // also submits multiple tokens through a kvCache-bearing call and needs every position).
+        if (DebugTrace) LogVram("before lm-head");
         int logitsRows = lastTokenLogitsOnly ? 1 : seqLen;
         _state.EnsureLogitsCapacity(logitsRows);
         nint lmHeadInput = logitsRows == seqLen
@@ -1687,6 +1690,7 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
             hiddenSize, eps, logitsRows, streamH);
         Gemm(_outputDevice, _outputQt, lmHeadInput, _state.Logits,
              _outputOutputDim, _outputInputDim, logitsRows);
+        if (DebugTrace) LogVram("after lm-head");
 
         // Sync and D2H the logits.
         _stream.Synchronize();
@@ -1695,8 +1699,29 @@ public sealed unsafe class CudaQwen3MoeHybridTransformerModel : IModel
         var result = UnmanagedTensor.Allocate(shape, DType.Float32, deviceId);
         CudaDriverApi.cuMemcpyDtoH_v2(result.DataPointer, _state.Logits,
             (nuint)((long)logitsRows * vocabSize * sizeof(float))).ThrowOnError();
+        if (DebugTrace) LogVram("after D2H logits copy");
 
         return result;
+    }
+
+    private static readonly bool DebugTrace =
+        Environment.GetEnvironmentVariable("DOTLLM_HYBRID_DEBUG") == "1";
+
+    /// <summary>
+    /// Issue #188 diagnostic: logs free/total device VRAM (via <c>cuMemGetInfo</c>) under the
+    /// same <see cref="DebugTrace"/> gate as <c>CudaQwen3HybridDenseTransformerModel.LogVram</c>
+    /// -- zero cost when unset. Added so the MoE hybrid model has the same VRAM-checkpoint
+    /// instrumentation the Dense model already carries from issue #185, since both classes share
+    /// the identical <c>EnsureCapacity</c> scratch-sizing logic (issue #188).
+    /// </summary>
+    private static void LogVram(string label)
+    {
+        CudaDriverApi.cuMemGetInfo_v2(out nuint free, out nuint total).ThrowOnError();
+        long usedMiB = (long)(total - free) / (1024 * 1024);
+        long freeMiB = (long)free / (1024 * 1024);
+        long totalMiB = (long)total / (1024 * 1024);
+        Console.Error.WriteLine($"[hybrid-debug][vram] {label}: used={usedMiB}MiB free={freeMiB}MiB total={totalMiB}MiB");
+        Console.Error.Flush();
     }
 
     /// <summary>

--- a/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridForwardStateCapacityGranularityTests.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridForwardStateCapacityGranularityTests.cs
@@ -1,0 +1,91 @@
+using DotLLM.Cuda.Architectures;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Cuda;
+
+/// <summary>
+/// CPU-only tests for the capacity-rounding math issue #188 introduced in
+/// <see cref="CudaQwen3HybridDenseForwardState.RoundUpCapacity"/> and
+/// <see cref="CudaQwen3MoeHybridForwardState.RoundUpCapacity"/>. Both methods are pure
+/// (no CUDA calls), so this discriminates the sizing policy itself without needing a GPU or
+/// constructing either state class (whose constructors allocate real device memory).
+/// </summary>
+/// <remarks>
+/// Issue #188: <c>EnsureCapacity</c> used to round every requested length up to the next
+/// power of two via <c>BitOperations.RoundUpToPowerOf2</c>, which meant a request one token past
+/// a power-of-two boundary (e.g. seqLen=1025) doubled the allocation (cap=2048) -- exactly what
+/// let <c>dotllm bench --depth 1536</c> (which rounded to cap=2048) land on 0 MiB free VRAM on a
+/// 12 GB card. The fix keeps pow2 rounding below <see cref="CudaQwen3HybridDenseForwardState.CapacityGranularity"/>
+/// tokens (cheap in absolute bytes, preserves amortization for small varying-length calls) and
+/// switches to fixed-granularity rounding above it (bounds worst-case waste to at most
+/// <c>CapacityGranularity - 1</c> tokens regardless of scale). These tests pin down both regimes
+/// and the regime boundary itself.
+/// </remarks>
+public sealed class CudaQwen3HybridForwardStateCapacityGranularityTests
+{
+    // Both classes' RoundUpCapacity are independent copies of the same policy (issue #188 --
+    // "apply the fix to BOTH forward-state classes" mirrors #185's cross-backend rule) --
+    // asserted to agree via the theory below, then exercised individually so a future edit to
+    // just one of the two copies fails immediately instead of silently diverging.
+
+    [Theory]
+    // ── Below-granularity regime: unchanged pow2 rounding ──
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(8, 8)]
+    [InlineData(200, 256)]
+    [InlineData(256, 256)] // exactly at the regime boundary -- still the pow2 branch (seqLen <= granularity)
+    // ── Above-granularity regime: fixed-granularity rounding ──
+    [InlineData(257, 512)] // one token over the boundary: old pow2 scheme would ALSO give 512 here,
+                            // so this alone doesn't discriminate -- see the next cases.
+    [InlineData(513, 768)] // old pow2 scheme: RoundUpToPowerOf2(513) = 1024 (waste=511).
+                            // New scheme: ceil(513/256)*256 = 768 (waste=255) -- exactly half the waste.
+    [InlineData(768, 768)] // exact multiple of granularity -- zero waste either scheme reaches only
+                            // by coincidence; old pow2 scheme actually gives 1024 here (waste=256),
+                            // this is the depth=768 case from issue #188's own repro.
+    [InlineData(1024, 1024)] // exact power of two AND exact multiple of granularity -- both regimes agree.
+    [InlineData(1025, 1280)] // one past a pow2 boundary: old scheme gives 2048 (waste=1023, ~2x).
+                             // New scheme gives 1280 (waste=255) -- the core issue #188 fix.
+    [InlineData(1536, 1536)] // issue #188's own repro depth: old scheme rounds to 2048 (waste=512,
+                             // landing on 0 MiB free VRAM on a 12 GB card); new scheme is exact.
+    [InlineData(2048, 2048)] // exact power of two AND exact multiple of granularity -- no rounding
+                             // waste is available to reclaim here under ANY monotonic scheme; the
+                             // depth=2048 repro case needed BenchRunner-side chunking (see
+                             // DotLLM.Cli's BenchRunner.DepthExtensionChunkSize), not a sizing-policy
+                             // change, to get comfortable headroom.
+    public void DenseAndMoeRoundUpCapacity_Agree_AndMatchExpected(int seqLen, int expectedCap)
+    {
+        int denseCap = CudaQwen3HybridDenseForwardState.RoundUpCapacity(seqLen);
+        int moeCap = CudaQwen3MoeHybridForwardState.RoundUpCapacity(seqLen);
+
+        Assert.Equal(expectedCap, denseCap);
+        Assert.Equal(expectedCap, moeCap);
+    }
+
+    [Theory]
+    [InlineData(257)]
+    [InlineData(1000)]
+    [InlineData(1537)]
+    [InlineData(4097)]
+    public void RoundUpCapacity_AboveGranularity_WasteIsBoundedByGranularityMinusOne(int seqLen)
+    {
+        int denseCap = CudaQwen3HybridDenseForwardState.RoundUpCapacity(seqLen);
+        int moeCap = CudaQwen3MoeHybridForwardState.RoundUpCapacity(seqLen);
+
+        Assert.True(denseCap >= seqLen);
+        Assert.True(denseCap - seqLen < CudaQwen3HybridDenseForwardState.CapacityGranularity);
+        Assert.True(moeCap >= seqLen);
+        Assert.True(moeCap - seqLen < CudaQwen3MoeHybridForwardState.CapacityGranularity);
+    }
+
+    [Fact]
+    public void RoundUpCapacity_NeverReturnsLessThanRequested()
+    {
+        foreach (int seqLen in new[] { 1, 2, 7, 8, 255, 256, 257, 511, 512, 513, 1023, 1024, 1025, 4096, 4097 })
+        {
+            Assert.True(CudaQwen3HybridDenseForwardState.RoundUpCapacity(seqLen) >= seqLen);
+            Assert.True(CudaQwen3MoeHybridForwardState.RoundUpCapacity(seqLen) >= seqLen);
+        }
+    }
+}


### PR DESCRIPTION
Closes #188

## Summary

Follow-up to #185/#187. `EnsureCapacity` in `CudaQwen3HybridDenseForwardState` / `CudaQwen3MoeHybridForwardState` rounded every per-token scratch buffer up to the next power of two. `Logits` was pulled out of that scheme in #185 (it's almost always sized to 1 row after `lastTokenLogitsOnly`), but every OTHER buffer (`HiddenState`, `Residual`, `NormOutput`, the GDN scratch, the attention Q/K/V/gate/output scratch, the dense FFN scratch, `TokenIdsDevice`/`PositionsDevice`) still rounded to the next power of two -- giving up to ~2x over-allocation right after crossing a boundary. `dotllm bench --depth 1536` rounds to `cap=2048`, landing on **exactly 0 MiB free** on a 12 GB card (confirmed via `cuMemGetInfo`), the same signature #185 found for `Logits`.

## Root cause confirmed (Phase 1 repro)

`DOTLLM_HYBRID_DEBUG=1 dotllm bench <Bonsai-27B GGUF> --device cuda -p 8 --depth 1536 -n 4 -r 1`:
```
before EnsureCapacity(seqLen=1536): free=1137MiB
after  EnsureCapacity (AllocatedBytes=1,181,930,952): free=26MiB
... [degrades to decode 9.70 tok/s vs ~17 tok/s at depth 768/1024]
before lm-head: free=0MiB
```
`--depth 2048` (also flagged in #188) reproduced as an outright 120s timeout (no crash, no orphaned process -- same pattern as #185's original finding).

## The tradeoff, and what I chose

The issue explicitly calls out that these buffers, unlike `Logits`, are live in ordinary variable-length prefill too -- unconditionally exact-sizing them (mirroring the `Logits` fix) would defeat the reallocation-amortization that power-of-two rounding buys real serving with varying request sizes (every slightly-different prompt length would otherwise force a full `FreeSequenceBuffers` + re-`AllocDevice` across ~20 buffers).

**Chosen fix: keep pow2 rounding below a 256-token threshold, switch to fixed-256-token-granularity rounding above it.**

- Below 256 tokens: unchanged `BitOperations.RoundUpToPowerOf2` -- at this scale the absolute byte cost of over-allocating is small, and pow2 rounding still gives cheap, well-understood amortization for the common small-varying-length case (chat prompts, short completions).
- Above 256 tokens: round up to the next multiple of 256. This bounds the worst-case waste to **at most 255 tokens' worth of buffers, at any depth** -- instead of waste that scales with the buffer size itself (2x at the worst point right after any pow2 boundary). A large call still only reallocates when it crosses into a new 256-token bucket, so normal serving keeps the "don't realloc on every single-token-different request" property; it just can't ever be 2x-oversized the way pow2 rounding could.
- I considered exact-sizing (granularity=1, no rounding at all) as the alternative the issue raises, mirroring `Logits`. Rejected because unlike `Logits`, a realistic serving workload calls these buffers on every prefill/decode step with genuinely varying lengths -- exact sizing would reallocate ~20 device buffers per request in the common case, which is a much larger cost than the bounded rounding waste this PR accepts instead.

All four repro depths from the issue happen to be exact multiples of 256 (768, 1024, 1536, 2048), so after this fix each gets `cap == seqLen` exactly -- zero rounding waste. That's not a coincidental win specific to those depths, though: any depth in between now wastes at most 255 tokens' worth of buffers rather than up to ~2x.

### The remaining piece: depth=2048 needed more than a rounding-policy change

`EnsureCapacity` rounding cannot help `depth=2048` on its own: 2048 is already an exact power of two, so it had **zero** rounding waste under the old scheme too (`cap=2048` for `seqLen=2048`, same either way). The buffer size at that point is a real requirement of `BenchRunner` submitting the entire synthetic depth extension as **one** `Forward` call of length `depth` -- there's no waste left to reclaim by changing how capacity rounds.

So I also chunked `BenchRunner`'s untimed depth-extension loop into fixed `DepthExtensionChunkSize` (256)-token chunks appended incrementally to the same `kvCache`, instead of one `depth`-token call. This caps the peak per-call scratch requirement at a small fixed size *regardless of how large `--depth` gets* -- and mirrors how real serving actually works (large prefills are chunked in practice, never submitted as a single multi-thousand-token call). Only the last chunk's logits are read; the re-tiled extension tokens are fixed ahead of time (not sampled), so intermediate chunks' outputs are safely discarded. This touches `src/DotLLM.Cli/Benchmarking/BenchRunner.cs` rather than just the two forward-state classes named in the issue -- flagging this explicitly since it's outside the issue's literally-named scope, but it's the change that actually makes depth=2048 (and any higher depth) viable, not a separate concern.

## Verification

GPU: RTX 3060 12 GB, confirmed idle before/after each run (`nvidia-smi`), no orphaned `DotLLM.Cli.exe` processes after any run (including the depth=2048 timeout repro before the fix).

| depth | before | after |
|---|---|---|
| 768  | works, tg 14.24→14.38 tok/s (warmup→rep), state cap was 1024 (33% waste) | works, tg 14.38 tok/s, **state cap now exactly 768** (0 waste), free ≈1.0-1.1 GiB throughout |
| 1024 | works, tg ≈14 tok/s, cap=1024 (already exact) | works, tg 14.17 tok/s, cap=1024 unchanged, free ≈1.0-1.1 GiB |
| 1536 | degrades to 0 MiB free after EnsureCapacity, decode falls to 9.70 tok/s | **AllocatedBytes 1,181,930,952 → 888,128,968** (cap 2048→1536, exact), free 256 MiB right after EnsureCapacity (was 26 MiB), decode 13.84 tok/s |
| 2048 | **hangs** (120s timeout, no crash) | completes cleanly: chunked `EnsureCapacity` never exceeds seqLen=256, `AllocatedBytes` stays at 153,624,008 throughout, free 795-987 MiB, decode 13.17-13.2 tok/s |

Full GPU-gated hybrid test suite (`--filter "FullyQualifiedName~CudaQwen3HybridDense|FullyQualifiedName~CudaQwen3MoeHybrid"` with `DOTLLM_BONSAI_PQ2_0_GGUF` set): **0 failed, 35 passed, 4 skipped** (skips pre-exist, unrelated to this change) -- run both before and after the fix, no regressions.

New CPU-only unit test (`tests/DotLLM.Tests.Unit/Cuda/CudaQwen3HybridForwardStateCapacityGranularityTests.cs`, 18 cases, no GPU needed) pins down `RoundUpCapacity`'s below/above-granularity regimes for both the Dense and MoE classes, including the exact issue #188 repro depths and the general worst-case-waste bound.

## Also added

`CudaQwen3MoeHybridTransformerModel` didn't have the `LogVram`/`DebugTrace` (`DOTLLM_HYBRID_DEBUG=1`) instrumentation the Dense model already had from #185 -- added the equivalent checkpoints at the same call sites so re-validating this class doesn't require re-deriving the instrumentation from scratch.

## Commits

1. `perf(cuda): bound EnsureCapacity rounding waste to a fixed granularity (#188)` -- the core fix, both Dense and MoE classes.
2. `perf(cuda): add hybrid-debug VRAM checkpoint logging to MoE model (#188)` -- diagnostic parity.
3. `perf(cli): chunk bench --depth's untimed context extension (#188)` -- the BenchRunner change that gets depth=2048 (and beyond) working.
4. `test(cuda): CPU-only coverage for EnsureCapacity's granularity rounding (#188)` -- regression test.
