### PR TITLE
fix(mla): size AttnOutput scratch for fused o_proj width (#193)

### DIFF
--- a/src/DotLLM.Models/Architectures/TransformerForwardState.cs
+++ b/src/DotLLM.Models/Architectures/TransformerForwardState.cs
@@ -24,6 +24,14 @@ internal sealed unsafe class TransformerForwardState : IDisposable
     // per-layer block so a single allocation covers both layer types.
     private readonly int _qBlockElems;   // max over layer types of numHeads   * layerHeadDim
     private readonly int _kvBlockElems;  // max over layer types of kvHeads(L) * layerHeadDim
+    // AttnOutput block size. Equals _qBlockElems for GQA/MHA/MQA models (the
+    // attention kernel writes the pre-o_proj, numHeads*headDim-wide output
+    // here; o_proj is applied afterward into a separate buffer). MLA models
+    // fuse o_proj INSIDE the kernel and write the already-projected,
+    // hiddenSize-wide result directly into AttnOutput instead — callers pass
+    // an explicit (possibly larger) size for that case. See TransformerModel
+    // .BuildFromPrebuiltWeightsInternal and #193.
+    private readonly int _attnOutBlockElems;
 
     private int _currentSeqLen;
 
@@ -37,7 +45,7 @@ internal sealed unsafe class TransformerForwardState : IDisposable
 
             long bytes = 0;
             bytes += s * _hiddenSize * 3;                    // HiddenState + Residual + NormOutput
-            bytes += s * _qBlockElems * 2;                   // Q + AttnOutput
+            bytes += s * (_qBlockElems + _attnOutBlockElems); // Q + AttnOutput
             bytes += s * _kvBlockElems * 2;                  // K + V
             bytes += s * _intermediateSize * 3;              // FfnGate + FfnUp + SiluOutput
             bytes += s * _vocabSize;                          // Logits (all positions for speculative verify)
@@ -113,6 +121,7 @@ internal sealed unsafe class TransformerForwardState : IDisposable
         float ropeTheta,
         int globalRopeDim = 0, float globalRopeTheta = 0f,
         int qBlockElems = 0, int kvBlockElems = 0,
+        int attnOutBlockElems = 0,
         int globalFullHeadDim = 0,
         float[]? globalFreqFactors = null)
     {
@@ -127,6 +136,9 @@ internal sealed unsafe class TransformerForwardState : IDisposable
         // every existing caller byte-identical.
         _qBlockElems = qBlockElems > 0 ? qBlockElems : numHeads * headDim;
         _kvBlockElems = kvBlockElems > 0 ? kvBlockElems : numKvHeads * headDim;
+        // Defaults to _qBlockElems when the caller doesn't pass an explicit
+        // size — keeps every existing (non-MLA) caller byte-identical.
+        _attnOutBlockElems = attnOutBlockElems > 0 ? attnOutBlockElems : _qBlockElems;
 
         // Pre-compute RoPE frequency tables
         int halfDim = ropeDim / 2;
@@ -186,7 +198,7 @@ internal sealed unsafe class TransformerForwardState : IDisposable
         Q = AllocFloats((long)newCapacity * _qBlockElems);
         K = AllocFloats((long)newCapacity * _kvBlockElems);
         V = AllocFloats((long)newCapacity * _kvBlockElems);
-        AttnOutput = AllocFloats((long)newCapacity * _qBlockElems);
+        AttnOutput = AllocFloats((long)newCapacity * _attnOutBlockElems);
         FfnGate = AllocFloats(newCapacity * _intermediateSize);
         FfnUp = AllocFloats(newCapacity * _intermediateSize);
         SiluOutput = AllocFloats(newCapacity * _intermediateSize);

--- a/src/DotLLM.Models/Architectures/TransformerModel.cs
+++ b/src/DotLLM.Models/Architectures/TransformerModel.cs
@@ -278,6 +278,24 @@ public sealed unsafe class TransformerModel : IModel
         int qBlockElems = config.NumAttentionHeads * Math.Max(slidingHeadDim, fullHeadDim);
         int kvBlockElems = Math.Max(slidingKvHeads * slidingHeadDim, fullKvHeads * fullHeadDim);
 
+        // MLA (DeepSeek-V2/V3) fuses o_proj INSIDE the attention kernel: unlike
+        // the GQA branch (which writes the pre-o_proj, numHeads*headDim-wide
+        // attention output into AttnOutput and applies o_proj afterward into a
+        // separate hiddenSize-wide buffer), the MLA branch writes its ALREADY
+        // o_proj-expanded, hiddenSize-wide result directly into the shared
+        // AttnOutput scratch. AttnOutput must therefore be sized to at least
+        // hiddenSize for MLA models — qBlockElems alone
+        // (numHeads*(qkNopeHeadDim+qkRopeHeadDim)) can be far smaller than
+        // hiddenSize on compact/synthetic configs (undersized allocation here
+        // is a native heap buffer overflow, not a catchable exception — #193).
+        // Real DeepSeek-V2-Lite-scale configs happen to satisfy qBlockElems >
+        // hiddenSize already (16 heads * 192 = 3072 > 2048), so this is a
+        // no-op there; Math.Max keeps every non-MLA architecture byte-for-byte
+        // unchanged.
+        int attnOutBlockElems = config.MlaConfig is not null
+            ? Math.Max(qBlockElems, config.HiddenSize)
+            : qBlockElems;
+
         var state = new TransformerForwardState(
             config.HiddenSize,
             config.NumAttentionHeads,
@@ -296,6 +314,7 @@ public sealed unsafe class TransformerModel : IModel
             globalRopeTheta,
             qBlockElems,
             kvBlockElems,
+            attnOutBlockElems: attnOutBlockElems,
             // Full global head dim — the partial-rotary frequency denominator
             // (Gemma 4 global layers: rotate globalRopeDim=128 dims but use freq
             // base over the full head dim 512). Equals globalRopeDim when there is

--- a/tests/DotLLM.Tests.Unit/Models/Architectures/DeepSeekV2GgufLoadTests.cs
+++ b/tests/DotLLM.Tests.Unit/Models/Architectures/DeepSeekV2GgufLoadTests.cs
@@ -78,6 +78,122 @@ public sealed class DeepSeekV2GgufLoadTests
         }
     }
 
