### PR TITLE
perf(vulkan): extend routed-MoE raw-quant-view to Q4_K/Q5_K/Q6_K

### DIFF
--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -569,13 +569,16 @@ immediately.
   a different rejection point/code than the iGPU finding, consistent with dGPUs not being able to
   serve arbitrary non-pinned mmap'd host pages as `DEVICE_LOCAL` over PCIe. Expected to remain
   dormant on dGPUs; the payoff is UMA-specific. See `.perf-runs/vulkan-load-147/README.md` addendum.
-- **Vulkan K-quant routed-MoE raw-view coverage** (#147 follow-up): `VulkanWeights.MoeRoutedRawDeviceQuantType`
-  only keeps routed expert banks (`W1`/`W2`/`W3`) raw for Q8_0 or F16(+coopmat); Q4_K/Q5_K/Q6_K routed
-  banks (the common `*_K_M` DeepSeek-family case) still require the F32 host-dequant arrays. This is
-  why `VulkanTransformerModel.LoadFromGguf` cannot yet pass `skipF32MoeDequant: true` the way CUDA
-  does (would zero-fill W1/W2/W3 for K-quant banks and silently corrupt DeepSeek-MoE Vulkan inference).
-  `VulkanQwen3MoeHybridKernels` already has the needed `MoeIndexedMatmulQ4_K/Q5_K/Q6_KF32Kernel`
-  dispatch for its own loader path; porting the same raw-view dispatch to the generic/DeepSeek path
-  would unlock a multi-GiB-per-load host-RAM win. Tracked separately from #147.
+- **Vulkan K-quant routed-MoE raw-view coverage** (#147 follow-up, resolved by #191):
+  `VulkanWeights.MoeRoutedRawDeviceQuantType` now recognizes Q4_K/Q5_K/Q6_K routed expert banks
+  (`W1`/`W2`/`W3`) in addition to Q8_0/F16(+coopmat) — the common `*_K_M` DeepSeek-family case.
+  `VulkanTransformerModel.LoadFromGguf` now calls `VulkanWeights.CanSkipMoeF32HostDequant` to
+  preflight every MoE layer's routed banks against this same resolver before opting into
+  `skipF32MoeDequant: true`, falling back to the safe F32 host-dequant default whenever any bank
+  wouldn't resolve to a supported raw-quant device type (avoids the CUDA-parity flag silently
+  zero-filling `W1`/`W2`/`W3` for an unsupported quant type). `RecordMoeIndexedMatmul` now dispatches
+  Q4_K/Q5_K/Q6_K routed banks through `MoeIndexedMatmulQ4_K/Q5_K/Q6_KF32Kernel` unconditionally
+  whenever the model has MoE layers (previously the Q4_K kernel was only ever constructed under
+  `Gemma4DualFfn`, so a non-Gemma4 model's K-quant routed banks always fell back to F32 upload).
 
 See [ROADMAP.md](ROADMAP.md) Phase 4 for the full plan.

--- a/src/DotLLM.Vulkan/VulkanTransformerModel.cs
+++ b/src/DotLLM.Vulkan/VulkanTransformerModel.cs
@@ -668,6 +668,13 @@ public sealed class VulkanTransformerModel : IModel
     // real 26B's experts quantized on device. Null when the model has no gemma4
     // quantized-MoE layer.
     private readonly MoeIndexedMatmulQ4_KF32Kernel? _moeIndexedMatmulQ4K;
+    // Generic (non-Gemma4) routed-MoE K-quant raw-view path (#191): siblings of
+    // _moeIndexedMatmulQ4K covering Q5_K/Q6_K routed banks (e.g. DeepSeek-family
+    // "UD" mixed-quant GGUFs whose down-projection quantizes differently from
+    // gate/up). Created whenever the model has MoE layers, not gated on
+    // Gemma4DualFfn — mirrors VulkanQwen3MoeHybridKernels' unconditional creation.
+    private readonly MoeIndexedMatmulQ5_KF32Kernel? _moeIndexedMatmulQ5K;
+    private readonly MoeIndexedMatmulQ6_KF32Kernel? _moeIndexedMatmulQ6K;
     private readonly MoeIndexedMatmulQ5_1F32Kernel? _moeIndexedMatmulQ5_1;
     // Indexed MMVQ (dp4a) decode variants of the quantized expert matmuls
     // (issue #137). Used on the S==1 decode path when the expanded MoE
@@ -915,6 +922,8 @@ public sealed class VulkanTransformerModel : IModel
         MoeTopKSoftmaxF32Kernel? moeTopkSoftmax, MoeIndexedMatmulF32Kernel? moeIndexedMatmul,
         MoeIndexedMatmulQ8_0F32Kernel? moeIndexedMatmulQ8,
         MoeIndexedMatmulQ4_KF32Kernel? moeIndexedMatmulQ4K,
+        MoeIndexedMatmulQ5_KF32Kernel? moeIndexedMatmulQ5K,
+        MoeIndexedMatmulQ6_KF32Kernel? moeIndexedMatmulQ6K,
         MoeIndexedMatmulQ5_1F32Kernel? moeIndexedMatmulQ5_1,
         MoeIndexedMatmulQ4KMmvqKernel? moeIndexedMatmulQ4KMmvq,
         MoeIndexedMatmulQ5_1MmvqKernel? moeIndexedMatmulQ5_1Mmvq,
@@ -1028,6 +1037,8 @@ public sealed class VulkanTransformerModel : IModel
         _moeIndexedMatmul = moeIndexedMatmul;
         _moeIndexedMatmulQ8 = moeIndexedMatmulQ8;
         _moeIndexedMatmulQ4K = moeIndexedMatmulQ4K;
+        _moeIndexedMatmulQ5K = moeIndexedMatmulQ5K;
+        _moeIndexedMatmulQ6K = moeIndexedMatmulQ6K;
         _moeIndexedMatmulQ5_1 = moeIndexedMatmulQ5_1;
         _moeIndexedMatmulQ4KMmvq = moeIndexedMatmulQ4KMmvq;
         _moeIndexedMatmulQ5_1Mmvq = moeIndexedMatmulQ5_1Mmvq;
@@ -1080,7 +1091,14 @@ public sealed class VulkanTransformerModel : IModel
         try
         {
             spvDir ??= Path.Combine(AppContext.BaseDirectory, "spv");
-            var cpuWeights = TransformerWeights.LoadFromGguf(gguf, config);
+            // #191: skip the per-expert F32 host dequant of routed MoE banks when
+            // every routed bank across every MoE layer would resolve to a supported
+            // raw-quant device view anyway (see CanSkipMoeF32HostDequant) — mirrors
+            // what CudaTransformerModel/CudaPipelineTransformerModel already do
+            // unconditionally, but gated here since Vulkan didn't have full K-quant
+            // routed-bank coverage until this issue.
+            bool skipF32MoeDequant = VulkanWeights.CanSkipMoeF32HostDequant(device, gguf, config);
+            var cpuWeights = TransformerWeights.LoadFromGguf(gguf, config, skipF32MoeDequant);
             return BuildModel(device, ownsDevice: true, config, cpuWeights, spvDir, gguf);
         }
         catch
@@ -1107,7 +1125,9 @@ public sealed class VulkanTransformerModel : IModel
         RejectUnsupportedArchitecture(config);
 
         spvDir ??= Path.Combine(AppContext.BaseDirectory, "spv");
-        var cpuWeights = TransformerWeights.LoadFromGguf(gguf, config);
+        // #191: see the other LoadFromGguf overload's comment.
+        bool skipF32MoeDequant = VulkanWeights.CanSkipMoeF32HostDequant(device, gguf, config);
+        var cpuWeights = TransformerWeights.LoadFromGguf(gguf, config, skipF32MoeDequant);
         return BuildModel(device, ownsDevice: false, config, cpuWeights, spvDir, gguf);
     }
 
@@ -1561,6 +1581,8 @@ public sealed class VulkanTransformerModel : IModel
         MoeIndexedMatmulF32Kernel? moeIndexedMatmul = null;
         MoeIndexedMatmulQ8_0F32Kernel? moeIndexedMatmulQ8 = null;
         MoeIndexedMatmulQ4_KF32Kernel? moeIndexedMatmulQ4K = null;
+        MoeIndexedMatmulQ5_KF32Kernel? moeIndexedMatmulQ5K = null;
+        MoeIndexedMatmulQ6_KF32Kernel? moeIndexedMatmulQ6K = null;
         MoeIndexedMatmulQ5_1F32Kernel? moeIndexedMatmulQ5_1 = null;
         MoeIndexedMatmulQ4KMmvqKernel? moeIndexedMatmulQ4KMmvq = null;
         MoeIndexedMatmulQ5_1MmvqKernel? moeIndexedMatmulQ5_1Mmvq = null;
@@ -1579,11 +1601,20 @@ public sealed class VulkanTransformerModel : IModel
             moeTopkSoftmax = MoeTopKSoftmaxF32Kernel.Create(device, spvDir);
             moeIndexedMatmul = MoeIndexedMatmulF32Kernel.Create(device, spvDir);
             moeIndexedMatmulQ8 = MoeIndexedMatmulQ8_0F32Kernel.Create(device, spvDir);
+            // K-quant indexed-expert matmul kernels: needed both by Gemma-4's fused
+            // quantized MoE path (Q4_K gate/up) and the generic DeepSeek/Mixtral/
+            // Qwen-MoE routed-bank K-quant raw-view path (#191). Created
+            // unconditionally whenever the model has MoE layers — previously Q4_K
+            // was only ever instantiated under Gemma4DualFfn, so the generic
+            // dispatcher's Q4_K branch threw for every non-Gemma4 model whose
+            // routed banks resolved to Q4_K.
+            moeIndexedMatmulQ4K = MoeIndexedMatmulQ4_KF32Kernel.Create(device, spvDir);
+            moeIndexedMatmulQ5K = MoeIndexedMatmulQ5_KF32Kernel.Create(device, spvDir);
+            moeIndexedMatmulQ6K = MoeIndexedMatmulQ6_KF32Kernel.Create(device, spvDir);
             if (config.Gemma4DualFfn)
             {
-                // Gemma-4 quantized experts: fused gate_up Q4_K + down Q5_1 stay
-                // quantized on device (the real 26B's F32 experts are tens of GB).
-                moeIndexedMatmulQ4K = MoeIndexedMatmulQ4_KF32Kernel.Create(device, spvDir);
+                // Gemma-4's quantized down-projection bank is Q5_1 (a legacy quant,
+                // not a K-quant) — stays Gemma4-specific.
                 moeIndexedMatmulQ5_1 = MoeIndexedMatmulQ5_1F32Kernel.Create(device, spvDir);
                 // Indexed MMVQ decode variants (issue #137): dp4a + coalesced
                 // subgroup-per-cell reads for the S==1 expert GEMVs. TryCreate
@@ -1681,7 +1712,7 @@ public sealed class VulkanTransformerModel : IModel
             biasAdd,
             mlaAttention, mlaRope, mlaKvSplit,
             moeTopkSoftmax, moeIndexedMatmul, moeIndexedMatmulQ8,
-            moeIndexedMatmulQ4K, moeIndexedMatmulQ5_1,
+            moeIndexedMatmulQ4K, moeIndexedMatmulQ5K, moeIndexedMatmulQ6K, moeIndexedMatmulQ5_1,
             moeIndexedMatmulQ4KMmvq, moeIndexedMatmulQ5_1Mmvq, moeIndexedMatmulQ8Mmvq,
             moeIndexedMatmulTiled, moeIndexedLoraDelta,
             moeExpertOffsets, moeExpandGroupByExpert, moeGroupedMatmulF16Coopmat, moeUngroupScatter,
@@ -3738,6 +3769,8 @@ public sealed class VulkanTransformerModel : IModel
         _moeIndexedMatmul?.InvalidateDescriptorCache();
         _moeIndexedMatmulQ8?.InvalidateDescriptorCache();
         _moeIndexedMatmulQ4K?.InvalidateDescriptorCache();
+        _moeIndexedMatmulQ5K?.InvalidateDescriptorCache();
+        _moeIndexedMatmulQ6K?.InvalidateDescriptorCache();
         _moeIndexedMatmulQ5_1?.InvalidateDescriptorCache();
         _moeIndexedMatmulQ4KMmvq?.InvalidateDescriptorCache();
         _moeIndexedMatmulQ5_1Mmvq?.InvalidateDescriptorCache();
@@ -5059,6 +5092,26 @@ public sealed class VulkanTransformerModel : IModel
             return;
         }
 
+        if (weightQt == QuantizationType.Q5_K)
+        {
+            if (_moeIndexedMatmulQ5K is null)
+                throw new InvalidOperationException("Q5_K MoE indexed matmul kernel was not created.");
+            _moeIndexedMatmulQ5K.Record(cmdBuf,
+                bank, x, indices, y,
+                m: m, k: k, n: n, numExperts: numExperts);
+            return;
+        }
+
+        if (weightQt == QuantizationType.Q6_K)
+        {
+            if (_moeIndexedMatmulQ6K is null)
+                throw new InvalidOperationException("Q6_K MoE indexed matmul kernel was not created.");
+            _moeIndexedMatmulQ6K.Record(cmdBuf,
+                bank, x, indices, y,
+                m: m, k: k, n: n, numExperts: numExperts);
+            return;
+        }
+
         if (weightQt != QuantizationType.F32)
             throw new NotSupportedException($"MoE indexed matmul does not support {weightQt} banks.");
 
@@ -6336,6 +6389,8 @@ public sealed class VulkanTransformerModel : IModel
         _moeIndexedMatmulQ4KMmvq?.Dispose();
         _moeIndexedMatmulQ8Mmvq?.Dispose();
         _moeIndexedMatmulQ5_1?.Dispose();
+        _moeIndexedMatmulQ6K?.Dispose();
+        _moeIndexedMatmulQ5K?.Dispose();
         _moeIndexedMatmulQ4K?.Dispose();
         _moeIndexedMatmulQ8?.Dispose();
         _moeIndexedMatmul?.Dispose();

--- a/src/DotLLM.Vulkan/VulkanWeights.cs
+++ b/src/DotLLM.Vulkan/VulkanWeights.cs
@@ -1,7 +1,9 @@
 using System.Runtime.InteropServices;
 using DotLLM.Core.Configuration;
+using DotLLM.Core.Models;
 using DotLLM.Cpu.Kernels;
 using DotLLM.Models.Architectures;
+using DotLLM.Models.Gguf;
 using DotLLM.Vulkan.Interop;
 using DotLLM.Vulkan.Kernels;
 
@@ -1919,7 +1921,37 @@ internal sealed class VulkanWeights : IDisposable
         && rawK == expectedK
         && (expectedK % 32) == 0;
 
-    private static QuantizationType MoeRoutedRawDeviceQuantType(
+    /// <summary>
+    /// Resolves the on-device storage type for ONE routed expert bank
+    /// (<c>ffn_gate_exps</c>/<c>ffn_up_exps</c>/<c>ffn_down_exps</c>): the raw
+    /// GGUF quant type is kept verbatim on device — dispatched through the
+    /// matching indexed-matmul kernel — when it is one of the types this
+    /// resolver recognizes AND the shape lines up; otherwise the caller falls
+    /// back to an F32 host dequant (<see cref="UploadRoutedBankWhole"/>'s F32
+    /// branch, which reads the per-expert <c>moe.W1</c>/<c>W2</c>/<c>W3</c>
+    /// pointers).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>#191.</b> Q4_K/Q5_K/Q6_K recognition (the common case for
+    /// <c>*_K_M</c>-quantized DeepSeek-family GGUFs) was added here — previously
+    /// only Q8_0 and coopmat-gated F16 were recognized, so K-quant routed banks
+    /// always fell back to F32, which silently defeats
+    /// <c>skipF32MoeDequant</c> (the CPU-side flag that skips populating the
+    /// F32 host arrays): with the flag set and no on-device K-quant path, this
+    /// resolver would have returned F32 and the caller would have read a null
+    /// per-expert pointer — see <see cref="CanSkipMoeF32HostDequant"/>, which
+    /// preflights against this exact predicate before the flag is ever passed
+    /// to <c>TransformerWeights.LoadFromGguf</c>.
+    /// </para>
+    /// <para>
+    /// <c>internal</c> (rather than <c>private</c>) so <see cref="CanSkipMoeF32HostDequant"/>
+    /// — and tests — can evaluate the identical resolution the real upload
+    /// path (<see cref="UploadMoeLayer"/>) will make, without needing a live
+    /// GGUF-backed <see cref="MoeLayerWeights"/> to probe it.
+    /// </para>
+    /// </remarks>
+    internal static QuantizationType MoeRoutedRawDeviceQuantType(
         VulkanDevice device,
         nint raw, QuantizationType qt,
         int rawM, int rawK,
@@ -1927,6 +1959,13 @@ internal sealed class VulkanWeights : IDisposable
     {
         if (MoeRoutedRawKeepsQ8(raw, qt, rawM, rawK, expectedM, expectedK))
             return QuantizationType.Q8_0;
+
+        if (raw != 0 && rawM == expectedM && rawK == expectedK)
+        {
+            if (MoeOverlayKeepsQ4K(qt, expectedK)) return QuantizationType.Q4_K;
+            if (MoeOverlayKeepsQ5K(qt, expectedK)) return QuantizationType.Q5_K;
+            if (MoeOverlayKeepsQ6K(qt, expectedK)) return QuantizationType.Q6_K;
+        }
 
         // Strategy C path: keep routed F16 expert banks raw only when the
         // coopmat grouped matmul can consume them. Otherwise upload F32 so
@@ -1940,6 +1979,80 @@ internal sealed class VulkanWeights : IDisposable
             return QuantizationType.F16;
 
         return QuantizationType.F32;
+    }
+
+    /// <summary>
+    /// Preflight check for whether <c>TransformerWeights.LoadFromGguf(gguf, config,
+    /// skipF32MoeDequant: true)</c> is safe to call for this (device, gguf, config)
+    /// combination — i.e. whether EVERY MoE layer's three routed banks (gate/up/down)
+    /// would resolve to a supported non-F32 on-device quant type via
+    /// <see cref="MoeRoutedRawDeviceQuantType"/>, the SAME predicate the real upload
+    /// path (<see cref="UploadMoeLayer"/>) uses.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Scope (#191).</b> Returns <c>false</c> immediately unless the model is
+    /// DeepSeek-family (MLA + MoE): <c>skipF32MoeDequant</c> only threads through
+    /// <c>TransformerWeights.LoadMlaLayer</c> → <c>LoadDeepSeekMoeLayer</c>. Every other
+    /// MoE loader path (<c>LoadQuantExpertMoeLayer</c> for Mixtral/Qwen-MoE/gpt-oss,
+    /// Gemma-4's dedicated loader) either never F32-dequants routed banks to begin with
+    /// or doesn't accept the flag — passing <c>true</c> there would be a silent no-op,
+    /// not a win, so this preflight isn't reached for them.
+    /// </para>
+    /// <para>
+    /// <b>Why the check matters.</b> When <c>skipF32MoeDequant</c> is true,
+    /// <c>LoadDeepSeekMoeLayer</c>'s <c>skipRoutedDequant</c> branch leaves
+    /// <see cref="MoeLayerWeights.W1"/>/<see cref="MoeLayerWeights.W2"/>/
+    /// <see cref="MoeLayerWeights.W3"/> as all-NULL pointer arrays — the raw GGUF mmap
+    /// view is the only valid weight source for that layer. If even one routed bank on
+    /// one MoE layer would resolve to <see cref="QuantizationType.F32"/> (the upload
+    /// fallback), <see cref="UploadRoutedBankWhole"/>'s F32 branch reads that null
+    /// pointer per expert — SILENT CORRUPTION (a null/garbage weight matrix silently
+    /// multiplied into the forward pass), not a crash. This preflight inspects the GGUF
+    /// tensor descriptors directly (no CPU weights loaded yet) and returns <c>false</c>
+    /// the moment any bank on any MoE layer would need the F32 fallback, so the caller
+    /// can fall back to the safe (if more host-RAM-hungry) default per model instead of
+    /// assuming universal K-quant coverage.
+    /// </para>
+    /// </remarks>
+    internal static bool CanSkipMoeF32HostDequant(VulkanDevice device, GgufFile gguf, ModelConfig config)
+    {
+        if (config.MlaConfig is null || config.Moe is null)
+            return false;
+
+        var moe = config.Moe;
+        var tensors = gguf.TensorsByName;
+        nint dataBase = gguf.DataBasePointer;
+        int hiddenSize = config.HiddenSize;
+        int moeIntermediate = moe.MoeIntermediateSize;
+
+        for (int i = 0; i < config.NumLayers; i++)
+        {
+            if (!moe.IsMoeLayer(i))
+                continue;
+
+            string prefix = $"blk.{i}";
+            if (!tensors.TryGetValue($"{prefix}.ffn_gate_exps.weight", out var gateDesc)
+                || !tensors.TryGetValue($"{prefix}.ffn_up_exps.weight", out var upDesc)
+                || !tensors.TryGetValue($"{prefix}.ffn_down_exps.weight", out var downDesc))
+                return false; // Unexpected/missing tensor — fall back to the safe F32 path.
+
+            nint gateRaw = dataBase + (nint)gateDesc.DataOffset;
+            nint upRaw = dataBase + (nint)upDesc.DataOffset;
+            nint downRaw = dataBase + (nint)downDesc.DataOffset;
+
+            var w1Qt = MoeRoutedRawDeviceQuantType(
+                device, gateRaw, gateDesc.QuantizationType, moeIntermediate, hiddenSize, moeIntermediate, hiddenSize);
+            var w3Qt = MoeRoutedRawDeviceQuantType(
+                device, upRaw, upDesc.QuantizationType, moeIntermediate, hiddenSize, moeIntermediate, hiddenSize);
+            var w2Qt = MoeRoutedRawDeviceQuantType(
+                device, downRaw, downDesc.QuantizationType, hiddenSize, moeIntermediate, hiddenSize, moeIntermediate);
+
+            if (w1Qt == QuantizationType.F32 || w2Qt == QuantizationType.F32 || w3Qt == QuantizationType.F32)
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>True iff a Q4_K MoE overlay can be kept on device as raw Q4_K super-blocks

--- a/tests/DotLLM.Tests.Unit/Vulkan/VulkanTransformerModelMoeKQuantRoutedForwardTests.cs
+++ b/tests/DotLLM.Tests.Unit/Vulkan/VulkanTransformerModelMoeKQuantRoutedForwardTests.cs
@@ -1,0 +1,468 @@
+using System.Reflection;
+using DotLLM.Core.Configuration;
+using DotLLM.Core.Models;
+using DotLLM.Core.Tensors;
+using DotLLM.Models.Architectures;
+using DotLLM.Models.Gguf;
+using DotLLM.Tests.Unit.Models.Gguf;
+using DotLLM.Vulkan;
+using Xunit;
+
+namespace DotLLM.Tests.Unit.Vulkan;
+
+/// <summary>
+/// CPU-vs-Vulkan forward parity for the routed-MoE K-quant raw-view path added by #191,
+/// plus preflight-check coverage for <c>VulkanWeights.CanSkipMoeF32HostDequant</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two fixtures, two purposes.</b> This file uses TWO different synthetic GGUF
+/// fixtures because the two things #191 touches live on different sides of an
+/// UNRELATED, pre-existing gap in test coverage discovered while writing this suite:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <b>Mixtral-style (dense GQA attention + MoE FFN)</b> — used for the full
+///     CPU-vs-Vulkan <see cref="Forward_RoutedKQuant_MatchesCpuReference"/> parity test.
+///     The CPU oracle here is <c>TransformerWeights.LoadQuantExpertMoeLayer</c> →
+///     <c>DotLLM.Cpu.Kernels.MoeQuantSwiGluMlp</c>, which ALWAYS reads routed experts
+///     straight from the raw GGUF quant view (no F32 host dequant, no
+///     <c>skipF32MoeDequant</c> flag involved) and already has explicit Q4_K/Q5_K/Q6_K
+///     cases — a solid, pre-existing ground truth. The Vulkan side resolves the SAME
+///     raw view via the newly-extended <c>VulkanWeights.MoeRoutedRawDeviceQuantType</c>
+///     and dispatches through the (previously Gemma4-only-gated)
+///     <c>MoeIndexedMatmulQ4_KF32Kernel</c>/<c>Q5_KF32Kernel</c>/<c>Q6_KF32Kernel</c>.
+///   </item>
+///   <item>
+///     <b>DeepSeek-V2-style (MLA + MoE)</b> — used ONLY for the
+///     <c>CanSkipMoeF32HostDequant_*</c> preflight tests (item 4), which never call
+///     <c>.Forward()</c>. <c>skipF32MoeDequant</c> exclusively threads through
+///     <c>TransformerWeights.LoadMlaLayer</c> → <c>LoadDeepSeekMoeLayer</c>, so testing
+///     the preflight gate needs an MLA+MoE config specifically.
+///   </item>
+/// </list>
+/// <para>
+/// <b>Why not one full MLA+MoE forward test?</b> A synthetic DeepSeek-V2-style GGUF
+/// with a full <c>.Forward()</c> call (CPU OR Vulkan — the crash reproduces on the CPU
+/// side alone, before Vulkan is even reached) reliably crashes the test host process,
+/// reproducible even with a plain-F32 (no quantization at all) 1-layer dense-only MLA
+/// fixture at <c>HiddenSize=256</c>. This is a pre-existing bug in the CPU MLA forward
+/// path unrelated to #191 (no existing test exercises a full forward on any synthetic
+/// MLA GGUF — <c>DeepSeekV2GgufLoadTests</c> only checks weight loading, and
+/// <c>VulkanTransformerModelMlaForwardTests</c> only exercises a dense, non-GGUF,
+/// non-MoE safetensors-loaded MLA model at <c>HiddenSize=16</c>). Chasing that crash is
+/// out of scope for this issue; the Mixtral-style fixture below sidesteps MLA entirely
+/// while still exercising the exact same <c>VulkanWeights.UploadMoeLayer</c> /
+/// <c>MoeRoutedRawDeviceQuantType</c> / <c>RecordMoeIndexedMatmul</c> code #191 changes
+/// (that code path does not care whether the model is MLA or dense-attention).
+/// </para>
+/// <para>
+/// Reference patterns: <c>VulkanQwen3MoeMoeUploadQ4KResidentTests</c> (upload/resolution
+/// level parity — the Q4_K/Q5_K/Q6_K indexed-matmul kernels themselves are already
+/// proven correct there and in the Q5_K/Q6_K sibling files) and
+/// <c>VulkanTransformerModelMoeQ8_0ForwardTests</c> (full CPU-vs-Vulkan forward parity
+/// for the generic, non-hybrid MoE path — mirrored here for K-quant instead of Q8_0).
+/// </para>
+/// </remarks>
+[Trait("Category", "GPU")]
+[Collection("VulkanKernels")]
+public sealed class VulkanTransformerModelMoeKQuantRoutedForwardTests : IDisposable
+{
+    // ── Mixtral-style (dense attention + MoE) fixture — full forward parity ──────────
+    // Both HiddenSize (gate/up contraction) and MoeIntermediate (down contraction) must
+    // be multiples of 256 (Q4_K/Q5_K/Q6_K super-block size).
+    private const int MxHiddenSize = 256;
+    private const int MxNumLayers = 1;         // single MoE layer (decoder_sparse_step=1 default → MoE)
+    private const int MxNumHeads = 4;
+    private const int MxNumKvHeads = 2;        // GQA
+    private const int MxHeadDim = 64;          // NumHeads * HeadDim == HiddenSize
+    private const int MxVocabSize = 8;
+    private const int MxMoeIntermediate = 256;
+    private const int MxNumExperts = 2;
+    private const int MxNumExpertsPerTok = 2;  // both experts always active — deterministic routing
+
+    // ── DeepSeek-V2-style (MLA + MoE) fixture — preflight-only, no forward call ──────
+    private const int DsHiddenSize = 256;
+    private const int DsNumLayers = 2;         // layer 0 dense, layer 1 MoE
+    private const int DsNumHeads = 2;
+    private const int DsVocabSize = 8;
+    private const int DsQkNope = 4;
+    private const int DsQkRope = 4;            // RoPE pairs — must be even
+    private const int DsVHead = 4;
+    private const int DsKvLoraRank = 8;
+    private const int DsIntermediateSize = 32; // dense-layer FFN width — no alignment need
+    private const int DsMoeIntermediate = 256;
+    private const int DsNumExperts = 2;
+    private const int DsNumExpertsPerTok = 2;
+    private const int DsLeadingDenseBlocks = 1;
+
+    // Looser than the repo's standard single-kernel-dispatch parity bar (5e-3 abs /
+    // 1e-3 rel, used by e.g. the Q4K/Q5K/Q6K resident-upload tests that compare ONE
+    // matmul dispatch in isolation). This test chains a FULL forward — RoPE, GQA
+    // attention softmax, RMSNorm ×2, router softmax, gate/up/down K-quant matmuls,
+    // SwiGLU, residual adds — through 3 causal positions. CPU (on-the-fly per-row
+    // dequant in DotLLM.Cpu.Kernels.MoeQuantSwiGluMlp) and Vulkan (workgroup-tree
+    // reduce in the indexed-matmul shader) both read the exact SAME quantized bytes
+    // but accumulate their dot products in a different order; that FP noise compounds
+    // through every subsequent nonlinear op (softmax, RMSNorm's rsqrt, SwiGLU) and
+    // across causal positions (each token's residual stream carries the prior tokens'
+    // rounding forward). Empirically: single-token drift is ~1.05-1.5x the tight
+    // single-kernel bar; full 3-token drift was measured up to ~6e-2 absolute, spread
+    // evenly across every logit column (not concentrated in one bank/column, which is
+    // what a functional dispatch bug would look like) and shrinking sharply with fewer
+    // chained positions — the signature of compounding FP noise, not a bug. This bar
+    // has ~30% headroom over the worst measured run across Q4_K/Q5_K/Q6_K.
+    private const float AbsTol = 8e-2f;
+    private const float RelTol = 8e-3f;
+
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (string path in _tempFiles)
+        {
+            try { File.Delete(path); } catch { /* best-effort */ }
+        }
+    }
+
+    [SkippableTheory]
+    [InlineData(QuantizationType.Q4_K, 42)]
+    [InlineData(QuantizationType.Q4_K, 43)]
+    [InlineData(QuantizationType.Q5_K, 7)]
+    [InlineData(QuantizationType.Q5_K, 8)]
+    [InlineData(QuantizationType.Q6_K, 101)]
+    [InlineData(QuantizationType.Q6_K, 102)]
+    public void Forward_RoutedKQuant_MatchesCpuReference(QuantizationType routedQuantType, int seed)
+    {
+        VulkanMatMulF32KernelTests.SkipIfUnavailable(out string spvDir);
+
+        string path = WriteMixtralFixture(routedQuantType, seed);
+
+        int[] tokenIds = [1, 2, 3];
+        int[] positions = [0, 1, 2];
+
+        // ── CPU oracle: MoeQuantSwiGluMlp reads the raw K-quant bytes directly
+        //    (already has explicit Q4_K/Q5_K/Q6_K support — no change from #191). ──
+        float[] cpuLogits;
+        using (var gguf = GgufFile.Open(path))
+        {
+            var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+            using var cpuWeights = TransformerWeights.LoadFromGguf(gguf, config);
+
+            // Sanity: the fixture actually carries a raw K-quant view of the requested
+            // type on the MoE layer, and the CPU loader routed it through the
+            // quant-experts path (not a hidden F32 upcast) — otherwise this test would
+            // silently prove nothing about the new resolver/dispatch.
+            var moe = cpuWeights.Layers[0].Moe;
+            Assert.NotNull(moe);
+            Assert.True(moe!.UseQuantExperts);
+            Assert.True(moe.HasRawQuantView);
+            Assert.Equal(routedQuantType, moe.GateExpsRawQt);
+            Assert.Equal(routedQuantType, moe.UpExpsRawQt);
+            Assert.Equal(routedQuantType, moe.DownExpsRawQt);
+
+            using var cpuModel = TransformerModel.BuildFromPrebuiltWeights(cpuWeights, config);
+            using ITensor logits = cpuModel.Forward(tokenIds, positions, deviceId: -1);
+            cpuLogits = CopyLogits(logits);
+        }
+
+        // ── Vulkan: resolves the same raw view to the K-quant device type and
+        //    dispatches through the new indexed-matmul kernel. ──
+        float[] vkLogits;
+        QuantizationType resolvedW1Qt, resolvedW2Qt, resolvedW3Qt;
+        using (var gguf = GgufFile.Open(path))
+        {
+            var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+            using var device = VulkanDevice.Create();
+            using var vkModel = VulkanTransformerModel.LoadFromGguf(device, gguf, config, spvDir);
+
+            (resolvedW1Qt, resolvedW2Qt, resolvedW3Qt) = ReadResolvedMoeBankQuantTypes(vkModel, layerIndex: 0);
+
+            using ITensor logits = vkModel.Forward(tokenIds, positions, deviceId: -1);
+            Assert.Equal(1, logits.Shape[0]);
+            Assert.Equal(MxVocabSize, logits.Shape[1]);
+            vkLogits = CopyLogits(logits);
+        }
+
+        // The whole point of #191: the routed banks must resolve to the K-quant type,
+        // NOT fall back to F32 — proves the new dispatch wiring was actually exercised.
+        Assert.Equal(routedQuantType, resolvedW1Qt);
+        Assert.Equal(routedQuantType, resolvedW2Qt);
+        Assert.Equal(routedQuantType, resolvedW3Qt);
+
+        int lastRow = tokenIds.Length - 1;
+        for (int c = 0; c < MxVocabSize; c++)
+        {
+            float cpu = cpuLogits[lastRow * MxVocabSize + c];
+            float vk = vkLogits[c];
+            float diff = MathF.Abs(cpu - vk);
+            float bar = AbsTol + RelTol * MathF.Abs(cpu);
+            Assert.True(diff <= bar,
+                $"quant={routedQuantType}, col={c}: cpu={cpu:F6} vs vulkan={vk:F6} (|diff|={diff:E3} > {bar:E3})");
+        }
+    }
+
+    /// <summary>
+    /// Preflight (#191 item 4) must recognize a fully K-quant-routed DeepSeek-V2-style
+    /// (MLA + MoE) fixture as safe for <c>skipF32MoeDequant: true</c> — every routed
+    /// bank on the (single) MoE layer resolves to the requested K-quant type, none fall
+    /// back to F32. Does not call <c>.Forward()</c> — see the type doc for why.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData(QuantizationType.Q4_K, 42)]
+    [InlineData(QuantizationType.Q5_K, 7)]
+    [InlineData(QuantizationType.Q6_K, 101)]
+    public void CanSkipMoeF32HostDequant_TrueForFullyKQuantRoutedFixture(QuantizationType routedQuantType, int seed)
+    {
+        VulkanMatMulF32KernelTests.SkipIfUnavailable(out _);
+
+        string path = WriteDeepSeekV2Fixture(routedQuantType, seed);
+        using var gguf = GgufFile.Open(path);
+        var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+        using var device = VulkanDevice.Create();
+
+        bool canSkip = InvokeCanSkipMoeF32HostDequant(device, gguf, config);
+        Assert.True(canSkip);
+    }
+
+    /// <summary>
+    /// Negative case: a non-MLA config (skipF32MoeDequant never threads through for
+    /// non-MLA loaders) must always report <c>false</c>, regardless of quant type —
+    /// guards the preflight's architecture gate.
+    /// </summary>
+    [SkippableFact]
+    public void CanSkipMoeF32HostDequant_FalseWithoutMlaConfig()
+    {
+        VulkanMatMulF32KernelTests.SkipIfUnavailable(out _);
+
+        string path = WriteDeepSeekV2Fixture(QuantizationType.Q4_K, seed: 1);
+        using var gguf = GgufFile.Open(path);
+        var config = GgufModelConfigExtractor.Extract(gguf.Metadata) with { MlaConfig = null };
+        using var device = VulkanDevice.Create();
+
+        bool canSkip = InvokeCanSkipMoeF32HostDequant(device, gguf, config);
+        Assert.False(canSkip);
+    }
+
+    // VulkanWeights is `internal` (InternalsVisibleTo covers this test assembly), so
+    // CanSkipMoeF32HostDequant can be called directly — no reflection needed.
+    private static bool InvokeCanSkipMoeF32HostDequant(VulkanDevice device, GgufFile gguf, ModelConfig config)
+        => VulkanWeights.CanSkipMoeF32HostDequant(device, gguf, config);
+
+    /// <summary>
+    /// Reflects into the Vulkan model's PRIVATE <c>_weights</c> field (the only part not
+    /// reachable via InternalsVisibleTo) to read the on-device quant type each routed
+    /// bank (gate/down/up) actually resolved to for the given layer — the same fields
+    /// <c>RecordMoeIndexedMatmul</c> dispatches on.
+    /// </summary>
+    private static (QuantizationType w1, QuantizationType w2, QuantizationType w3) ReadResolvedMoeBankQuantTypes(
+        VulkanTransformerModel model, int layerIndex)
+    {
+        var weightsField = typeof(VulkanTransformerModel).GetField("_weights",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var weights = (VulkanWeights)weightsField!.GetValue(model)!;
+        var moe = weights.Layers[layerIndex].Moe;
+        Assert.NotNull(moe);
+        return (moe!.Value.W1DeviceQuantType, moe.Value.W2DeviceQuantType, moe.Value.W3DeviceQuantType);
+    }
+
+    private static unsafe float[] CopyLogits(ITensor logits)
+    {
+        int total = checked(logits.Shape[0] * logits.Shape[1]);
+        float[] copy = new float[total];
+        new ReadOnlySpan<float>((void*)logits.DataPointer, total).CopyTo(copy);
+        return copy;
+    }
+
+    /// <summary>
+    /// Writes a synthetic minimal Mixtral-shaped GGUF (standard dense GQA attention,
+    /// one all-MoE layer, no shared experts) to a temp file. Every tensor is F32 EXCEPT
+    /// the three routed-expert banks (<c>ffn_gate_exps</c>/<c>ffn_up_exps</c>/
+    /// <c>ffn_down_exps</c>), which are real <paramref name="routedQuantType"/>-quantized
+    /// bytes — the exact on-disk shape a real <c>*_K_M</c>-quantized Mixtral/DeepSeek
+    /// -family checkpoint carries.
+    /// </summary>
+    private string WriteMixtralFixture(QuantizationType routedQuantType, int seed)
+    {
+        var b = new GgufTestData(version: 3);
+        var rng = new Random(seed);
+        int qOut = MxNumHeads * MxHeadDim;
+        int kvOut = MxNumKvHeads * MxHeadDim;
+
+        b.AddString("general.architecture", "mixtral");
+        b.AddUInt32("mixtral.embedding_length", (uint)MxHiddenSize);
+        b.AddUInt32("mixtral.block_count", (uint)MxNumLayers);
+        b.AddUInt32("mixtral.attention.head_count", (uint)MxNumHeads);
+        b.AddUInt32("mixtral.attention.head_count_kv", (uint)MxNumKvHeads);
+        b.AddUInt32("mixtral.attention.key_length", (uint)MxHeadDim);
+        b.AddUInt32("mixtral.context_length", 16);
+        b.AddFloat32("mixtral.attention.layer_norm_rms_epsilon", 1e-5f);
+        b.AddUInt32("mixtral.vocab_size", (uint)MxVocabSize);
+        b.AddFloat32("mixtral.rope.freq_base", 10000.0f);
+        b.AddUInt32("mixtral.rope.dimension_count", (uint)MxHeadDim);
+        b.AddUInt32("mixtral.expert_count", (uint)MxNumExperts);
+        b.AddUInt32("mixtral.expert_used_count", (uint)MxNumExpertsPerTok);
+        b.AddUInt32("mixtral.expert_feed_forward_length", (uint)MxMoeIntermediate);
+
+        AddF32Tensor(b, "token_embd.weight", [MxHiddenSize, MxVocabSize], rng);
+        AddF32Tensor(b, "output_norm.weight", [MxHiddenSize], rng, center: 1.0f, jitter: 0.05f);
+        AddF32Tensor(b, "output.weight", [MxHiddenSize, MxVocabSize], rng);
+
+        for (int i = 0; i < MxNumLayers; i++)
+        {
+            string p = $"blk.{i}";
+            AddF32Tensor(b, $"{p}.attn_norm.weight", [MxHiddenSize], rng, center: 1.0f, jitter: 0.05f);
+            AddF32Tensor(b, $"{p}.ffn_norm.weight", [MxHiddenSize], rng, center: 1.0f, jitter: 0.05f);
+
+            AddF32Tensor(b, $"{p}.attn_q.weight", [MxHiddenSize, qOut], rng);
+            AddF32Tensor(b, $"{p}.attn_k.weight", [MxHiddenSize, kvOut], rng);
+            AddF32Tensor(b, $"{p}.attn_v.weight", [MxHiddenSize, kvOut], rng);
+            AddF32Tensor(b, $"{p}.attn_output.weight", [qOut, MxHiddenSize], rng);
+
+            AddF32Tensor(b, $"{p}.ffn_gate_inp.weight", [MxHiddenSize, MxNumExperts], rng);
+            AddExpertBankQuant(b, $"{p}.ffn_gate_exps.weight",
+                k: MxHiddenSize, m: MxMoeIntermediate, numExperts: MxNumExperts, routedQuantType, rng);
+            AddExpertBankQuant(b, $"{p}.ffn_up_exps.weight",
+                k: MxHiddenSize, m: MxMoeIntermediate, numExperts: MxNumExperts, routedQuantType, rng);
+            AddExpertBankQuant(b, $"{p}.ffn_down_exps.weight",
+                k: MxMoeIntermediate, m: MxHiddenSize, numExperts: MxNumExperts, routedQuantType, rng);
+        }
+
+        string path = b.WriteToTempFile();
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Writes a synthetic minimal DeepSeek-V2-Lite-shaped GGUF (monolithic-Q MLA,
+    /// layer 0 dense / layer 1 MoE) to a temp file, mirroring
+    /// <c>DeepSeekV2GgufLoadTests.WriteFixture</c>'s recipe (F32 there) with the three
+    /// routed-expert banks swapped for real <paramref name="routedQuantType"/>-quantized
+    /// bytes. Used ONLY by the <c>CanSkipMoeF32HostDequant_*</c> preflight tests, which
+    /// never call <c>.Forward()</c> — see the type doc for why a full MLA forward isn't
+    /// exercised here.
+    /// </summary>
+    private string WriteDeepSeekV2Fixture(QuantizationType routedQuantType, int seed)
+    {
+        var b = new GgufTestData(version: 3);
+        var rng = new Random(seed);
+
+        int qkHead = DsQkNope + DsQkRope;
+        int qTotal = DsNumHeads * qkHead;
+        int kvAOut = DsKvLoraRank + DsQkRope;
+        int kvBOut = DsNumHeads * (DsQkNope + DsVHead);
+        int oInput = DsNumHeads * DsVHead;
+
+        b.AddString("general.architecture", "deepseek2");
+        b.AddUInt32("deepseek2.embedding_length", (uint)DsHiddenSize);
+        b.AddUInt32("deepseek2.block_count", (uint)DsNumLayers);
+        b.AddUInt32("deepseek2.feed_forward_length", (uint)DsIntermediateSize);
+        b.AddUInt32("deepseek2.attention.head_count", (uint)DsNumHeads);
+        b.AddUInt32("deepseek2.attention.head_count_kv", (uint)DsNumHeads);
+        b.AddUInt32("deepseek2.context_length", 16);
+        b.AddFloat32("deepseek2.attention.layer_norm_rms_epsilon", 1e-6f);
+        b.AddUInt32("deepseek2.vocab_size", (uint)DsVocabSize);
+        b.AddFloat32("deepseek2.rope.freq_base", 10000.0f);
+        b.AddUInt32("deepseek2.rope.dimension_count", (uint)DsQkRope);
+
+        b.AddUInt32("deepseek2.attention.q_lora_rank", 0);   // monolithic Q (V2-Lite convention)
+        b.AddUInt32("deepseek2.attention.kv_lora_rank", (uint)DsKvLoraRank);
+        b.AddUInt32("deepseek2.attention.key_length", (uint)(DsQkNope + DsQkRope));
+        b.AddUInt32("deepseek2.attention.value_length", (uint)DsVHead);
+
+        b.AddUInt32("deepseek2.expert_count", (uint)DsNumExperts);
+        b.AddUInt32("deepseek2.expert_used_count", (uint)DsNumExpertsPerTok);
+        b.AddUInt32("deepseek2.expert_shared_count", 0);
+        b.AddUInt32("deepseek2.expert_feed_forward_length", (uint)DsMoeIntermediate);
+        b.AddUInt32("deepseek2.leading_dense_block_count", (uint)DsLeadingDenseBlocks);
+
+        AddF32Tensor(b, "token_embd.weight", [DsHiddenSize, DsVocabSize], rng);
+        AddF32Tensor(b, "output_norm.weight", [DsHiddenSize], rng, center: 1.0f, jitter: 0.05f);
+        AddF32Tensor(b, "output.weight", [DsHiddenSize, DsVocabSize], rng);
+
+        for (int i = 0; i < DsNumLayers; i++)
+        {
+            string p = $"blk.{i}";
+
+            AddF32Tensor(b, $"{p}.attn_norm.weight", [DsHiddenSize], rng, center: 1.0f, jitter: 0.05f);
+            AddF32Tensor(b, $"{p}.ffn_norm.weight", [DsHiddenSize], rng, center: 1.0f, jitter: 0.05f);
+
+            AddF32Tensor(b, $"{p}.attn_q.weight", [DsHiddenSize, qTotal], rng);
+            AddF32Tensor(b, $"{p}.attn_kv_a_mqa.weight", [DsHiddenSize, kvAOut], rng);
+            AddF32Tensor(b, $"{p}.attn_kv_a_norm.weight", [DsKvLoraRank], rng, center: 1.0f, jitter: 0.05f);
+            AddF32Tensor(b, $"{p}.attn_kv_b.weight", [DsKvLoraRank, kvBOut], rng);
+            AddF32Tensor(b, $"{p}.attn_output.weight", [oInput, DsHiddenSize], rng);
+
+            if (i < DsLeadingDenseBlocks)
+            {
+                AddF32Tensor(b, $"{p}.ffn_gate.weight", [DsHiddenSize, DsIntermediateSize], rng);
+                AddF32Tensor(b, $"{p}.ffn_up.weight", [DsHiddenSize, DsIntermediateSize], rng);
+                AddF32Tensor(b, $"{p}.ffn_down.weight", [DsIntermediateSize, DsHiddenSize], rng);
+            }
+            else
+            {
+                AddF32Tensor(b, $"{p}.ffn_gate_inp.weight", [DsHiddenSize, DsNumExperts], rng);
+                AddExpertBankQuant(b, $"{p}.ffn_gate_exps.weight",
+                    k: DsHiddenSize, m: DsMoeIntermediate, numExperts: DsNumExperts, routedQuantType, rng);
+                AddExpertBankQuant(b, $"{p}.ffn_up_exps.weight",
+                    k: DsHiddenSize, m: DsMoeIntermediate, numExperts: DsNumExperts, routedQuantType, rng);
+                AddExpertBankQuant(b, $"{p}.ffn_down_exps.weight",
+                    k: DsMoeIntermediate, m: DsHiddenSize, numExperts: DsNumExperts, routedQuantType, rng);
+            }
+        }
+
+        string path = b.WriteToTempFile();
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    /// <summary>
+    /// Writes one fused-experts tensor ([<paramref name="k"/>, <paramref name="m"/>,
+    /// <paramref name="numExperts"/>] — K innermost, GGUF convention) as REAL
+    /// <paramref name="qt"/>-quantized bytes: each expert's [<paramref name="m"/>,
+    /// <paramref name="k"/>] slab is generated as random F32 then quantized via the
+    /// matching test fixture quantizer, matching llama.cpp's on-disk block layout
+    /// byte-for-byte (verified elsewhere by the Q4K/Q5K/Q6K resident-upload tests).
+    /// </summary>
+    private static void AddExpertBankQuant(
+        GgufTestData b, string name, int k, int m, int numExperts, QuantizationType qt, Random rng)
+    {
+        int rowBytes = qt switch
+        {
+            QuantizationType.Q4_K => (k / Q4KFixture.Q4KGroupSize) * Q4KFixture.Q4KBlockBytes,
+            QuantizationType.Q5_K => (k / Q5KFixture.Q5KGroupSize) * Q5KFixture.Q5KBlockBytes,
+            QuantizationType.Q6_K => (k / Q6KFixture.Q6KGroupSize) * Q6KFixture.Q6KBlockBytes,
+            _ => throw new NotSupportedException($"Unsupported routed quant type for this fixture: {qt}"),
+        };
+        var all = new byte[(long)numExperts * m * rowBytes];
+        for (int e = 0; e < numExperts; e++)
+        {
+            float[] f32 = Q4KFixture.RandomFloats(rng, m * k, range: 0.1f);
+            byte[] q = qt switch
+            {
+                QuantizationType.Q4_K => Q4KFixture.QuantizeRows(f32, m, k),
+                QuantizationType.Q5_K => Q5KFixture.QuantizeRows(f32, m, k),
+                QuantizationType.Q6_K => Q6KFixture.QuantizeRows(f32, m, k),
+                _ => throw new NotSupportedException(),
+            };
+            Buffer.BlockCopy(q, 0, all, e * m * rowBytes, q.Length);
+        }
+        b.AddTensor(name, [k, m, numExperts], (uint)qt, all);
+    }
+
+    private static void AddF32Tensor(GgufTestData b, string name, int[] shape, Random rng,
+        float amplitude = 0.1f, float center = 0.0f, float jitter = 0.0f)
+    {
+        long n = 1;
+        foreach (int d in shape) n *= d;
+        byte[] bytes = new byte[n * sizeof(float)];
+        for (long i = 0; i < n; i++)
+        {
+            float raw = (float)(rng.NextDouble() * 2.0 - 1.0);
+            float v = jitter > 0f ? center + jitter * raw : amplitude * raw;
+            System.Buffers.Binary.BinaryPrimitives.WriteSingleLittleEndian(
+                bytes.AsSpan((int)(i * sizeof(float)), sizeof(float)), v);
+        }
+        b.AddTensor(name, shape, quantType: 0, bytes);
+    }
+}


### PR DESCRIPTION
## Summary

- Extends `VulkanWeights.MoeRoutedRawDeviceQuantType` to recognize Q4_K/Q5_K/Q6_K for routed expert banks (`ffn_gate_exps`/`ffn_up_exps`/`ffn_down_exps`), not just Q8_0/coopmat-F16 — the common case for `*_K_M`-quantized DeepSeek-family/Mixtral/Qwen-MoE GGUFs.
- Wires the corresponding `MoeIndexedMatmulQ4_K/Q5_K/Q6_KF32Kernel` dispatch into `VulkanTransformerModel`'s generic (non-hybrid) MoE forward path, moving Q4_K kernel construction out of the `Gemma4DualFfn`-only gate (it was dead code for every non-Gemma4 model) and adding Q5_K/Q6_K construction + dispatch alongside it.
- Adds `VulkanWeights.CanSkipMoeF32HostDequant`, a preflight that scans a GGUF's MoE tensor descriptors against the same resolver the real upload uses, and gates `VulkanTransformerModel.LoadFromGguf`'s `skipF32MoeDequant` on it — so Vulkan can now match CUDA's unconditional host-RAM-saving skip wherever safe, falling back to the F32 host-dequant default per-model when any routed bank wouldn't resolve to a supported raw-quant type (unconditionally skipping would leave those banks pointing at null host arrays — silent corruption, not a crash).

Closes #191.

## Test plan

- [x] New `VulkanTransformerModelMoeKQuantRoutedForwardTests`: CPU-vs-Vulkan full forward parity for Q4_K, Q5_K, and Q6_K routed banks (2 seeds each), against a synthetic Mixtral-style GGUF carrying real quantized bytes (not F32) for the routed expert tensors — both backends read the identical quantized data, CPU via `DotLLM.Cpu.Kernels.MoeQuantSwiGluMlp`, Vulkan via the newly-wired indexed-matmul kernels.
- [x] Same test file: `CanSkipMoeF32HostDequant` preflight-gate coverage (true for a fully K-quant-routed DeepSeek-V2-style MLA+MoE fixture across Q4_K/Q5_K/Q6_K; false without `MlaConfig`).
- [x] Verified the resolver/dispatcher wiring is load-bearing: temporarily reverting the Q4_K/Q5_K/Q6_K resolver branch makes 9/10 of the new tests fail as expected, confirming the suite discriminates real breakage.
- [x] Full Vulkan test suite (`--filter "FullyQualifiedName~Vulkan"`, 1045 tests, ~54 min) run to completion: 1035 passed, 10 failed. All 10 failures (`VulkanLoraAdapterUploadTests`/`VulkanLoraForwardParityTests`/`VulkanTurboQuantKvEndToEndTests`/`VulkanPipelineParityTests`) are pre-existing and unrelated to MoE/K-quant — confirmed by clean passes when rerun standalone; the failures are Vulkan device-creation resource exhaustion / multi-device threading flakiness from sustained back-to-back GPU test execution, not functional regressions.
- [x] Local RTX 3060, `nvidia-smi` idle before/after.

## Scope note

Item 3 from the original design (parity tests) targeted a DeepSeek-V2-style MLA+MoE fixture directly, but a full `.Forward()` call on ANY synthetic MLA GGUF (CPU or Vulkan, with or without quantization) reliably crashes the test host — a pre-existing bug in the CPU MLA forward path with zero prior test coverage (no existing test runs a full forward on a synthetic MLA GGUF at all). This is unrelated to #191 and out of scope here; the forward-parity tests instead use a Mixtral-style (dense attention + MoE) fixture, which exercises the exact same `VulkanWeights.UploadMoeLayer` / `MoeRoutedRawDeviceQuantType` / `RecordMoeIndexedMatmul` code this issue changes (that code path doesn't care whether the model is MLA or dense-attention). The preflight-gate tests (item 4) still use a DeepSeek-V2-style MLA+MoE fixture since `skipF32MoeDequant` only threads through the MLA loader path, but those tests never call `.Forward()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)