### PR TITLE
docs(vulkan): #147 dGPU verification + skipF32MoeDequant risk correction

### DIFF
--- a/.perf-runs/vulkan-load-147/README.md
+++ b/.perf-runs/vulkan-load-147/README.md
@@ -113,3 +113,76 @@ campaign), not with a deterministic regression.
   net; "Recurring transient VK_ERROR_MEMORY_MAP_FAILED at load" note can be retired.
 - Zero-copy import: current driver rejects ALL mmap imports (`VK_ERROR_INVALID_EXTERNAL_HANDLE`
   at vkAllocateMemory, both handle types) — regression vs the documented earlier behaviour.
+
+## Addendum: RTX 3060 dGPU verification (2026-07-27)
+
+Re-verified this already-merged branch state (`origin/dev` @ `ab853eb`, #147 content landed via
+`be991b4`/`f5e8ddb`/`7e65e4a`/`4ae4db3`/`e506d45`/`46d31dd`, already an ancestor of `origin/dev` —
+no PR was ever opened for it, which is presumably why #147 was still open with 0 comments) on a
+**discrete** GPU (RTX 3060 12 GiB, NVIDIA proprietary driver, PCIe, non-UMA) to see how the
+findings generalize off the original Strix Halo iGPU box. GPU confirmed idle before each run
+(`nvidia-smi`, <=557 MiB / 12288 MiB, 0-5% util).
+
+**Item 1+2 before/after, apples-to-apples (both warm OS page cache), Qwen3-8B Q4_K_M
+(`unsloth/Qwen3-8B-GGUF`, real weights, Q4_K token-embed):**
+
+| Config | Load ms | Peak commit MiB | Logits SHA-256 |
+|---|---|---|---|
+| Simulated pre-#147 (`DOTLLM_VULKAN_DISABLE_EMBED_GPU_DEQUANT=1` + `DOTLLM_VULKAN_STAGING_MB=3000`, i.e. CPU embed dequant + one giant staging buffer sized for the largest upload) | 15492 | 9444.3 | `A3A077163737523D` |
+| Current default (64 MiB staging cap, GPU Q4_K embed dequant) | 6292 | 7233.9 | `A3A077163737523D` (identical) |
+
+Load time **-59%** (2.46x), peak commit **-2210 MiB** (-23.4%) — same direction and similar
+magnitude to the Strix Halo numbers above, on completely different hardware/driver. Logits
+bit-identical between configs, confirming item 2's GPU dequant is a true no-op on output.
+`VulkanEmbedGpuDequantParityTests.EmbedTable_GpuDequant_BitIdenticalToCpuPath` (previously SKIP
+on this box — its default fixture path is Strix-only) passes green when pointed at this model via
+`DOTLLM_VULKAN_EMBED_PARITY_MODEL`.
+
+Cold-cache (first read off disk, OS cache empty) load for the same model: 54.6 s — dominated by
+disk I/O for the 4.8 GiB file, not by the load-path allocator; not used for the before/after
+comparison above for that reason.
+
+SmolLM-135M Q4_K_M (`token_embd.weight` is Q8_0 in this GGUF, confirmed by direct tensor-info
+parse, dims `[576, 49152]`, ggml_type 8): `embedDequant='cpu'` as expected — Q8_0/F16/F32 embed
+tables correctly fall through to the still-CPU streamed path per the existing scope (item 4 row
+"Token-embed CPU dequant, other types").
+
+**Item 3 (zero-copy import) on this dGPU:** `device.HasExternalMemoryHost` reports true and the
+handle-type query succeeds, but every import **still falls back to staging** —
+`lastFallbackReason='import_rejected'`, `import-reject: stage='vkAllocateMemory' vkResult=-2`
+(`VK_ERROR_OUT_OF_DEVICE_MEMORY`) on both the 100 MiB SmolLM and 4.8 GiB Qwen3-8B models (i.e. not
+an actual memory-pressure condition — 12 GiB free). This is a **different rejection point and
+code** than the Strix Halo amdvlk finding (`VK_ERROR_INVALID_EXTERNAL_HANDLE` at the same call) —
+plausibly the NVIDIA driver accepting the host-pointer query but refusing to back a
+`DEVICE_LOCAL`-usable allocation with arbitrary (non-pinned) `MemoryMappedFile` pages over PCIe,
+which is the expected/principled outcome for non-UMA hardware (there is no page a dGPU can access
+without *some* PCIe hop; "zero-copy" only has a real payoff when the pages are already GPU-local
+DRAM, i.e. UMA). Net: on both hardware classes verified so far (AMD iGPU/UMA and NVIDIA dGPU), the
+whole-import path is real, tested code but dormant in production — the bounded-staging fallback
+(item 1) is what's actually carrying the load-path today everywhere. **Could not test the
+UMA-specific zero-copy win itself** — this machine has no iGPU; that requires Strix Halo or
+similar (see docs/GPU.md Future Work: Mesa radv validation is the next real chance to see it fire).
+
+**Item 4 follow-up re-audited — the `skipF32MoeDequant` row above is NOT a safe drop-in as
+worded.** Traced `VulkanWeights.UploadMoeLayer` -> `MoeRoutedRawDeviceQuantType`
+(`src/DotLLM.Vulkan/VulkanWeights.cs`): for the routed-expert banks (`W1`/`W2`/`W3`) this only
+keeps the raw quantized view for **Q8_0** (`MoeRoutedRawKeepsQ8`) or **F16 with cooperative-matrix
+support**; every other quant type — including **Q4_K/Q5_K/Q6_K**, the common case for
+`*_K_M`-quantized DeepSeek-family GGUFs, e.g. the V2-Lite Q4_K_M example this very ledger uses —
+falls through to `QuantizationType.F32` and reads `moe.W1/W2/W3` (the F32 host-dequant arrays).
+`LoadDeepSeekMoeLayer`'s `skipRoutedDequant` path leaves those arrays as `new nint[numExperts]`
+(all-null pointers) when `skipF32MoeDequant: true`. So passing that flag to
+`VulkanTransformerModel.LoadFromGguf` today, unconditionally, would silently corrupt DeepSeek-MoE
+Vulkan inference for any K-quant routed-expert bank — exactly the "silently wrong, not a crash"
+failure mode this task explicitly warns against. NOT shipping this.
+
+The K-quant indexed-matmul kernels this would need already exist and are already wired up — just
+for the *other* MoE loader path: `VulkanQwen3MoeHybridKernels`/`VulkanQwen3MoeHybridTransformerModel`
+has `MoeIndexedMatmulQ4_KF32Kernel`/`Q5_K`/`Q6_K` (plus MMQ variants) with a `useRawQuantView`
+dispatch. The generic/DeepSeek path (`VulkanWeights`/`VulkanTransformerModel`) has no equivalent
+dispatch on the routed-bank quant type — it always issues the F32 indexed matmul. Making
+`skipF32MoeDequant` safe for Vulkan therefore means porting that dispatch (recognize Q4_K/Q5_K/Q6_K
+routed banks when the contraction axis is a multiple of 256, upload raw, and record the matching
+indexed kernel instead of `MoeIndexedMatmulF32Kernel`) to the generic path first — real, scoped,
+but a distinct chunk of work with its own correctness-parity test needs, not a one-line flag flip.
+Filed as a new, separate issue rather than attempted here under time/risk constraints.

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -563,5 +563,19 @@ immediately.
 - **Multi-GPU** (Step 51): NCCL-based tensor parallelism
 - **Fatbin distribution**: Pre-compiled SASS for common architectures to eliminate JIT overhead
 - **Mesa radv host-import validation**: confirm Linux Mesa radv accepts mmap'd GGUF pointers via `HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT`, unblocks zero-copy on Strix Halo Linux.
+- **NVIDIA dGPU host-import rejection** (#147 follow-up): on an RTX 3060 the driver accepts the
+  `vkGetMemoryHostPointerPropertiesEXT` query but rejects the subsequent `vkAllocateMemory` with
+  `VK_ERROR_OUT_OF_DEVICE_MEMORY` (not `VK_ERROR_INVALID_EXTERNAL_HANDLE` as on Strix Halo amdvlk) —
+  a different rejection point/code than the iGPU finding, consistent with dGPUs not being able to
+  serve arbitrary non-pinned mmap'd host pages as `DEVICE_LOCAL` over PCIe. Expected to remain
+  dormant on dGPUs; the payoff is UMA-specific. See `.perf-runs/vulkan-load-147/README.md` addendum.
+- **Vulkan K-quant routed-MoE raw-view coverage** (#147 follow-up): `VulkanWeights.MoeRoutedRawDeviceQuantType`
+  only keeps routed expert banks (`W1`/`W2`/`W3`) raw for Q8_0 or F16(+coopmat); Q4_K/Q5_K/Q6_K routed
+  banks (the common `*_K_M` DeepSeek-family case) still require the F32 host-dequant arrays. This is
+  why `VulkanTransformerModel.LoadFromGguf` cannot yet pass `skipF32MoeDequant: true` the way CUDA
+  does (would zero-fill W1/W2/W3 for K-quant banks and silently corrupt DeepSeek-MoE Vulkan inference).
+  `VulkanQwen3MoeHybridKernels` already has the needed `MoeIndexedMatmulQ4_K/Q5_K/Q6_KF32Kernel`
+  dispatch for its own loader path; porting the same raw-view dispatch to the generic/DeepSeek path
+  would unlock a multi-GiB-per-load host-RAM win. Tracked separately from #147.
 
 See [ROADMAP.md](ROADMAP.md) Phase 4 for the full plan.


### PR DESCRIPTION
## Summary

Issue #147 asked for 4 items to minimize host-RAM materialisation on the Vulkan
weight-load path. Investigation found **all 4 items were already implemented and
merged to `dev`** prior to this session — commits `be991b4` (bounded staging),
`f5e8ddb` (GPU-side Q4_K/Q6_K token-embed dequant), `7e65e4a` (zero-copy import for
contiguous banks), `4ae4db3`/`e506d45` (docs + ledger). That work never went through
a GitHub PR referencing `#147` in a discoverable way, so the issue sat open with 0
comments despite being resolved.

This PR is **docs-only** — no functional changes. It adds fresh verification on a
second, structurally different hardware class (this repo's convention: prior
validation was Strix Halo/iGPU/UMA only) plus a corrected risk assessment on one
follow-up item that turned out to be unsafe as originally worded.

- **Item 1 (bounded staging)** — confirmed present (`VulkanStagingBuffer`, 64 MiB
  cap, persistent map). Not touched.
- **Item 2 (GPU embed dequant)** — confirmed present and re-verified bit-exact on
  an RTX 3060 (dGPU) using a real local Q4_K model
  (`VulkanEmbedGpuDequantParityTests`, previously `SKIP` here since its default
  fixture is Strix-only — passes green via `DOTLLM_VULKAN_EMBED_PARITY_MODEL`).
  Fresh before/after on this box (Qwen3-8B Q4_K_M, warm-cache apples-to-apples):
  load time **-59%** (15492ms → 6292ms), peak commit **-23.4%** (9444 → 7234 MiB),
  logits bit-identical.
- **Item 3 (zero-copy import audit)** — confirmed present. On this dGPU the import
  is also dormant, but for a *different* reason than the original Strix Halo
  finding: `VK_ERROR_OUT_OF_DEVICE_MEMORY` at `vkAllocateMemory` (vs.
  `VK_ERROR_INVALID_EXTERNAL_HANDLE` on amdvlk) — consistent with dGPUs not being
  able to serve arbitrary non-pinned mmap'd host pages as `DEVICE_LOCAL` over PCIe.
  **Could not measure the UMA-specific zero-copy win itself** — this machine has no
  iGPU; that still needs Strix Halo or Linux Mesa radv (already tracked in
  `docs/GPU.md` Future Work).
- **Item 4 (sweep)** — confirmed comprehensively documented already. Re-audited the
  one flagged follow-up (pass `skipF32MoeDequant: true` to the Vulkan loader,
  mirroring CUDA) and found it is **not safe** as worded: traced
  `VulkanWeights.MoeRoutedRawDeviceQuantType` and confirmed it only keeps routed MoE
  expert banks raw for Q8_0/F16(+coopmat) — Q4_K/Q5_K/Q6_K routed banks (the common
  `*_K_M` DeepSeek case, including the V2-Lite example the existing ledger itself
  uses) still require the F32 host-dequant arrays. Flipping the flag today would
  silently corrupt K-quant DeepSeek-MoE Vulkan inference — a silently-wrong result,
  not a crash. **Not shipping that flag flip.** Documented the actual fix (port
  `VulkanQwen3MoeHybridKernels`' existing Q4_K/Q5_K/Q6_K indexed-matmul dispatch to
  the generic/DeepSeek loader path) as a separate, appropriately-scoped follow-up.

## What changed

- `.perf-runs/vulkan-load-147/README.md` — addendum with the RTX 3060 measurements
  and the corrected `skipF32MoeDequant` finding.
- `docs/GPU.md` — two new Future Work bullets (NVIDIA dGPU host-import rejection
  mode; Vulkan K-quant routed-MoE raw-view coverage gap).

## Test plan

- [x] `dotnet build` (Release) — clean, 0 warnings/errors touching changed files
- [x] `VulkanEmbedGpuDequantParityTests.EmbedTable_GpuDequant_BitIdenticalToCpuPath`
      passes bit-exact against a real local Q4_K model on this RTX 3060
- [x] Full `~Vulkan` suite: `dotnet test ... --filter "FullyQualifiedName~Vulkan"` —
      **1000 passed, 0 failed, 35 skipped** (1h01m), no regressions
- [x] `nvidia-smi` confirmed GPU idle before all timed runs

Addresses #147 (items 1-4 already resolved on `dev`; item 3's UMA-specific benefit
unverifiable on this dGPU; item 4's `skipF32MoeDequant` follow-up deliberately
deferred — see PR body above and issue comment for the separate follow-up scope).
Leaving #147 open per the corrected-risk item; will comment on the issue with a
recommendation to close once maintainer/owner reviews, and file a separate issue
for the K-quant routed-MoE follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)