+    // ── Minimal MLA Forward() repro (#193) ──────────────────────────────
+    // A synthetic, plain-F32, 1-layer, dense-only (no MoE) MLA fixture at
+    // HiddenSize=256 — about as small as the architecture allows. Root cause
+    // (see Forward_MinimalMlaFixture_DoesNotCrash_ProducesFiniteLogits):
+    // TransformerForwardState sizes the shared Q/AttnOutput scratch buffer
+    // to `numHeads * headDim` (the GQA per-token attention-output width).
+    // The MLA branch of TransformerModel's forward loop writes its ALREADY
+    // o_proj-expanded, hiddenSize-wide output directly into that same
+    // AttnOutput buffer (MLA fuses o_proj inside the kernel, unlike GQA which
+    // writes pre-projection numHeads*headDim-wide output and applies o_proj
+    // afterward into a separate hiddenSize-wide buffer). Whenever
+    // numHeads*(qkNopeHeadDim+qkRopeHeadDim) < hiddenSize, the MLA kernel
+    // overruns the AttnOutput allocation and corrupts the native heap —
+    // fatal, not a catchable .NET exception. Real DeepSeek-V2-Lite
+    // (hidden=2048, 16 heads, headDim=192 ⇒ 3072 > 2048) never triggers this
+    // by coincidence; a minimal fixture with small head dims (this one:
+    // 2 heads * (4+4) = 16 ≪ 256) reliably does.
+    private const int MiniHiddenSize = 256;
+    private const int MiniNumHeads = 2;
+    private const int MiniVocabSize = 8;
+    private const int MiniQkNope = 4;
+    private const int MiniQkRope = 4;
+    private const int MiniVHead = 4;
+    private const int MiniKvLoraRank = 8;
+    private const int MiniIntermediateSize = 32;
+
+    [Fact]
+    public void Forward_MinimalMlaFixture_DoesNotCrash_ProducesFiniteLogits()
+    {
+        string ggufPath = WriteMinimalMlaFixture();
+        try
+        {
+            using var gguf = GgufFile.Open(ggufPath);
+            var config = GgufModelConfigExtractor.Extract(gguf.Metadata);
+
+            Assert.Equal(AttentionType.MLA, config.AttentionType);
+            Assert.NotNull(config.MlaConfig);
+            Assert.Null(config.Moe);
+
+            using var model = TransformerModel.LoadFromGguf(gguf, config);
+
+            int[] tokenIds = [0, 1, 2, 3];
+            int[] positions = [0, 1, 2, 3];
+            using ITensor logits = model.Forward(tokenIds, positions, deviceId: 0);
+
+            unsafe
+            {
+                int total = logits.Shape.Rank == 1 ? logits.Shape[0] : logits.Shape[1];
+                var span = new ReadOnlySpan<float>((void*)logits.DataPointer, total);
+                int finite = 0;
+                foreach (float v in span)
+                    if (float.IsFinite(v)) finite++;
+                Assert.True(finite == total,
+                    $"Expected all {total} logits finite; got {finite}. " +
+                    $"First 8: [{string.Join(", ", span.Slice(0, Math.Min(8, total)).ToArray().Select(v => v.ToString("F3")))}]");
+            }
+        }
+        finally
+        {
+            File.Delete(ggufPath);
+        }
+    }
+
+    /// <summary>
+    /// Writes a minimal 1-layer, dense-only (no MoE), plain-F32 DeepSeek-V2-style
+    /// GGUF — see the remarks above <see cref="Forward_MinimalMlaFixture_DoesNotCrash_ProducesFiniteLogits"/>.
+    /// </summary>
+    private static string WriteMinimalMlaFixture()
+    {
+        var b = new GgufTestData(version: 3);
+        var rng = new Random(1234);
+
+        int qkHead = MiniQkNope + MiniQkRope;
+        int qTotal = MiniNumHeads * qkHead;
+        int kvAOut = MiniKvLoraRank + MiniQkRope;
+        int kvBOut = MiniNumHeads * (MiniQkNope + MiniVHead);
+        int oInput = MiniNumHeads * MiniVHead;
+
+        b.AddString("general.architecture", "deepseek2");
+        b.AddUInt32("deepseek2.embedding_length", (uint)MiniHiddenSize);
+        b.AddUInt32("deepseek2.block_count", 1);
+        b.AddUInt32("deepseek2.feed_forward_length", (uint)MiniIntermediateSize);
+        b.AddUInt32("deepseek2.attention.head_count", (uint)MiniNumHeads);
+        b.AddUInt32("deepseek2.attention.head_count_kv", (uint)MiniNumHeads);
+        b.AddUInt32("deepseek2.context_length", 16);
+        b.AddFloat32("deepseek2.attention.layer_norm_rms_epsilon", 1e-6f);
+        b.AddUInt32("deepseek2.vocab_size", (uint)MiniVocabSize);
+        b.AddFloat32("deepseek2.rope.freq_base", 10000.0f);
+        b.AddUInt32("deepseek2.rope.dimension_count", (uint)MiniQkRope);
+
+        b.AddUInt32("deepseek2.attention.q_lora_rank", 0);
+        b.AddUInt32("deepseek2.attention.kv_lora_rank", (uint)MiniKvLoraRank);
+        b.AddUInt32("deepseek2.attention.key_length", (uint)qkHead);
+        b.AddUInt32("deepseek2.attention.value_length", (uint)MiniVHead);
+
+        AddF32Tensor(b, "token_embd.weight", [MiniHiddenSize, MiniVocabSize], rng.Next());
+        AddF32Tensor(b, "output_norm.weight", [MiniHiddenSize], rng.Next(), center: 1.0f, jitter: 0.05f);
+        AddF32Tensor(b, "output.weight", [MiniHiddenSize, MiniVocabSize], rng.Next());
+
+        const string p = "blk.0";
+        AddF32Tensor(b, $"{p}.attn_norm.weight", [MiniHiddenSize], rng.Next(), center: 1.0f, jitter: 0.05f);
+        AddF32Tensor(b, $"{p}.ffn_norm.weight", [MiniHiddenSize], rng.Next(), center: 1.0f, jitter: 0.05f);
+
+        AddF32Tensor(b, $"{p}.attn_q.weight", [MiniHiddenSize, qTotal], rng.Next());
+        AddF32Tensor(b, $"{p}.attn_kv_a_mqa.weight", [MiniHiddenSize, kvAOut], rng.Next());
+        AddF32Tensor(b, $"{p}.attn_kv_a_norm.weight", [MiniKvLoraRank], rng.Next(), center: 1.0f, jitter: 0.05f);
+        AddF32Tensor(b, $"{p}.attn_kv_b.weight", [MiniKvLoraRank, kvBOut], rng.Next());
+        AddF32Tensor(b, $"{p}.attn_output.weight", [oInput, MiniHiddenSize], rng.Next());
+
+        AddF32Tensor(b, $"{p}.ffn_gate.weight", [MiniHiddenSize, MiniIntermediateSize], rng.Next());
+        AddF32Tensor(b, $"{p}.ffn_up.weight", [MiniHiddenSize, MiniIntermediateSize], rng.Next());
+        AddF32Tensor(b, $"{p}.ffn_down.weight", [MiniIntermediateSize, MiniHiddenSize], rng.Next());
+
+        return b.WriteToTempFile();
+    }
+
     /// <summary>
     /// Real-checkpoint config-extraction smoke test against a cached
     /// <c>DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M.gguf</c> (~10.4 GB,


