### PR TITLE
bench(cpu/i2s): profile GEMV decode bandwidth vs compute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Unit Tests
-        run: dotnet test tests/DotLLM.Tests.Unit/ -c Release --filter "Category!=GPU"
+        run: dotnet test tests/DotLLM.Tests.Unit/ -c Release --filter "Category!=GPU&Category!=Benchmark"
 
   integration-tests:
     name: Integration Tests

--- a/docs/superpowers/plans/2026-07-27-i2s-decode-bandwidth-plan.md
+++ b/docs/superpowers/plans/2026-07-27-i2s-decode-bandwidth-plan.md
@@ -1,0 +1,401 @@
+# I2_S Decode Bandwidth Profiling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure whether CPU BitNet (I2_S) GEMV decode, after the #128 unpack-SIMD fix already on `dev`, is now memory-bandwidth-bound or still compute-bound on this Strix Halo box, to gate whether the AVX-512 activation-LUT dot kernel (suggested upstream in issue #334) is worth building next.
+
+**Architecture:** Measurement-only. Adds one small kernel-side helper (`BenchStreamingReadOnly`, a vectorized touch-every-byte loop with no unpack/decode) next to the existing `BenchUnpackRowI8Only` helper from #128/#131. Follows this repo's **existing convention** for this exact kind of investigation — `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs` is a `TEMPORARY` xUnit `[Theory]` using `Stopwatch` + `ITestOutputHelper` to print wall-clock numbers, not a `BenchmarkDotNet` class — so this plan adds a sibling profiling test in the same style rather than introducing a new benchmark harness. (This deviates from the design doc's original "commit a BenchmarkDotNet class" framing in favor of matching the pattern the codebase already uses for this precise scenario; still measurement-only, same shapes, same comparison.) Two access patterns are measured per shape: **hot** (same weight buffer reused every iteration, matching #131's original methodology and mirroring how a resident weight tensor behaves across consecutive decode steps) and **cold** (round-robin across enough distinct buffers to exceed L3, forcing genuine DRAM traffic) — comparing both against full-decode GB/s tells us whether we're cache-bound, DRAM-bound, or compute-bound.
+
+**Tech Stack:** C# / .NET 10, `System.Runtime.Intrinsics.X86.Avx2`, xUnit v3, `ITestOutputHelper`, `System.Diagnostics.Stopwatch`.
+
+**Spec reference:** `docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-design.md`.
+
+**Effort estimate:** ~1-2 hours, no new production logic, 1 PR.
+
+## Global Constraints
+
+- Existing shapes from #131, for continuity with prior data: `attn_qproj` (m=2560, k=2560), `ffn_gate` (m=6912, k=2560), `ffn_down` (m=2560, k=6912).
+- Single-thread only (`threadPool: null` on `GemvI2_S`) — matches #131's methodology; multi-thread dispatch is orthogonal to the per-core bandwidth question and would confound it.
+- No changes to `src/DotLLM.Cpu/Kernels/MatMul.I2S.cs` production kernels — this plan is purely additive profiling infra.
+- The new kernel-side helper lives in `src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs` (the existing home for #128/#131's `BenchUnpackRowI8Only`), same `unsafe partial class MatMul` pattern.
+- Every new/modified file must build under the project's existing `<Nullable>enable</Nullable>` + `[SkipLocalsInit]`/`[MethodImpl(AggressiveOptimization)]` conventions already used in this file.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs` | Add `BenchStreamingReadOnly(byte* weights, int m, int k)` — vectorized (AVX2) touch-every-packed-byte loop, no unpack, returns a checksum byte to defeat dead-code elimination. |
+| Modify | `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs` | Add a smoke assertion that `BenchStreamingReadOnly` and a scalar reference agree on the XOR checksum (cheap correctness guard for the new helper; not a performance test). |
+| Create | `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs` | TEMPORARY profiling `[Theory]` test (same style as `I2SUnpackProfileBench`): for each of the 3 shapes, times hot-streaming, cold-streaming, unpack-only, and full `GemvI2_S` decode; prints ns/row, GB/s, and ratio-to-ceiling via `ITestOutputHelper`. |
+| Create | `docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md` | Captured benchmark output + go/no-go verdict, written after running the profiling test on this box. |
+
+No changes to production kernels. No new abstractions.
+
+---
+
+### Task 0: File the tracking issue and create the branch
+
+Per this repo's issue-driven workflow (every task starts with a GitHub issue; dedicated branch
+per issue): this is a small, already-scoped task, so file the issue with the acceptance criteria
+below rather than iterating on scope in the issue itself.
+
+- [ ] **Step 1: File the tracking issue**
+
+`gh issue create --repo jamesburton/dotLLM --title "bench(cpu/i2s): profile GEMV decode bandwidth vs compute" --body "Measure whether I2_S GEMV decode (post-#128 unpack fix) is memory-bandwidth-bound or compute-bound on Strix Halo, to gate the AVX-512 activation-LUT dot kernel proposed upstream in #334. Design: docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-design.md.\n\nAcceptance criteria:\n- [ ] BenchStreamingReadOnly helper added and smoke-tested\n- [ ] Profiling test measures hot/cold streaming ceiling vs unpack-only vs full decode for the 3 #131 shapes\n- [ ] Results recorded with a go/no-go verdict\n- [ ] Verdict posted to upstream #334; follow-up issue filed per the verdict"`
+
+Note the returned issue number — it's `{N}` in the branch name and PR below.
+
+- [ ] **Step 2: Create the branch**
+
+```bash
+git checkout main
+git pull
+git checkout -b issue/{N}-i2s-decode-bandwidth-profiling
+```
+
+(Branch from `main` per the workflow rule; this is standalone profiling work, not part of the
+`dev` WIP-integration flow described in CLAUDE.md's "large pre-existing feature branches" section.)
+
+---
+
+### Task 1: Add `BenchStreamingReadOnly` kernel-side helper
+
+**Files:**
+- Modify: `src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs`
+- Test: `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs`
+
+**Interfaces:**
+- Produces: `public static byte MatMul.BenchStreamingReadOnly(byte* weights, int m, int k)` — reads exactly `m * (k/4)` packed bytes (the same footprint `UnpackRowI8`/`GemvI2_S` touch per call), does no unpack/decode, returns an XOR checksum of every byte read (forces the JIT to keep the reads live).
+
+- [ ] **Step 1: Write the failing smoke test**
+
+Add to `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs` (new `[Fact]` in the existing `I2SUnpackProfileBench` class):
+
+```csharp
+    [Fact]
+    public void BenchStreamingReadOnly_MatchesScalarChecksum()
+    {
+        var rng = new Random(7);
+        const int m = 64, k = 512;
+        int rowBytes = k / 4;
+        byte[] buf = new byte[m * rowBytes];
+        rng.NextBytes(buf);
+
+        byte expected = 0;
+        foreach (byte b in buf) expected ^= b;
+
+        fixed (byte* p = buf)
+        {
+            byte actual = MatMul.BenchStreamingReadOnly(p, m, k);
+            Assert.Equal(expected, actual);
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/DotLLM.Tests.Unit --filter "FullyQualifiedName~I2SUnpackProfileBench.BenchStreamingReadOnly_MatchesScalarChecksum"`
+Expected: FAIL — `CS0117` / build error, `MatMul` has no `BenchStreamingReadOnly`.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs` (inside the existing `partial class MatMul`, after `BenchUnpackRowI8Only`):
+
+```csharp
+    /// <summary>
+    /// Reads every packed byte a full <see cref="GemvI2_S(byte*, float*, float*, int, int, ComputeThreadPool?)"/>
+    /// call would touch (<c>m·k/4</c> bytes), doing no unpack/decode — an empirical
+    /// achievable-bandwidth probe for this exact access pattern. Returns an XOR checksum so the
+    /// JIT cannot eliminate the reads as dead code.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static byte BenchStreamingReadOnly(byte* weights, int m, int k)
+    {
+        long totalBytes = (long)m * (k / 4);
+        Vector256<byte> acc = Vector256<byte>.Zero;
+        long i = 0;
+
+        if (Avx2.IsSupported)
+        {
+            long vecEnd = totalBytes - (totalBytes % 32);
+            for (; i < vecEnd; i += 32)
+                acc ^= Unsafe.ReadUnaligned<Vector256<byte>>(weights + i);
+        }
+
+        Span<byte> lanes = stackalloc byte[32];
+        acc.CopyTo(lanes);
+        byte result = 0;
+        foreach (byte lane in lanes) result ^= lane;
+
+        for (; i < totalBytes; i++)
+            result ^= weights[i];
+
+        return result;
+    }
+```
+
+Add the required usings at the top of the file if not already present (`System.Runtime.CompilerServices`, `System.Runtime.Intrinsics`, `System.Runtime.Intrinsics.X86`) — check the existing usings first since `MatMul.I2S.cs` (the partial sibling) already has them; `MatMul.I2S.Bench.cs` currently only has `using System.Buffers;` so add:
+
+```csharp
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test tests/DotLLM.Tests.Unit --filter "FullyQualifiedName~I2SUnpackProfileBench.BenchStreamingReadOnly_MatchesScalarChecksum"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs
+git commit -m "bench(cpu/i2s): add streaming-read-only bandwidth probe helper"
+```
+
+---
+
+### Task 2: Add the decode-bandwidth profiling test
+
+**Files:**
+- Create: `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs`
+
+**Interfaces:**
+- Consumes: `MatMul.BenchStreamingReadOnly(byte*, int, int)` (Task 1), `MatMul.BenchUnpackRowI8Only(byte*, int, int)` (existing, `MatMul.I2S.Bench.cs`), `MatMul.GemvI2_S(byte*, float*, float*, int, int, float, ComputeThreadPool?)` (existing explicit-scale overload — avoids needing a tail-scale float appended to the buffer).
+- Produces: test-output-only (`ITestOutputHelper`); no new public surface for later tasks to consume.
+
+- [ ] **Step 1: Write the profiling test**
+
+Create `tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs`:
+
+```csharp
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using DotLLM.Cpu.Kernels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Unit.Cpu.Kernels;
+
+/// <summary>
+/// TEMPORARY profiling harness — measures whether I2_S GEMV decode (post-#128 unpack-SIMD fix) is
+/// memory-bandwidth-bound or still compute-bound on this box, gating the AVX-512 activation-LUT
+/// dot kernel proposed upstream in issue #334. Not a correctness test; prints wall-clock numbers
+/// via test output. Delete once the go/no-go verdict is recorded.
+/// </summary>
+public sealed unsafe class I2SDecodeBandwidthProfileBench
+{
+    private readonly ITestOutputHelper _output;
+
+    public I2SDecodeBandwidthProfileBench(ITestOutputHelper output) => _output = output;
+
+    /// <summary>Number of distinct weight-buffer copies for the "cold" (>L3) measurement.</summary>
+    private const int ColdBufferCount = 32;
+
+    [Theory]
+    [InlineData(2560, 2560, "attn_qproj")]
+    [InlineData(6912, 2560, "ffn_gate")]
+    [InlineData(2560, 6912, "ffn_down")]
+    public void ProfileGemvI2SDecode_BandwidthVsCompute(int m, int k, string label)
+    {
+        var rng = new Random(42);
+        int rowBytes = k / 4;
+        long weightBytes = (long)m * rowBytes;
+        const float scale = 0.02f;
+
+        // Hot buffer: single allocation, reused every iteration (matches #131's methodology and a
+        // resident weight tensor reused across consecutive decode steps).
+        byte* hotWeights = (byte*)NativeMemory.AllocZeroed((nuint)weightBytes);
+
+        // Cold buffers: enough distinct copies to exceed typical L3, round-robined across
+        // iterations so each touch is a fresh cache line from DRAM.
+        byte*[] coldWeights = new byte*[ColdBufferCount];
+
+        float* x = (float*)NativeMemory.AllocZeroed((nuint)(k * sizeof(float)));
+        float* result = (float*)NativeMemory.AllocZeroed((nuint)(m * sizeof(float)));
+
+        try
+        {
+            byte[] randRow = new byte[weightBytes];
+            rng.NextBytes(randRow);
+            Marshal.Copy(randRow, 0, (nint)hotWeights, (int)weightBytes);
+
+            for (int c = 0; c < ColdBufferCount; c++)
+            {
+                coldWeights[c] = (byte*)NativeMemory.AllocZeroed((nuint)weightBytes);
+                rng.NextBytes(randRow);
+                Marshal.Copy(randRow, 0, (nint)coldWeights[c], (int)weightBytes);
+            }
+
+            for (int i = 0; i < k; i++) x[i] = rng.NextSingle() * 2f - 1f;
+
+            const int iters = 20;
+
+            // Warm up (JIT).
+            MatMul.GemvI2_S(hotWeights, x, result, m, k, scale, null);
+            MatMul.BenchUnpackRowI8Only(hotWeights, m, k);
+            MatMul.BenchStreamingReadOnly(hotWeights, m, k);
+
+            double hotStreamMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.BenchStreamingReadOnly(hotWeights, m, k);
+            }, iters);
+
+            double coldStreamMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.BenchStreamingReadOnly(coldWeights[i % ColdBufferCount], m, k);
+            }, iters);
+
+            double unpackMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.BenchUnpackRowI8Only(hotWeights, m, k);
+            }, iters);
+
+            double decodeMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.GemvI2_S(hotWeights, x, result, m, k, scale, null);
+            }, iters);
+
+            double hotStreamGBs = GBs(weightBytes, hotStreamMs);
+            double coldStreamGBs = GBs(weightBytes, coldStreamMs);
+            double decodeGBs = GBs(weightBytes, decodeMs);
+
+            _output.WriteLine($"[{label}] m={m} k={k} weightBytes={weightBytes} " +
+                               $"AVX2={System.Runtime.Intrinsics.X86.Avx2.IsSupported} " +
+                               $"AvxVnni={System.Runtime.Intrinsics.X86.AvxVnni.IsSupported}");
+            _output.WriteLine($"  hot streaming-only:  {hotStreamMs:F4} ms/call   {hotStreamGBs:F2} GB/s   (cache-resident ceiling)");
+            _output.WriteLine($"  cold streaming-only: {coldStreamMs:F4} ms/call   {coldStreamGBs:F2} GB/s   (DRAM-forced ceiling)");
+            _output.WriteLine($"  unpack-only:         {unpackMs:F4} ms/call");
+            _output.WriteLine($"  full GemvI2_S decode:{decodeMs:F4} ms/call   {decodeGBs:F2} GB/s");
+            _output.WriteLine($"  decode / hot-ceiling ratio:  {decodeGBs / hotStreamGBs:P1}");
+            _output.WriteLine($"  decode / cold-ceiling ratio: {decodeGBs / coldStreamGBs:P1}");
+        }
+        finally
+        {
+            NativeMemory.Free(hotWeights);
+            foreach (byte* p in coldWeights)
+                if (p is not null) NativeMemory.Free(p);
+            NativeMemory.Free(x);
+            NativeMemory.Free(result);
+        }
+    }
+
+    private static double Time(Action body, int iters)
+    {
+        var sw = Stopwatch.StartNew();
+        body();
+        sw.Stop();
+        return sw.Elapsed.TotalMilliseconds / iters;
+    }
+
+    private static double GBs(long bytes, double ms) => bytes / (ms / 1000.0) / 1e9;
+}
+```
+
+- [ ] **Step 2: Run it to verify it compiles and executes**
+
+Run: `dotnet test tests/DotLLM.Tests.Unit --filter "FullyQualifiedName~I2SDecodeBandwidthProfileBench" --logger "console;verbosity=detailed"`
+Expected: PASS (3 theory cases, one per shape) — this is a profiling harness, not a correctness assertion, so "pass" just means it ran to completion without exceptions. Confirm the printed output shows plausible non-zero GB/s numbers for all three shapes and all four measurements.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs
+git commit -m "bench(cpu/i2s): profile GEMV decode vs hot/cold streaming bandwidth ceiling"
+```
+
+---
+
+### Task 3: Run the profiling test on this box and record results
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md`
+
+**Interfaces:**
+- Consumes: printed `ITestOutputHelper` output from Task 2's test run.
+- Produces: the go/no-go verdict that Task 4 acts on.
+
+- [ ] **Step 1: Run the profiling test in Release with output captured**
+
+Run: `dotnet test tests/DotLLM.Tests.Unit -c Release --filter "FullyQualifiedName~I2SDecodeBandwidthProfileBench" --logger "console;verbosity=detailed" > /tmp/i2s-bandwidth-results.txt 2>&1`
+
+(Use the project's scratchpad path instead of `/tmp` if running on Windows PowerShell — redirect to a file under the session scratchpad directory.)
+
+Release build matters here — Debug JIT will understate the SIMD paths.
+
+- [ ] **Step 2: Extract the three shapes' numbers into a results table**
+
+Write `docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md`:
+
+```markdown
+# I2_S Decode Bandwidth Profiling — Results
+
+Ran on: Strix Halo (Ryzen AI Max 395, Zen5, AVX2+AVX-512+VNNI), .NET 10, Release build,
+`dotnet test tests/DotLLM.Tests.Unit -c Release --filter "FullyQualifiedName~I2SDecodeBandwidthProfileBench"`.
+
+| Shape | Hot ceiling (GB/s) | Cold/DRAM ceiling (GB/s) | Full decode (GB/s) | decode/hot | decode/cold |
+|---|---|---|---|---|---|
+| attn_qproj (2560×2560) | <fill from run> | <fill from run> | <fill from run> | <fill from run> | <fill from run> |
+| ffn_gate (6912×2560) | <fill from run> | <fill from run> | <fill from run> | <fill from run> | <fill from run> |
+| ffn_down (2560×6912) | <fill from run> | <fill from run> | <fill from run> | <fill from run> | <fill from run> |
+
+## Verdict
+
+<Write one paragraph: is decode close to either ceiling (bandwidth-bound) or well under both
+(compute-bound, headroom for the LUT kernel)? State which follow-up issue to file per the design
+doc's decision rule.>
+```
+
+Fill in the actual numbers from the Task 3 Step 1 output — no placeholders left in the committed file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
+git commit -m "docs: record I2_S decode bandwidth profiling results and verdict"
+```
+
+---
+
+### Task 4: Close the loop upstream and file the follow-up issue (requires user go-ahead)
+
+This task performs actions visible to others (posting to a GitHub issue not owned by this repo,
+filing a new issue) — confirm with the user before running these steps; do not execute
+automatically even if Tasks 1-3 were run non-interactively.
+
+**Files:** none (GitHub actions only).
+
+- [ ] **Step 1: Post the results table to upstream issue #334**
+
+`gh issue comment 334 --repo kkokosa/dotLLM --body "<results table + one-paragraph verdict from Task 3>"`
+
+- [ ] **Step 2: File the follow-up issue on the fork per the verdict**
+
+If bandwidth-bound → file "Packing density improvements for I2_S BitNet weights" (fallback per
+shifulegend's advice in #334).
+If headroom exists → file "AVX-512 activation-LUT dot kernel for I2_S GEMV decode", referencing
+shifulegend's N/K-groups-axis = our M/output-rows-axis mapping from their 2026-07-18 comment, and
+noting the `dev-dotnet11` preview-track question is moot here since `Avx512BW`/`Avx512F` are
+already mainstream-shipping intrinsics.
+
+`gh issue create --repo jamesburton/dotLLM --title "<title per verdict>" --body "<scoped acceptance criteria, referencing this profiling issue/PR and the RESULTS.md table>"`
+
+- [ ] **Step 3: Open the PR for this profiling work**
+
+`gh pr create --repo jamesburton/dotLLM --title "bench(cpu/i2s): profile GEMV decode bandwidth vs compute" --body "Closes #{N} (Task 0). Results: docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md"`
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** the design's three probes (streaming ceiling, full decode, ratio) are covered by Task 2; the design's "commit as reusable benchmark" intent is satisfied by the profiling test being a checked-in file (deviated to the xUnit/Stopwatch style already used for this exact scenario in `I2SUnpackProfileBench.cs`, per "follow existing patterns"); the design's "post to #334 + file follow-up" output step is Task 4.
+- **Placeholder scan:** the only bracketed placeholders left are inside the RESULTS.md template in Task 3 Step 2, which Task 3 Step 2 itself instructs to fill in before committing — no placeholders remain in any task's *committed* deliverable.
+- **Type consistency:** `MatMul.BenchStreamingReadOnly(byte*, int, int)` (Task 1) is the exact signature Task 2's test calls; `MatMul.GemvI2_S(byte*, float*, float*, int, int, float, ComputeThreadPool?)` is the existing explicit-scale overload (confirmed in `src/DotLLM.Cpu/Kernels/MatMul.I2S.cs:128`), used instead of the tail-scale-reading overload so the synthetic buffer doesn't need a trailing scale float appended.

--- a/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
+++ b/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
@@ -46,9 +46,10 @@ and **4.2%–4.6% of the DRAM-forced (cold) streaming-read ceiling** across all 
 — decode is well under *both* ceilings, not close to either, so on this box the kernel is
 **compute-bound, not memory-bandwidth-bound**: there is roughly 20-60× of unused bandwidth headroom
 between what the raw bytes-in-flight could sustain and what the full unpack+dot decode actually
-achieves. `unpack-only` time (0.43–0.73 ms) is itself already a large fraction of total decode time
-(1.48–3.85 ms) — 29%–35% — confirming the 2-bit-unpack/dot arithmetic, not the memory access
-pattern, is the limiting factor. Note the cold-ceiling column here (24–27 GB/s) is noticeably higher
+achieves. `unpack-only` time (0.43–0.73 ms) is itself already a non-trivial fraction of total decode
+time (1.48–3.85 ms) — 13.1%–29.2% across the three shapes (attn_qproj 0.4338/1.4835=29.2%,
+ffn_down 0.4884/3.7321=13.1%, ffn_gate 0.7263/3.8532=18.8%) — corroborating that the 2-bit-unpack/dot
+arithmetic, not the memory access pattern, is the limiting factor. Note the cold-ceiling column here (24–27 GB/s) is noticeably higher
 and more uniform across shapes than the Task 2 reference run (which saw 2.86–3.11 GB/s cold for the
 two larger, 4.4 MB-weight shapes) — this run-to-run swing is itself an illustration of the design
 doc's caveat that the round-robined cold buffer probe is sensitive to TLB/page-walk and

--- a/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
+++ b/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
@@ -1,15 +1,29 @@
 # I2_S Decode Bandwidth Profiling — Results
 
-Ran on: Strix Halo (Ryzen AI Max 395, Zen5, AVX2+AVX-512+VNNI), .NET 10, Release build,
+Ran on: Strix Halo (Ryzen AI Max 395, Zen5, AVX2+AvxVnni confirmed by this harness's own probe;
+AVX-512 is present on this box but was not probed/exercised by this harness — see note below),
+.NET 10, Release build,
 `dotnet test tests/DotLLM.Tests.Unit -c Release --filter "FullyQualifiedName~I2SDecodeBandwidthProfileBench"`.
 
 All 3 test cases passed (`Total tests: 3, Passed: 3`).
+
+Note: the streaming-ceiling probe (`BenchStreamingReadOnly`) itself only uses AVX2 vectorization
+(not AVX-512, despite the design spec originally suggesting AVX-512). This is a conservative
+choice for the compute-bound conclusion below — a wider (AVX-512) probe could only report a
+*higher* achievable-bandwidth ceiling, which would only widen the existing 20-60× headroom gap
+and strengthen, not weaken, the compute-bound verdict.
 
 | Shape | Hot ceiling (GB/s) | Cold/DRAM ceiling (GB/s) | Full decode (GB/s) | decode/hot | decode/cold |
 |---|---|---|---|---|---|
 | attn_qproj (2560×2560) | 38.98 | 24.07 | 1.10 | 2.8% | 4.6% |
 | ffn_gate (6912×2560) | 56.59 | 27.07 | 1.15 | 2.0% | 4.2% |
 | ffn_down (2560×6912) | 67.87 | 26.55 | 1.19 | 1.7% | 4.5% |
+
+The "decode/cold" column is not an apples-to-apples comparison: hot-buffer decode was never
+measured against the cold/DRAM-forced buffers directly (decode only ran against `hotWeights`).
+Read it as a lower-bound argument instead — if hot-buffer decode is only ~4-5% of even the
+pessimistic cold ceiling, memory bandwidth cannot be the limiter under any plausible residency
+assumption. The "decode/hot" column is the true apples-to-apples ratio and the more direct signal.
 
 Raw output per shape:
 
@@ -22,14 +36,6 @@ Raw output per shape:
   decode / hot-ceiling ratio:  2.8%
   decode / cold-ceiling ratio: 4.6%
 
-[ffn_down] m=2560 k=6912 weightBytes=4423680 AVX2=True AvxVnni=True
-  hot streaming-only:  0.0652 ms/call   67.87 GB/s   (cache-resident ceiling)
-  cold streaming-only: 0.1666 ms/call   26.55 GB/s   (DRAM-forced ceiling)
-  unpack-only:         0.4884 ms/call
-  full GemvI2_S decode:3.7321 ms/call   1.19 GB/s
-  decode / hot-ceiling ratio:  1.7%
-  decode / cold-ceiling ratio: 4.5%
-
 [ffn_gate] m=6912 k=2560 weightBytes=4423680 AVX2=True AvxVnni=True
   hot streaming-only:  0.0782 ms/call   56.59 GB/s   (cache-resident ceiling)
   cold streaming-only: 0.1634 ms/call   27.07 GB/s   (DRAM-forced ceiling)
@@ -37,6 +43,14 @@ Raw output per shape:
   full GemvI2_S decode:3.8532 ms/call   1.15 GB/s
   decode / hot-ceiling ratio:  2.0%
   decode / cold-ceiling ratio: 4.2%
+
+[ffn_down] m=2560 k=6912 weightBytes=4423680 AVX2=True AvxVnni=True
+  hot streaming-only:  0.0652 ms/call   67.87 GB/s   (cache-resident ceiling)
+  cold streaming-only: 0.1666 ms/call   26.55 GB/s   (DRAM-forced ceiling)
+  unpack-only:         0.4884 ms/call
+  full GemvI2_S decode:3.7321 ms/call   1.19 GB/s
+  decode / hot-ceiling ratio:  1.7%
+  decode / cold-ceiling ratio: 4.5%
 ```
 
 ## Verdict
@@ -49,8 +63,13 @@ between what the raw bytes-in-flight could sustain and what the full unpack+dot 
 achieves. `unpack-only` time (0.43–0.73 ms) is itself already a non-trivial fraction of total decode
 time (1.48–3.85 ms) — 13.1%–29.2% across the three shapes (attn_qproj 0.4338/1.4835=29.2%,
 ffn_down 0.4884/3.7321=13.1%, ffn_gate 0.7263/3.8532=18.8%) — corroborating that the 2-bit-unpack/dot
-arithmetic, not the memory access pattern, is the limiting factor. Note the cold-ceiling column here (24–27 GB/s) is noticeably higher
-and more uniform across shapes than the Task 2 reference run (which saw 2.86–3.11 GB/s cold for the
+arithmetic, not the memory access pattern, is the limiting factor. By subtraction, the remaining
+71–87% of full decode time (100% minus the 13.1%–29.2% unpack share) is spent in the dot-product
+routine (`VecDotI2SQ8`-style code in `src/DotLLM.Cpu/Kernels/MatMul.I2S.cs`) — precisely the routine
+the proposed AVX-512 activation-LUT kernel would replace, which is a more direct justification for
+that follow-up than the bandwidth-headroom argument alone, though it strengthens rather than
+replaces that argument. Note the cold-ceiling column here (24–27 GB/s) is noticeably higher
+and more uniform across shapes than an earlier run of the same harness (which saw 2.86–3.11 GB/s cold for the
 two larger, 4.4 MB-weight shapes) — this run-to-run swing is itself an illustration of the design
 doc's caveat that the round-robined cold buffer probe is sensitive to TLB/page-walk and
 system-memory-contention effects on this UMA box (a known source of ~40% bandwidth measurement

--- a/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
+++ b/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md
@@ -1,0 +1,61 @@
+# I2_S Decode Bandwidth Profiling — Results
+
+Ran on: Strix Halo (Ryzen AI Max 395, Zen5, AVX2+AVX-512+VNNI), .NET 10, Release build,
+`dotnet test tests/DotLLM.Tests.Unit -c Release --filter "FullyQualifiedName~I2SDecodeBandwidthProfileBench"`.
+
+All 3 test cases passed (`Total tests: 3, Passed: 3`).
+
+| Shape | Hot ceiling (GB/s) | Cold/DRAM ceiling (GB/s) | Full decode (GB/s) | decode/hot | decode/cold |
+|---|---|---|---|---|---|
+| attn_qproj (2560×2560) | 38.98 | 24.07 | 1.10 | 2.8% | 4.6% |
+| ffn_gate (6912×2560) | 56.59 | 27.07 | 1.15 | 2.0% | 4.2% |
+| ffn_down (2560×6912) | 67.87 | 26.55 | 1.19 | 1.7% | 4.5% |
+
+Raw output per shape:
+
+```
+[attn_qproj] m=2560 k=2560 weightBytes=1638400 AVX2=True AvxVnni=True
+  hot streaming-only:  0.0420 ms/call   38.98 GB/s   (cache-resident ceiling)
+  cold streaming-only: 0.0681 ms/call   24.07 GB/s   (DRAM-forced ceiling)
+  unpack-only:         0.4338 ms/call
+  full GemvI2_S decode:1.4835 ms/call   1.10 GB/s
+  decode / hot-ceiling ratio:  2.8%
+  decode / cold-ceiling ratio: 4.6%
+
+[ffn_down] m=2560 k=6912 weightBytes=4423680 AVX2=True AvxVnni=True
+  hot streaming-only:  0.0652 ms/call   67.87 GB/s   (cache-resident ceiling)
+  cold streaming-only: 0.1666 ms/call   26.55 GB/s   (DRAM-forced ceiling)
+  unpack-only:         0.4884 ms/call
+  full GemvI2_S decode:3.7321 ms/call   1.19 GB/s
+  decode / hot-ceiling ratio:  1.7%
+  decode / cold-ceiling ratio: 4.5%
+
+[ffn_gate] m=6912 k=2560 weightBytes=4423680 AVX2=True AvxVnni=True
+  hot streaming-only:  0.0782 ms/call   56.59 GB/s   (cache-resident ceiling)
+  cold streaming-only: 0.1634 ms/call   27.07 GB/s   (DRAM-forced ceiling)
+  unpack-only:         0.7263 ms/call
+  full GemvI2_S decode:3.8532 ms/call   1.15 GB/s
+  decode / hot-ceiling ratio:  2.0%
+  decode / cold-ceiling ratio: 4.2%
+```
+
+## Verdict
+
+Full `GemvI2_S` decode uses only **1.7%–2.8% of the cache-resident (hot) streaming-read ceiling**
+and **4.2%–4.6% of the DRAM-forced (cold) streaming-read ceiling** across all three probed shapes
+— decode is well under *both* ceilings, not close to either, so on this box the kernel is
+**compute-bound, not memory-bandwidth-bound**: there is roughly 20-60× of unused bandwidth headroom
+between what the raw bytes-in-flight could sustain and what the full unpack+dot decode actually
+achieves. `unpack-only` time (0.43–0.73 ms) is itself already a large fraction of total decode time
+(1.48–3.85 ms) — 29%–35% — confirming the 2-bit-unpack/dot arithmetic, not the memory access
+pattern, is the limiting factor. Note the cold-ceiling column here (24–27 GB/s) is noticeably higher
+and more uniform across shapes than the Task 2 reference run (which saw 2.86–3.11 GB/s cold for the
+two larger, 4.4 MB-weight shapes) — this run-to-run swing is itself an illustration of the design
+doc's caveat that the round-robined cold buffer probe is sensitive to TLB/page-walk and
+system-memory-contention effects on this UMA box (a known source of ~40% bandwidth measurement
+swings here) rather than a clean, reproducible DRAM bandwidth figure; it should not be read as a
+precise ceiling in either run. The hot-ceiling ratio is the more stable and trustworthy signal, and
+by that measure the conclusion is unambiguous regardless of cold-column noise. Per the design doc's
+decision rule, this points to proceeding with the **AVX-512 activation-LUT dot kernel** as the
+follow-up issue — not a pivot to packing-density work — since the bottleneck is arithmetic
+throughput in the unpack+dot path, not bytes moved from memory.

--- a/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-design.md
+++ b/docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-design.md
@@ -1,0 +1,90 @@
+# Spec — CPU BitNet (I2_S) GEMV decode: bandwidth-vs-compute profiling
+
+**Status**: Approved (2026-07-27). Ready for plan generation.
+**Owner**: dev branch, CPU backend (`src/DotLLM.Cpu/Kernels/MatMul.I2S.cs`).
+**Phasing**: single small plan, single PR.
+
+## Goal
+
+Determine whether `GemvI2_S`'s decode path (single-token GEMV: `UnpackRowI8` + int8 VPDPBUSD dot),
+after the #128 unpack-SIMD-vectorization fix already merged to `dev`, is now DRAM-bandwidth-bound
+or still compute-bound on this Strix Halo box. This is a go/no-go gate for the AVX-512
+activation-LUT dot-kernel optimization suggested upstream (issue #334, external contributor
+`shifulegend`): if decode is already near the achievable memory-bandwidth ceiling for this access
+pattern, a faster dot product would only convert to a modest end-to-end gain (their own BitNet
+port saw 6-10% real tok/s from a 3.6x kernel speedup once bandwidth-bound); if decode is well
+under the ceiling, the LUT kernel should convert its raw speedup more directly.
+
+No new production code ships from this spec — it produces a measurement and a documented verdict
+that decides the next issue (LUT kernel, or pivot to packing-density work).
+
+## Non-goals
+
+- Building the AVX-512 activation-LUT kernel itself — that's a follow-up issue, gated on this
+  result.
+- Prefill/GEMM path (`GemmI2_SW2A8Rows`) — unpack cost amortizes there already (#131 finding);
+  this spec is decode/GEMV-only, where unpack was previously found unpack-bound.
+- GPU (Vulkan/CUDA) BitNet paths — CPU only.
+- Merging `dev-dotnet11` (`AvxVnni.V512`/`Avx512Bf16`) — not needed here; `Avx512BW`/`Avx512F`
+  used for the streaming-ceiling probe are already mainstream-shipping intrinsics available on
+  `dev`. Only revisit the preview-track merge if this profiling motivates a kernel that genuinely
+  needs the unmerged VNNI-512/BF16 ops.
+
+## Approach
+
+Reuse the existing profiling hooks from #128/#131 (`BenchUnpackRowI8Only`, public forwarder in
+`src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs`) plus the public `GemvI2_S` entry point, and add one
+new probe: a **pure streaming-read kernel** over the same packed I2_S weight buffers (no unpack,
+no dot — just touch every byte) to measure the empirical achievable bandwidth ceiling for this
+exact access pattern (sequential 2-bit-packed byte reads) on this box, independent of compute.
+
+This isolates three numbers per shape:
+1. Streaming-only GB/s (the ceiling for this access pattern)
+2. Full `GemvI2_S` decode GB/s (bytes of packed weight moved ÷ wall time)
+3. Ratio of (2)/(1) — how close current decode already is to that ceiling
+
+Unlike #131's throwaway "vendored copies in a standalone bench", this profiling harness is
+committed to the repo as a normal BenchmarkDotNet benchmark class, since it's reusable —
+future kernel changes (the LUT dot, packing-density changes) get the same before/after comparison
+for free.
+
+### Shapes
+
+Same three shapes used in #131 for continuity with prior data: `attn_qproj` (2560×2560),
+`ffn_gate` (6912×2560), `ffn_down` (2560×6912). Single-thread, matching #131's methodology (the
+existing multi-thread dispatch in `GemvI2_SCore`/`GemvI2_SWorker` is orthogonal to this
+bandwidth question and would confound the per-core-bandwidth reading).
+
+### What gets added
+
+| File | Change |
+|---|---|
+| `benchmarks/DotLLM.Benchmarks/I2SDecodeBandwidthBenchmarks.cs` | New BenchmarkDotNet class: `[Benchmark] StreamingOnly()`, `[Benchmark] UnpackOnly()` (via `BenchUnpackRowI8Only`), `[Benchmark] FullGemvDecode()` (via `GemvI2_S`), parameterized over the three shapes. Reports ns/row and derived GB/s via a custom column (reuse pattern from `Columns/DecodeTokPerSecColumn.cs`). |
+| `src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs` | Add `BenchStreamingReadOnly(byte* weights, int m, int k)` — touches every packed byte (XOR-accumulate into a discarded local to prevent dead-code elimination) with no unpack/decode, single pass, same loop shape as `BenchUnpackRowI8Only` for a fair comparison. |
+
+No changes to production kernels (`MatMul.I2S.cs`) — this is measurement-only.
+
+## Error handling / edge cases
+
+Not applicable — benchmark-only code, not a hot-path or user-facing change. Standard
+`ArrayPool` rent/return in the new bench helper, mirroring the existing `BenchUnpackRowI8Only`
+pattern.
+
+## Testing
+
+No new correctness tests needed (no new production logic). The benchmark class itself is
+exercised by running it, not by the unit-test suite. Verification is running
+`dotnet run -c Release --project benchmarks/DotLLM.Benchmarks -- --filter *I2SDecodeBandwidth*`
+on this box and recording the three shapes' numbers.
+
+## Output / next step
+
+Post the resulting table (streaming-ceiling GB/s, full-decode GB/s, ratio) as a comment on
+upstream issue #334, closing the loop with `shifulegend`. Then file a follow-up issue:
+- if full-decode GB/s is well under the streaming ceiling (headroom exists): "AVX-512
+  activation-LUT dot kernel for I2_S GEMV decode", scoped per shifulegend's suggested mapping
+  (their N/K-groups axis = our M/output-rows axis, LUT built once per token and amortized across
+  M rows).
+- if full-decode GB/s is already close to the streaming ceiling (bandwidth-bound): pivot the
+  follow-up issue to packing-density work instead (per shifulegend's fallback advice), scoped
+  separately since it's a different code path (weight format, not just the decode kernel).

--- a/src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs
+++ b/src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs
@@ -1,4 +1,7 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 namespace DotLLM.Cpu.Kernels;
 
@@ -39,4 +42,36 @@ public static unsafe partial class MatMul
     /// unreachable on AVX2 hardware.
     /// </summary>
     public static void UnpackRowI8Public(byte* rowPtr, sbyte* dest, int k) => UnpackRowI8(rowPtr, dest, k);
+
+    /// <summary>
+    /// Reads every packed byte a full <see cref="GemvI2_S(byte*, float*, float*, int, int, DotLLM.Cpu.Threading.ComputeThreadPool?)"/>
+    /// call would touch (<c>m·k/4</c> bytes), doing no unpack/decode — an empirical
+    /// achievable-bandwidth probe for this exact access pattern. Returns an XOR checksum so the
+    /// JIT cannot eliminate the reads as dead code.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static byte BenchStreamingReadOnly(byte* weights, int m, int k)
+    {
+        long totalBytes = (long)m * (k / 4);
+        Vector256<byte> acc = Vector256<byte>.Zero;
+        long i = 0;
+
+        if (Avx2.IsSupported)
+        {
+            long vecEnd = totalBytes - (totalBytes % 32);
+            for (; i < vecEnd; i += 32)
+                acc ^= Unsafe.ReadUnaligned<Vector256<byte>>(weights + i);
+        }
+
+        Span<byte> lanes = stackalloc byte[32];
+        acc.CopyTo(lanes);
+        byte result = 0;
+        foreach (byte lane in lanes) result ^= lane;
+
+        for (; i < totalBytes; i++)
+            result ^= weights[i];
+
+        return result;
+    }
 }

--- a/src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs
+++ b/src/DotLLM.Cpu/Kernels/MatMul.I2S.Bench.cs
@@ -6,11 +6,14 @@ using System.Runtime.Intrinsics.X86;
 namespace DotLLM.Cpu.Kernels;
 
 /// <summary>
-/// Profiling-only passthrough for issue #128 (vectorize I2_S UnpackRowI8). Exposes the otherwise-
-/// private scalar/AVX2 unpack loop so a benchmark harness can measure its standalone cost vs the
-/// full GEMV call, and so tests can force-compare the scalar and vectorized code paths directly
-/// regardless of which one <see cref="MatMul.GemvI2_S(byte*, float*, float*, int, int, DotLLM.Cpu.Threading.ComputeThreadPool?)"/>
-/// would pick at runtime.
+/// Profiling-only passthroughs used by two investigations: issue #128 (vectorize I2_S
+/// UnpackRowI8) exposes the otherwise-private scalar/AVX2 unpack loop so a benchmark harness can
+/// measure its standalone cost vs the full GEMV call, and so tests can force-compare the scalar
+/// and vectorized code paths directly regardless of which one
+/// <see cref="MatMul.GemvI2_S(byte*, float*, float*, int, int, DotLLM.Cpu.Threading.ComputeThreadPool?)"/>
+/// would pick at runtime; issue #196 (decode bandwidth profiling) adds
+/// <see cref="BenchStreamingReadOnly"/>, an achievable-bandwidth probe used to determine whether
+/// I2_S decode is memory-bandwidth-bound or compute-bound.
 /// </summary>
 public static unsafe partial class MatMul
 {

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs
@@ -7,11 +7,15 @@ using Xunit.Abstractions;
 namespace DotLLM.Tests.Unit.Cpu.Kernels;
 
 /// <summary>
-/// TEMPORARY profiling harness — measures whether I2_S GEMV decode (post-#128 unpack-SIMD fix) is
+/// Retained profiling harness — measures whether I2_S GEMV decode (post-#128 unpack-SIMD fix) is
 /// memory-bandwidth-bound or still compute-bound on this box, gating the AVX-512 activation-LUT
 /// dot kernel proposed upstream in issue #334. Not a correctness test; prints wall-clock numbers
-/// via test output. Delete once the go/no-go verdict is recorded.
+/// via test output. The recorded baseline verdict lives in
+/// <c>docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md</c>; this class is kept
+/// (rather than deleted) as the before/after comparison harness for the AVX-512 activation-LUT
+/// kernel that investigation recommends as the follow-up.
 /// </summary>
+[Trait("Category", "Benchmark")]
 public sealed unsafe class I2SDecodeBandwidthProfileBench
 {
     private readonly ITestOutputHelper _output;

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SDecodeBandwidthProfileBench.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using DotLLM.Cpu.Kernels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotLLM.Tests.Unit.Cpu.Kernels;
+
+/// <summary>
+/// TEMPORARY profiling harness — measures whether I2_S GEMV decode (post-#128 unpack-SIMD fix) is
+/// memory-bandwidth-bound or still compute-bound on this box, gating the AVX-512 activation-LUT
+/// dot kernel proposed upstream in issue #334. Not a correctness test; prints wall-clock numbers
+/// via test output. Delete once the go/no-go verdict is recorded.
+/// </summary>
+public sealed unsafe class I2SDecodeBandwidthProfileBench
+{
+    private readonly ITestOutputHelper _output;
+
+    public I2SDecodeBandwidthProfileBench(ITestOutputHelper output) => _output = output;
+
+    /// <summary>Number of distinct weight-buffer copies for the "cold" (>L3) measurement.</summary>
+    private const int ColdBufferCount = 32;
+
+    [Theory]
+    [InlineData(2560, 2560, "attn_qproj")]
+    [InlineData(6912, 2560, "ffn_gate")]
+    [InlineData(2560, 6912, "ffn_down")]
+    public void ProfileGemvI2SDecode_BandwidthVsCompute(int m, int k, string label)
+    {
+        var rng = new Random(42);
+        int rowBytes = k / 4;
+        long weightBytes = (long)m * rowBytes;
+        const float scale = 0.02f;
+
+        // Hot buffer: single allocation, reused every iteration (matches #131's methodology and a
+        // resident weight tensor reused across consecutive decode steps).
+        byte* hotWeights = (byte*)NativeMemory.AllocZeroed((nuint)weightBytes);
+
+        // Cold buffers: enough distinct copies to exceed typical L3, round-robined across
+        // iterations so each touch is a fresh cache line from DRAM.
+        byte*[] coldWeights = new byte*[ColdBufferCount];
+
+        float* x = (float*)NativeMemory.AllocZeroed((nuint)(k * sizeof(float)));
+        float* result = (float*)NativeMemory.AllocZeroed((nuint)(m * sizeof(float)));
+
+        try
+        {
+            byte[] randRow = new byte[weightBytes];
+            rng.NextBytes(randRow);
+            Marshal.Copy(randRow, 0, (nint)hotWeights, (int)weightBytes);
+
+            for (int c = 0; c < ColdBufferCount; c++)
+            {
+                coldWeights[c] = (byte*)NativeMemory.AllocZeroed((nuint)weightBytes);
+                rng.NextBytes(randRow);
+                Marshal.Copy(randRow, 0, (nint)coldWeights[c], (int)weightBytes);
+            }
+
+            for (int i = 0; i < k; i++) x[i] = rng.NextSingle() * 2f - 1f;
+
+            const int iters = 20;
+
+            // Warm up (JIT).
+            MatMul.GemvI2_S(hotWeights, x, result, m, k, scale, null);
+            MatMul.BenchUnpackRowI8Only(hotWeights, m, k);
+            MatMul.BenchStreamingReadOnly(hotWeights, m, k);
+
+            double hotStreamMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.BenchStreamingReadOnly(hotWeights, m, k);
+            }, iters);
+
+            double coldStreamMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.BenchStreamingReadOnly(coldWeights[i % ColdBufferCount], m, k);
+            }, iters);
+
+            double unpackMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.BenchUnpackRowI8Only(hotWeights, m, k);
+            }, iters);
+
+            double decodeMs = Time(() =>
+            {
+                for (int i = 0; i < iters; i++)
+                    MatMul.GemvI2_S(hotWeights, x, result, m, k, scale, null);
+            }, iters);
+
+            double hotStreamGBs = GBs(weightBytes, hotStreamMs);
+            double coldStreamGBs = GBs(weightBytes, coldStreamMs);
+            double decodeGBs = GBs(weightBytes, decodeMs);
+
+            _output.WriteLine($"[{label}] m={m} k={k} weightBytes={weightBytes} " +
+                               $"AVX2={System.Runtime.Intrinsics.X86.Avx2.IsSupported} " +
+                               $"AvxVnni={System.Runtime.Intrinsics.X86.AvxVnni.IsSupported}");
+            _output.WriteLine($"  hot streaming-only:  {hotStreamMs:F4} ms/call   {hotStreamGBs:F2} GB/s   (cache-resident ceiling)");
+            _output.WriteLine($"  cold streaming-only: {coldStreamMs:F4} ms/call   {coldStreamGBs:F2} GB/s   (DRAM-forced ceiling)");
+            _output.WriteLine($"  unpack-only:         {unpackMs:F4} ms/call");
+            _output.WriteLine($"  full GemvI2_S decode:{decodeMs:F4} ms/call   {decodeGBs:F2} GB/s");
+            _output.WriteLine($"  decode / hot-ceiling ratio:  {decodeGBs / hotStreamGBs:P1}");
+            _output.WriteLine($"  decode / cold-ceiling ratio: {decodeGBs / coldStreamGBs:P1}");
+        }
+        finally
+        {
+            NativeMemory.Free(hotWeights);
+            foreach (byte* p in coldWeights)
+                if (p is not null) NativeMemory.Free(p);
+            NativeMemory.Free(x);
+            NativeMemory.Free(result);
+        }
+    }
+
+    private static double Time(Action body, int iters)
+    {
+        var sw = Stopwatch.StartNew();
+        body();
+        sw.Stop();
+        return sw.Elapsed.TotalMilliseconds / iters;
+    }
+
+    private static double GBs(long bytes, double ms) => bytes / (ms / 1000.0) / 1e9;
+}

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs
@@ -19,25 +19,6 @@ public sealed unsafe class I2SUnpackProfileBench
 
     public I2SUnpackProfileBench(ITestOutputHelper output) => _output = output;
 
-    [Fact]
-    public void BenchStreamingReadOnly_MatchesScalarChecksum()
-    {
-        var rng = new Random(7);
-        const int m = 64, k = 512;
-        int rowBytes = k / 4;
-        byte[] buf = new byte[m * rowBytes];
-        rng.NextBytes(buf);
-
-        byte expected = 0;
-        foreach (byte b in buf) expected ^= b;
-
-        fixed (byte* p = buf)
-        {
-            byte actual = MatMul.BenchStreamingReadOnly(p, m, k);
-            Assert.Equal(expected, actual);
-        }
-    }
-
     [Theory]
     [InlineData(6912, 2560, "ffn_down-like (BitNet 3B: m=ffn, k=hidden)")]
     [InlineData(2560, 6912, "ffn_up-like (BitNet 3B: m=hidden, k=ffn)")]

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackProfileBench.cs
@@ -19,6 +19,25 @@ public sealed unsafe class I2SUnpackProfileBench
 
     public I2SUnpackProfileBench(ITestOutputHelper output) => _output = output;
 
+    [Fact]
+    public void BenchStreamingReadOnly_MatchesScalarChecksum()
+    {
+        var rng = new Random(7);
+        const int m = 64, k = 512;
+        int rowBytes = k / 4;
+        byte[] buf = new byte[m * rowBytes];
+        rng.NextBytes(buf);
+
+        byte expected = 0;
+        foreach (byte b in buf) expected ^= b;
+
+        fixed (byte* p = buf)
+        {
+            byte actual = MatMul.BenchStreamingReadOnly(p, m, k);
+            Assert.Equal(expected, actual);
+        }
+    }
+
     [Theory]
     [InlineData(6912, 2560, "ffn_down-like (BitNet 3B: m=ffn, k=hidden)")]
     [InlineData(2560, 6912, "ffn_up-like (BitNet 3B: m=hidden, k=ffn)")]

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackVectorizedMatchesScalarTests.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2SUnpackVectorizedMatchesScalarTests.cs
@@ -16,6 +16,31 @@ namespace DotLLM.Tests.Unit.Cpu.Kernels;
 /// </summary>
 public sealed unsafe class I2SUnpackVectorizedMatchesScalarTests
 {
+    /// <summary>
+    /// Correctness coverage for <see cref="MatMul.BenchStreamingReadOnly"/> (the issue #196
+    /// decode-bandwidth-profiling read-only streaming probe): its XOR checksum over every packed
+    /// byte must match an independent scalar XOR reduction, across both the AVX2 vectorized
+    /// accumulation path and the scalar tail.
+    /// </summary>
+    [Fact]
+    public void BenchStreamingReadOnly_MatchesScalarChecksum()
+    {
+        var rng = new Random(7);
+        const int m = 64, k = 512;
+        int rowBytes = k / 4;
+        byte[] buf = new byte[m * rowBytes];
+        rng.NextBytes(buf);
+
+        byte expected = 0;
+        foreach (byte b in buf) expected ^= b;
+
+        fixed (byte* p = buf)
+        {
+            byte actual = MatMul.BenchStreamingReadOnly(p, m, k);
+            Assert.Equal(expected, actual);
+        }
+    }
+
     [Theory]
     [InlineData(128, 1)]     // single block
     [InlineData(128, 7)]


### PR DESCRIPTION
Closes #196.

## Summary
- Measures whether CPU BitNet I2_S GEMV decode (post-#128 unpack-SIMD fix) is memory-bandwidth-bound or compute-bound on Strix Halo, gating the AVX-512 activation-LUT dot kernel suggested upstream in kkokosa/dotLLM#334.
- Adds `MatMul.BenchStreamingReadOnly` (vectorized touch-every-byte probe, no unpack/decode) alongside the existing `BenchUnpackRowI8Only`.
- Adds a TEMPORARY-turned-retained profiling test (`I2SDecodeBandwidthProfileBench`, `Category=Benchmark`, excluded from CI) measuring hot/cold streaming ceilings vs unpack-only vs full decode across 3 shapes.
- Results + verdict: `docs/superpowers/specs/2026-07-27-bitnet-decode-bandwidth-RESULTS.md` — decode is **compute-bound** (1.7-2.8% of hot-ceiling bandwidth; 71-87% of decode time in the dot-product routine).

## Follow-up
- Verdict posted to kkokosa/dotLLM#334.
- Follow-up issue filed: #202 (AVX-512 activation-LUT dot kernel).

## Test plan
- [x] `I2SUnpackVectorizedMatchesScalarTests` (8/8, includes the relocated `BenchStreamingReadOnly` checksum test)
- [x] `I2SUnpackProfileBench` (2/2, unaffected by the test relocation)
- [x] `I2SDecodeBandwidthProfileBench` (3/3, Release, `Category=Benchmark` — excluded from CI, run manually)
- [x] No production kernel changes (`src/DotLLM.Cpu/Kernels/MatMul.I2S.cs` untouched)