### PR DESCRIPTION
## Summary
- `TransformerModel`'s MLA branch fuses `o_proj` *inside* the attention kernel and writes its already-projected, `hiddenSize`-wide output directly into the shared `AttnOutput` scratch buffer — unlike the GQA/MHA branch, which writes pre-`o_proj`, `numHeads*headDim`-wide output there and projects afterward into a separate buffer.
- `TransformerForwardState` sized `AttnOutput` to `numHeads*headDim` only. Real DeepSeek-V2-Lite-scale configs never hit this (16 heads * 192 = 3072 > hidden 2048 happens to hold), but any config where `numHeads*(qkNopeHeadDim+qkRopeHeadDim) < hiddenSize` — including any minimal/synthetic MLA fixture — overruns the native heap when the MLA kernel writes its output. That's a fatal access violation, not a catchable .NET exception, which is why it crashed the whole test host process (#193).
- Fix: size `AttnOutput` to `Math.Max(qBlockElems, hiddenSize)` specifically when `MlaConfig` is present. No-op for every non-MLA architecture (byte-identical allocation size).
- Adds the missing regression test: a minimal 1-layer, F32, dense-only (no MoE) MLA GGUF fixture at `HiddenSize=256` + a full `.Forward()` call — this exact combination had zero prior coverage (`DeepSeekV2GgufLoadTests` only checked loading; `VulkanTransformerModelMlaForwardTests` used a dense, non-GGUF, safetensors-loaded model). The new test crashed the process reliably before the fix, passes deterministically after.

## Root cause detail
`_qBlockElems = NumAttentionHeads * Math.Max(slidingHeadDim, fullHeadDim)` where, for MLA, `HeadDim` is patched to `qkNopeHeadDim + qkRopeHeadDim` (the per-head attention dimension). This bears no relation to `hiddenSize` (the residual-stream width) for MLA models — MLA's whole point is decoupling the compressed KV/attention dimensionality from the residual width. `AttnOutput` needs to hold the residual-width output because MLA's kernel (`MlaAttention.Execute` / `ExecuteLatent` / `ExecuteLatentHybrid`) performs the `o_proj` GEMM internally and writes `[seqLen, hiddenSize]` directly, whereas GQA writes `[seqLen, numHeads*headDim]` and the caller applies `o_proj` afterward into `normOut` (hiddenSize-wide).

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~Forward_MinimalMlaFixture_DoesNotCrash"` — crashes host process pre-fix (confirmed twice), passes post-fix (confirmed 4x in a row).
- [x] `dotnet test --filter "FullyQualifiedName~Mla|FullyQualifiedName~DeepSeek"` — 107 passed, 0 failed, 10 skipped (real-checkpoint/CUDA gated, unchanged).
- [x] `VulkanTransformerModelMlaForwardTests` (existing dense/safetensors MLA path, live GPU) — 3/3 pass, no regression.
- [x] `dotnet test --filter "FullyQualifiedName~DotLLM.Tests.Unit.Models.Architectures|FullyQualifiedName~DotLLM.Tests.Unit.Cpu.Kernels"` (broader sanity pass covering every call site of `TransformerForwardState`/`TransformerModel`) — 749 passed, 0 failed, 13 skipped.

Closes #193