### PR TITLE
fix(bitnet): support ragged (non-128-multiple) I2_S row lengths

### DIFF
--- a/docs/QUANTIZATION.md
+++ b/docs/QUANTIZATION.md
@@ -86,6 +86,32 @@ weights. CPU vec_dot pairs MXFP4 weights with Q8_0-quantized activations
 (nibble→sbyte pshufb LUT + integer MAC), mirroring llama.cpp's
 `ggml_vec_dot_mxfp4_q8_0`.
 
+### I2_S (BitNet b1.58 ternary, ~2 bits/weight, GGUF type 36)
+
+```
+Row-major W[m,k]: 4 ternary codes {0,1,2} → {-1,0,+1} packed per byte (2 bits each).
+128-element block = 32 bytes. Byte at group_pos (0..31) holds codes for elements
+{group_pos, +32, +64, +96} at bit offsets {6,4,2,0}.
+ONE per-tensor float32 scale at the tensor tail, byte offset m·k/4.
+Dequantize: val = (code - 1) * scale
+```
+
+**Ragged K (`k % 128 != 0`, issue #206).** Most I2_S GGUFs have every row length (`k`) an exact
+multiple of 128 (e.g. microsoft/bitnet-b1.58-2B-4T: 2560/6912). At least one real checkpoint family
+(1bitLLM-style `bitnet_b1_58-large`/`-xl`: hidden=2048, intermediate=5460, `5460 % 128 == 84`) has a
+genuinely non-128-aligned `ffn_down` row length. The critical subtlety, verified against the real
+GGUF's tensor byte offsets and against the upstream bitnet.cpp writer (`ggml-bitnet-mad.cpp`'s
+`quantize_i2_s`): **the 128-element block interleave is computed over the flattened `m·k` element
+stream, not reset at each row boundary.** So a ragged row generally does not start on a block
+boundary at all (only every `128/gcd(k,128)`-th row does) — a "tail cleanup after the fast path"
+approach would be wrong for most of a ragged tensor's rows, not just the last few elements. When `k`
+is a multiple of 128 this is moot: every row boundary is also a block boundary, so per-row
+block-reset addressing and the flattened-stream addressing are bit-identical (why the 128-aligned
+fast paths never noticed the distinction). dotLLM's ragged-K support (CPU: `MatMul.I2S.cs`'s
+`I2SRaggedCode`/`UnpackRowRagged`; CUDA: `i2_s_gemv_{f16,f32}in_ragged` / `dequant_i2_s_f16_ragged`
+in `native/kernels/`) is a scalar, correctness-first fallback reached only when `k % 128 != 0` — the
+aligned SIMD/uint4 fast paths are untouched.
+
 ## Kernel Types
 
 Each quantization format needs two kernels:

--- a/native/kernels/dequant_i2_s.cu
+++ b/native/kernels/dequant_i2_s.cu
@@ -62,3 +62,39 @@ extern "C" __global__ void __launch_bounds__(256) dequant_i2_s_f16(
         out_base[lane + 96] = __float2half((float)c3 * scale);
     }
 }
+
+// ───────────────────────── Ragged K (k % 128 != 0) — issue #206 ─────────────────────────
+//
+// `blocks_per_row = k/128` above is an integer division: for a ragged k it silently floors,
+// dropping each row's tail elements (dst would keep whatever garbage was already in the scratch
+// buffer for those columns — not just a crash, a silent correctness bug). The block-128 interleave
+// for a ragged tensor is also NOT reset per row (see i2_s_gemv.cu's issue #206 comment / the
+// bitnet.cpp reference `quantize_i2_s`): it is computed over the flattened n*k element stream, so
+// `dst[flat]` (== `dst[row*k+col]`, since flat is already exactly that) can be derived directly
+// from the flattened index without ever separating row/col. One thread per output element,
+// grid-stride over the whole tensor — simple and correct; this is an edge-case fallback for the
+// (rare) ragged prefill path, not the tuned hot loop.
+extern "C" __global__ void __launch_bounds__(256) dequant_i2_s_f16_ragged(
+    const uint8_t* __restrict__ weight,   // packed codes [n * k/4 bytes] + trailing f32 scale
+    half*          __restrict__ dst,      // [n * k] dense FP16, row-major
+    const int n,
+    const int k)
+{
+    const float scale = *reinterpret_cast<const float*>(weight + (size_t)n * (k / 4));
+    const long long total = (long long)n * (long long)k;
+
+    const long long idx0   = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    const long long stride = (long long)gridDim.x * blockDim.x;
+
+    for (long long flat = idx0; flat < total; flat += stride)
+    {
+        long long block = flat >> 7;              // flat / 128
+        int inBlock = (int)(flat & 127);          // flat % 128
+        int groupPos = inBlock & 31;
+        int groupIdx = inBlock >> 5;
+        uint8_t packed = weight[block * 32 + groupPos];
+        int shift = 6 - 2 * groupIdx;
+        int code = (packed >> shift) & 0x3;
+        dst[flat] = __float2half(((float)code - 1.0f) * scale);
+    }
+}

--- a/native/kernels/i2_s_gemv.cu
+++ b/native/kernels/i2_s_gemv.cu
@@ -9,6 +9,19 @@
 //     offset-binary {1,2,3}; the decode here subtracts 1.
 //   * ONE per-tensor float32 scale at the tensor tail, byte offset (size_t)n*(k/4).
 //
+// RAGGED K (issue #206): every kernel above this comment requires k % 128 == 0 — the uint4/block
+// addressing (row_bytes=k/4, num_u4=row_bytes/16) assumes it, and going in unaligned crashes with
+// "CUDA error 716: misaligned address". At least one real checkpoint family (1bitLLM-style
+// bitnet_b1_58-large/-xl: hidden=2048, intermediate=5460, 5460%128==84) has a genuinely
+// non-128-aligned ffn_down row length. Critically, the on-disk 128-element block interleave for a
+// ragged tensor is computed over the FLATTENED n*k element stream (matches the upstream
+// bitnet.cpp writer, ggml-bitnet-mad.cpp's quantize_i2_s — verified against the real GGUF's tensor
+// byte extents), NOT reset at each row boundary — so a ragged row generally does not even start on
+// a block boundary (see MatMul.I2S.cs's class remarks for the full derivation). The ragged kernels
+// below (i2_s_gemv_f16in_ragged / i2_s_gemv_f32in_ragged) are a scalar, correctness-first fallback
+// reached ONLY when the caller detects k % 128 != 0 (see CudaTransformerModel.Project /
+// HybridTransformerModel.ProjectGpu) — they never touch the aligned fast paths above.
+//
 // ───────────────────────── Occupancy / MLP optimization (v2: warp-per-row) ─────────────────────────
 // HISTORY. v1 used grid=(n,1,1)/block=(256,1,1) with ONE block per output row, each thread striding the
 // row's uint4 units. But a row is only k/4 bytes = k/64 uint4 units = 40 (k=2560) .. 108 (k=6912) units,
@@ -683,4 +696,87 @@ extern "C" __global__ void __launch_bounds__(256) i2_s_gemv_a8_device_scale(
     float acc = i2s_warp_reduce((float)iacc);
     if (lane == 0) y[row] = acc * scale * inv;
     }
+}
+
+// ───────────────────────── Ragged K (k % 128 != 0) — issue #206 ─────────────────────────
+//
+// One warp per output row; lanes stride over columns directly (no uint4/shared-block tricks —
+// those all assume k % 128 == 0). Per-element address is computed via the SAME tensor-global
+// block-128 interleave used by the CPU ragged path (MatMul.I2S.cs's I2SRaggedCode): for
+// flattened index `flat = row*k + col`, block = flat/128, byte = block*32 + (flat%32), and the
+// 2-bit code lives at bit offset 6-2*((flat%128)/32) within that byte. Correctness-first: no
+// coalescing tricks, no ILP widening — this is an edge-case fallback, not the hot path.
+__device__ __forceinline__ int i2s_ragged_code(const uint8_t* __restrict__ weight, long long flat)
+{
+    long long block = flat >> 7;              // flat / 128
+    int inBlock = (int)(flat & 127);          // flat % 128
+    int groupPos = inBlock & 31;              // byte within the 32-byte block
+    int groupIdx = inBlock >> 5;              // interleaved slot (0..3)
+    uint8_t packed = weight[block * 32 + groupPos];
+    int shift = 6 - 2 * groupIdx;
+    return (packed >> shift) & 0x3;
+}
+
+extern "C" __global__ void __launch_bounds__(256) i2_s_gemv_f16in_ragged(
+    const uint8_t* __restrict__ weight,   // packed codes [n * k/4 bytes] + trailing f32 scale
+    const half*    __restrict__ x,        // [k]
+    half*          __restrict__ y,        // [n]
+    const int n,
+    const int k)
+{
+    __shared__ float xs[I2S_MAX_K];
+    for (int i = threadIdx.x; i < k; i += blockDim.x)
+        xs[i] = __half2float(x[i]);
+    __syncthreads();
+
+    const int wid  = threadIdx.x >> 5;        // warp id within block (0..7), one row per warp
+    const int lane = threadIdx.x & 31;
+
+    const int row = blockIdx.x * 8 + wid;
+    if (row >= n) return;
+
+    const float scale = *reinterpret_cast<const float*>(weight + (size_t)n * (k / 4));
+    const long long rowStart = (long long)row * (long long)k;
+
+    float acc = 0.0f;
+    for (int col = lane; col < k; col += 32)
+    {
+        int code = i2s_ragged_code(weight, rowStart + col);
+        acc += ((float)code - 1.0f) * xs[col];
+    }
+
+    acc = i2s_warp_reduce(acc);
+    if (lane == 0) y[row] = __float2half(acc * scale);
+}
+
+extern "C" __global__ void __launch_bounds__(256) i2_s_gemv_f32in_ragged(
+    const uint8_t* __restrict__ weight,
+    const float*   __restrict__ x,
+    float*         __restrict__ y,
+    const int n,
+    const int k)
+{
+    __shared__ float xs[I2S_MAX_K];
+    for (int i = threadIdx.x; i < k; i += blockDim.x)
+        xs[i] = x[i];
+    __syncthreads();
+
+    const int wid  = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+
+    const int row = blockIdx.x * 8 + wid;
+    if (row >= n) return;
+
+    const float scale = *reinterpret_cast<const float*>(weight + (size_t)n * (k / 4));
+    const long long rowStart = (long long)row * (long long)k;
+
+    float acc = 0.0f;
+    for (int col = lane; col < k; col += 32)
+    {
+        int code = i2s_ragged_code(weight, rowStart + col);
+        acc += ((float)code - 1.0f) * xs[col];
+    }
+
+    acc = i2s_warp_reduce(acc);
+    if (lane == 0) y[row] = acc * scale;
 }

--- a/native/ptx/dequant_i2_s.ptx
+++ b/native/ptx/dequant_i2_s.ptx
@@ -128,4 +128,85 @@ $L__BB0_3:
 	ret;
 
 }
+	// .globl	dequant_i2_s_f16_ragged
+.visible .entry dequant_i2_s_f16_ragged(
+	.param .u64 dequant_i2_s_f16_ragged_param_0,
+	.param .u64 dequant_i2_s_f16_ragged_param_1,
+	.param .u32 dequant_i2_s_f16_ragged_param_2,
+	.param .u32 dequant_i2_s_f16_ragged_param_3
+)
+.maxntid 256, 1, 1
+{
+	.reg .pred 	%p<3>;
+	.reg .b16 	%rs<3>;
+	.reg .f32 	%f<5>;
+	.reg .b32 	%r<23>;
+	.reg .b64 	%rd<30>;
+
+
+	ld.param.u64 	%rd11, [dequant_i2_s_f16_ragged_param_0];
+	ld.param.u64 	%rd12, [dequant_i2_s_f16_ragged_param_1];
+	ld.param.u32 	%r2, [dequant_i2_s_f16_ragged_param_2];
+	ld.param.u32 	%r1, [dequant_i2_s_f16_ragged_param_3];
+	cvt.s64.s32 	%rd1, %r2;
+	cvt.s64.s32 	%rd2, %r1;
+	mul.wide.s32 	%rd13, %r1, %r2;
+	mov.u32 	%r3, %ctaid.x;
+	mov.u32 	%r4, %ntid.x;
+	cvt.u64.u32 	%rd3, %r4;
+	mul.wide.u32 	%rd14, %r3, %r4;
+	mov.u32 	%r5, %tid.x;
+	cvt.u64.u32 	%rd15, %r5;
+	add.s64 	%rd29, %rd14, %rd15;
+	setp.ge.s64 	%p1, %rd29, %rd13;
+	@%p1 bra 	$L__BB1_3;
+
+	shr.s32 	%r6, %r1, 31;
+	shr.u32 	%r7, %r6, 30;
+	add.s32 	%r8, %r1, %r7;
+	shr.s32 	%r9, %r8, 2;
+	cvt.s64.s32 	%rd17, %r9;
+	mul.lo.s64 	%rd18, %rd17, %rd1;
+	cvta.to.global.u64 	%rd5, %rd11;
+	add.s64 	%rd19, %rd5, %rd18;
+	ld.global.nc.f32 	%f1, [%rd19];
+	cvta.to.global.u64 	%rd6, %rd12;
+	mul.lo.s64 	%rd7, %rd2, %rd1;
+	mov.u32 	%r13, %nctaid.x;
+	cvt.u64.u32 	%rd22, %r13;
+	mul.lo.s64 	%rd8, %rd22, %rd3;
+
+$L__BB1_2:
+	cvt.u32.u64 	%r14, %rd29;
+	and.b32  	%r15, %r14, 96;
+	shr.u32 	%r16, %r15, 4;
+	shr.u64 	%rd23, %rd29, 7;
+	and.b64  	%rd24, %rd29, 31;
+	bfi.b64 	%rd25, %rd23, %rd24, 5, 59;
+	add.s64 	%rd26, %rd5, %rd25;
+	mov.u32 	%r17, 6;
+	sub.s32 	%r18, %r17, %r16;
+	ld.global.nc.u8 	%rs2, [%rd26];
+	cvt.u32.u16 	%r19, %rs2;
+	and.b32  	%r20, %r19, 255;
+	shr.u32 	%r21, %r20, %r18;
+	and.b32  	%r22, %r21, 3;
+	cvt.rn.f32.s32 	%f3, %r22;
+	add.f32 	%f4, %f3, 0fBF800000;
+	mul.f32 	%f2, %f1, %f4;
+	// begin inline asm
+	{  cvt.rn.f16.f32 %rs1, %f2;}
+
+	// end inline asm
+	shl.b64 	%rd27, %rd29, 1;
+	add.s64 	%rd28, %rd6, %rd27;
+	st.global.u16 	[%rd28], %rs1;
+	add.s64 	%rd29, %rd29, %rd8;
+	setp.lt.s64 	%p2, %rd29, %rd7;
+	@%p2 bra 	$L__BB1_2;
+
+$L__BB1_3:
+	ret;
+
+}
 

--- a/native/ptx/i2_s_gemv.ptx
+++ b/native/ptx/i2_s_gemv.ptx
@@ -20,6 +20,8 @@
 // _ZZ15i2_s_gemv_f32inE2xs has been demoted
 // _ZZ25quantize_f16_to_i8_absmaxE8warp_max has been demoted
 // _ZZ25quantize_f16_to_i8_absmaxE5scale has been demoted
+// _ZZ22i2_s_gemv_f16in_raggedE2xs has been demoted
+// _ZZ22i2_s_gemv_f32in_raggedE2xs has been demoted
 
 .visible .entry i2_s_gemv_f16in(
 	.param .u64 i2_s_gemv_f16in_param_0,
@@ -12182,6 +12184,1026 @@ $L__BB7_76:
 	st.global.f32 	[%rd4+4], %f138;
 
 $L__BB7_78:
+	ret;
+
+}
+	// .globl	i2_s_gemv_f16in_ragged
+.visible .entry i2_s_gemv_f16in_ragged(
+	.param .u64 i2_s_gemv_f16in_ragged_param_0,
+	.param .u64 i2_s_gemv_f16in_ragged_param_1,
+	.param .u64 i2_s_gemv_f16in_ragged_param_2,
+	.param .u32 i2_s_gemv_f16in_ragged_param_3,
+	.param .u32 i2_s_gemv_f16in_ragged_param_4
+)
+.maxntid 256, 1, 1
+{
+	.reg .pred 	%p<72>;
+	.reg .b16 	%rs<8>;
+	.reg .f32 	%f<102>;
+	.reg .b32 	%r<252>;
+	.reg .b64 	%rd<54>;
+	// demoted variable
+	.shared .align 4 .b8 _ZZ22i2_s_gemv_f16in_raggedE2xs[27648];
+
+	ld.param.u64 	%rd11, [i2_s_gemv_f16in_ragged_param_0];
+	ld.param.u64 	%rd12, [i2_s_gemv_f16in_ragged_param_1];
+	ld.param.u64 	%rd13, [i2_s_gemv_f16in_ragged_param_2];
+	ld.param.u32 	%r56, [i2_s_gemv_f16in_ragged_param_3];
+	ld.param.u32 	%r57, [i2_s_gemv_f16in_ragged_param_4];
+	mov.u32 	%r1, %tid.x;
+	setp.ge.s32 	%p1, %r1, %r57;
+	@%p1 bra 	$L__BB8_3;
+
+	mov.u32 	%r2, %ntid.x;
+	cvta.to.global.u64 	%rd1, %rd12;
+	mov.u32 	%r244, %r1;
+
+$L__BB8_2:
+	mul.wide.s32 	%rd14, %r244, 2;
+	add.s64 	%rd15, %rd1, %rd14;
+	ld.global.nc.u16 	%rs1, [%rd15];
+	// begin inline asm
+	{  cvt.f32.f16 %f41, %rs1;}
+
+	// end inline asm
+	shl.b32 	%r58, %r244, 2;
+	mov.u32 	%r59, _ZZ22i2_s_gemv_f16in_raggedE2xs;
+	add.s32 	%r60, %r59, %r58;
+	st.shared.f32 	[%r60], %f41;
+	add.s32 	%r244, %r244, %r2;
+	setp.lt.s32 	%p2, %r244, %r57;
+	@%p2 bra 	$L__BB8_2;
+
+$L__BB8_3:
+	bar.sync 	0;
+	and.b32  	%r5, %r1, 31;
+	mov.u32 	%r61, %ctaid.x;
+	shl.b32 	%r62, %r61, 3;
+	shr.u32 	%r63, %r1, 5;
+	add.s32 	%r6, %r62, %r63;
+	setp.ge.s32 	%p3, %r6, %r56;
+	@%p3 bra 	$L__BB8_45;
+
+	shr.s32 	%r64, %r57, 31;
+	shr.u32 	%r65, %r64, 30;
+	add.s32 	%r66, %r57, %r65;
+	shr.s32 	%r67, %r66, 2;
+	mul.wide.s32 	%rd16, %r67, %r56;
+	cvta.to.global.u64 	%rd17, %rd11;
+	add.s64 	%rd18, %rd17, %rd16;
+	ld.global.nc.f32 	%f1, [%rd18];
+	cvt.s64.s32 	%rd2, %r6;
+	setp.ge.s32 	%p4, %r5, %r57;
+	mov.f32 	%f101, 0f00000000;
+	@%p4 bra 	$L__BB8_11;
+
+	not.b32 	%r68, %r5;
+	add.s32 	%r7, %r68, %r57;
+	shr.u32 	%r69, %r7, 5;
+	add.s32 	%r70, %r69, 1;
+	and.b32  	%r247, %r70, 3;
+	setp.eq.s32 	%p5, %r247, 0;
+	mov.f32 	%f101, 0f00000000;
+	mov.u32 	%r248, %r5;
+	@%p5 bra 	$L__BB8_8;
+
+	shl.b32 	%r71, %r5, 2;
+	mov.u32 	%r72, _ZZ22i2_s_gemv_f16in_raggedE2xs;
+	add.s32 	%r245, %r72, %r71;
+	cvt.s64.s32 	%rd19, %r57;
+	mul.lo.s64 	%rd20, %rd19, %rd2;
+	mov.u32 	%r73, %tid.x;
+	cvt.u64.u32 	%rd21, %r73;
+	and.b64  	%rd22, %rd21, 31;
+	add.s64 	%rd52, %rd20, %rd22;
+	mov.f32 	%f101, 0f00000000;
+	mov.u32 	%r248, %r5;
+
+$L__BB8_7:
+	.pragma "nounroll";
+	cvt.u32.u64 	%r74, %rd52;
+	and.b32  	%r75, %r74, 96;
+	shr.u32 	%r76, %r75, 4;
+	shr.s64 	%rd23, %rd52, 7;
+	and.b64  	%rd24, %rd52, 31;
+	bfi.b64 	%rd25, %rd23, %rd24, 5, 59;
+	add.s64 	%rd26, %rd17, %rd25;
+	mov.u32 	%r77, 6;
+	sub.s32 	%r78, %r77, %r76;
+	ld.global.nc.u8 	%rs2, [%rd26];
+	cvt.u32.u16 	%r79, %rs2;
+	and.b32  	%r80, %r79, 255;
+	shr.u32 	%r81, %r80, %r78;
+	and.b32  	%r82, %r81, 3;
+	cvt.rn.f32.s32 	%f46, %r82;
+	add.f32 	%f47, %f46, 0fBF800000;
+	ld.shared.f32 	%f48, [%r245];
+	fma.rn.f32 	%f101, %f48, %f47, %f101;
+	add.s32 	%r248, %r248, 32;
+	add.s32 	%r245, %r245, 128;
+	add.s64 	%rd52, %rd52, 32;
+	add.s32 	%r247, %r247, -1;
+	setp.ne.s32 	%p6, %r247, 0;
+	@%p6 bra 	$L__BB8_7;
+
+$L__BB8_8:
+	setp.lt.u32 	%p7, %r7, 96;
+	@%p7 bra 	$L__BB8_11;
+
+	cvt.s64.s32 	%rd27, %r57;
+	mul.lo.s64 	%rd28, %rd27, %rd2;
+	cvt.u64.u32 	%rd29, %r248;
+	add.s64 	%rd53, %rd28, %rd29;
+	mad.lo.s32 	%r83, %r57, %r6, %r248;
+	add.s32 	%r250, %r83, 96;
+	shl.b32 	%r84, %r248, 2;
+	mov.u32 	%r85, _ZZ22i2_s_gemv_f16in_raggedE2xs;
+	add.s32 	%r86, %r85, %r84;
+	add.s32 	%r249, %r86, 256;
+
+$L__BB8_10:
+	add.s32 	%r87, %r250, -96;
+	and.b32  	%r88, %r87, 96;
+	shr.u32 	%r89, %r88, 4;
+	shr.s64 	%rd30, %rd53, 7;
+	and.b64  	%rd31, %rd53, 31;
+	bfi.b64 	%rd32, %rd30, %rd31, 5, 59;
+	add.s64 	%rd33, %rd17, %rd32;
+	mov.u32 	%r90, 6;
+	sub.s32 	%r91, %r90, %r89;
+	ld.global.nc.u8 	%rs3, [%rd33];
+	cvt.u32.u16 	%r92, %rs3;
+	and.b32  	%r93, %r92, 255;
+	shr.u32 	%r94, %r93, %r91;
+	and.b32  	%r95, %r94, 3;
+	cvt.rn.f32.s32 	%f49, %r95;
+	add.f32 	%f50, %f49, 0fBF800000;
+	ld.shared.f32 	%f51, [%r249+-256];
+	fma.rn.f32 	%f52, %f51, %f50, %f101;
+	add.s64 	%rd34, %rd53, 32;
+	shr.s64 	%rd35, %rd34, 7;
+	add.s32 	%r96, %r250, -64;
+	and.b32  	%r97, %r96, 96;
+	and.b64  	%rd36, %rd34, 31;
+	shr.u32 	%r98, %r97, 4;
+	bfi.b64 	%rd37, %rd35, %rd36, 5, 59;
+	add.s64 	%rd38, %rd17, %rd37;
+	sub.s32 	%r99, %r90, %r98;
+	ld.global.nc.u8 	%rs4, [%rd38];
+	cvt.u32.u16 	%r100, %rs4;
+	and.b32  	%r101, %r100, 255;
+	shr.u32 	%r102, %r101, %r99;
+	and.b32  	%r103, %r102, 3;
+	cvt.rn.f32.s32 	%f53, %r103;
+	add.f32 	%f54, %f53, 0fBF800000;
+	ld.shared.f32 	%f55, [%r249+-128];
+	fma.rn.f32 	%f56, %f55, %f54, %f52;
+	add.s64 	%rd39, %rd53, 64;
+	shr.s64 	%rd40, %rd39, 7;
+	add.s32 	%r104, %r250, -32;
+	and.b32  	%r105, %r104, 96;
+	and.b64  	%rd41, %rd39, 31;
+	shr.u32 	%r106, %r105, 4;
+	bfi.b64 	%rd42, %rd40, %rd41, 5, 59;
+	add.s64 	%rd43, %rd17, %rd42;
+	sub.s32 	%r107, %r90, %r106;
+	ld.global.nc.u8 	%rs5, [%rd43];
+	cvt.u32.u16 	%r108, %rs5;
+	and.b32  	%r109, %r108, 255;
+	shr.u32 	%r110, %r109, %r107;
+	and.b32  	%r111, %r110, 3;
+	cvt.rn.f32.s32 	%f57, %r111;
+	add.f32 	%f58, %f57, 0fBF800000;
+	ld.shared.f32 	%f59, [%r249];
+	fma.rn.f32 	%f60, %f59, %f58, %f56;
+	add.s64 	%rd44, %rd53, 96;
+	shr.s64 	%rd45, %rd44, 7;
+	and.b64  	%rd46, %rd44, 31;
+	and.b32  	%r112, %r250, 96;
+	shr.u32 	%r113, %r112, 4;
+	bfi.b64 	%rd47, %rd45, %rd46, 5, 59;
+	add.s64 	%rd48, %rd17, %rd47;
+	sub.s32 	%r114, %r90, %r113;
+	ld.global.nc.u8 	%rs6, [%rd48];
+	cvt.u32.u16 	%r115, %rs6;
+	and.b32  	%r116, %r115, 255;
+	shr.u32 	%r117, %r116, %r114;
+	and.b32  	%r118, %r117, 3;
+	cvt.rn.f32.s32 	%f61, %r118;
+	add.f32 	%f62, %f61, 0fBF800000;
+	ld.shared.f32 	%f63, [%r249+128];
+	fma.rn.f32 	%f101, %f63, %f62, %f60;
+	add.s64 	%rd53, %rd53, 128;
+	add.s32 	%r250, %r250, 128;
+	add.s32 	%r249, %r249, 512;
+	add.s32 	%r248, %r248, 128;
+	setp.lt.s32 	%p8, %r248, %r57;
+	@%p8 bra 	$L__BB8_10;
+
+$L__BB8_11:
+	mov.u32 	%r25, WARP_SZ;
+	setp.lt.s32 	%p9, %r25, 2;
+	@%p9 bra 	$L__BB8_43;
+
+	shr.u32 	%r119, %r25, 1;
+	mov.b32 	%r120, %f101;
+	mov.u32 	%r121, 31;
+	mov.u32 	%r122, -1;
+	shfl.sync.down.b32 	%r123|%p10, %r120, %r119, %r121, %r122;
+	mov.b32 	%f64, %r123;
+	add.f32 	%f101, %f101, %f64;
+	shr.u32 	%r26, %r25, 2;
+	setp.eq.s32 	%p11, %r26, 0;
+	@%p11 bra 	$L__BB8_43;
+
+	mov.b32 	%r124, %f101;
+	shfl.sync.down.b32 	%r127|%p12, %r124, %r26, %r121, %r122;
+	mov.b32 	%f65, %r127;
+	add.f32 	%f101, %f101, %f65;
+	shr.u32 	%r27, %r25, 3;
+	setp.eq.s32 	%p13, %r27, 0;
+	@%p13 bra 	$L__BB8_43;
+
+	mov.b32 	%r128, %f101;
+	mov.u32 	%r129, 31;
+	mov.u32 	%r130, -1;
+	shfl.sync.down.b32 	%r131|%p14, %r128, %r27, %r129, %r130;
+	mov.b32 	%f66, %r131;
+	add.f32 	%f101, %f101, %f66;
+	shr.u32 	%r28, %r25, 4;
+	setp.eq.s32 	%p15, %r28, 0;
+	@%p15 bra 	$L__BB8_43;
+
+	mov.b32 	%r132, %f101;
+	shfl.sync.down.b32 	%r135|%p16, %r132, %r28, %r129, %r130;
+	mov.b32 	%f67, %r135;
+	add.f32 	%f101, %f101, %f67;
+	shr.u32 	%r29, %r25, 5;
+	setp.eq.s32 	%p17, %r29, 0;
+	@%p17 bra 	$L__BB8_43;
+
+	mov.b32 	%r136, %f101;
+	mov.u32 	%r137, 31;
+	mov.u32 	%r138, -1;
+	shfl.sync.down.b32 	%r139|%p18, %r136, %r29, %r137, %r138;
+	mov.b32 	%f68, %r139;
+	add.f32 	%f101, %f101, %f68;
+	shr.u32 	%r30, %r25, 6;
+	setp.eq.s32 	%p19, %r30, 0;
+	@%p19 bra 	$L__BB8_43;
+
+	mov.b32 	%r140, %f101;
+	shfl.sync.down.b32 	%r143|%p20, %r140, %r30, %r137, %r138;
+	mov.b32 	%f69, %r143;
+	add.f32 	%f101, %f101, %f69;
+	shr.u32 	%r31, %r25, 7;
+	setp.eq.s32 	%p21, %r31, 0;
+	@%p21 bra 	$L__BB8_43;
+
+	mov.b32 	%r144, %f101;
+	mov.u32 	%r145, 31;
+	mov.u32 	%r146, -1;
+	shfl.sync.down.b32 	%r147|%p22, %r144, %r31, %r145, %r146;
+	mov.b32 	%f70, %r147;
+	add.f32 	%f101, %f101, %f70;
+	shr.u32 	%r32, %r25, 8;
+	setp.eq.s32 	%p23, %r32, 0;
+	@%p23 bra 	$L__BB8_43;
+
+	mov.b32 	%r148, %f101;
+	shfl.sync.down.b32 	%r151|%p24, %r148, %r32, %r145, %r146;
+	mov.b32 	%f71, %r151;
+	add.f32 	%f101, %f101, %f71;
+	shr.u32 	%r33, %r25, 9;
+	setp.eq.s32 	%p25, %r33, 0;
+	@%p25 bra 	$L__BB8_43;
+
+	mov.b32 	%r152, %f101;
+	mov.u32 	%r153, 31;
+	mov.u32 	%r154, -1;
+	shfl.sync.down.b32 	%r155|%p26, %r152, %r33, %r153, %r154;
+	mov.b32 	%f72, %r155;
+	add.f32 	%f101, %f101, %f72;
+	shr.u32 	%r34, %r25, 10;
+	setp.eq.s32 	%p27, %r34, 0;
+	@%p27 bra 	$L__BB8_43;
+
+	mov.b32 	%r156, %f101;
+	shfl.sync.down.b32 	%r159|%p28, %r156, %r34, %r153, %r154;
+	mov.b32 	%f73, %r159;
+	add.f32 	%f101, %f101, %f73;
+	shr.u32 	%r35, %r25, 11;
+	setp.eq.s32 	%p29, %r35, 0;
+	@%p29 bra 	$L__BB8_43;
+
+	mov.b32 	%r160, %f101;
+	mov.u32 	%r161, 31;
+	mov.u32 	%r162, -1;
+	shfl.sync.down.b32 	%r163|%p30, %r160, %r35, %r161, %r162;
+	mov.b32 	%f74, %r163;
+	add.f32 	%f101, %f101, %f74;
+	shr.u32 	%r36, %r25, 12;
+	setp.eq.s32 	%p31, %r36, 0;
+	@%p31 bra 	$L__BB8_43;
+
+	mov.b32 	%r164, %f101;
+	shfl.sync.down.b32 	%r167|%p32, %r164, %r36, %r161, %r162;
+	mov.b32 	%f75, %r167;
+	add.f32 	%f101, %f101, %f75;
+	shr.u32 	%r37, %r25, 13;
+	setp.eq.s32 	%p33, %r37, 0;
+	@%p33 bra 	$L__BB8_43;
+
+	mov.b32 	%r168, %f101;
+	mov.u32 	%r169, 31;
+	mov.u32 	%r170, -1;
+	shfl.sync.down.b32 	%r171|%p34, %r168, %r37, %r169, %r170;
+	mov.b32 	%f76, %r171;
+	add.f32 	%f101, %f101, %f76;
+	shr.u32 	%r38, %r25, 14;
+	setp.eq.s32 	%p35, %r38, 0;
+	@%p35 bra 	$L__BB8_43;
+
+	mov.b32 	%r172, %f101;
+	shfl.sync.down.b32 	%r175|%p36, %r172, %r38, %r169, %r170;
+	mov.b32 	%f77, %r175;
+	add.f32 	%f101, %f101, %f77;
+	shr.u32 	%r39, %r25, 15;
+	setp.eq.s32 	%p37, %r39, 0;
+	@%p37 bra 	$L__BB8_43;
+
+	mov.b32 	%r176, %f101;
+	mov.u32 	%r177, 31;
+	mov.u32 	%r178, -1;
+	shfl.sync.down.b32 	%r179|%p38, %r176, %r39, %r177, %r178;
+	mov.b32 	%f78, %r179;
+	add.f32 	%f101, %f101, %f78;
+	shr.u32 	%r40, %r25, 16;
+	setp.eq.s32 	%p39, %r40, 0;
+	@%p39 bra 	$L__BB8_43;
+
+	mov.b32 	%r180, %f101;
+	shfl.sync.down.b32 	%r183|%p40, %r180, %r40, %r177, %r178;
+	mov.b32 	%f79, %r183;
+	add.f32 	%f101, %f101, %f79;
+	shr.u32 	%r41, %r25, 17;
+	setp.eq.s32 	%p41, %r41, 0;
+	@%p41 bra 	$L__BB8_43;
+
+	mov.b32 	%r184, %f101;
+	mov.u32 	%r185, 31;
+	mov.u32 	%r186, -1;
+	shfl.sync.down.b32 	%r187|%p42, %r184, %r41, %r185, %r186;
+	mov.b32 	%f80, %r187;
+	add.f32 	%f101, %f101, %f80;
+	shr.u32 	%r42, %r25, 18;
+	setp.eq.s32 	%p43, %r42, 0;
+	@%p43 bra 	$L__BB8_43;
+
+	mov.b32 	%r188, %f101;
+	shfl.sync.down.b32 	%r191|%p44, %r188, %r42, %r185, %r186;
+	mov.b32 	%f81, %r191;
+	add.f32 	%f101, %f101, %f81;
+	shr.u32 	%r43, %r25, 19;
+	setp.eq.s32 	%p45, %r43, 0;
+	@%p45 bra 	$L__BB8_43;
+
+	mov.b32 	%r192, %f101;
+	mov.u32 	%r193, 31;
+	mov.u32 	%r194, -1;
+	shfl.sync.down.b32 	%r195|%p46, %r192, %r43, %r193, %r194;
+	mov.b32 	%f82, %r195;
+	add.f32 	%f101, %f101, %f82;
+	shr.u32 	%r44, %r25, 20;
+	setp.eq.s32 	%p47, %r44, 0;
+	@%p47 bra 	$L__BB8_43;
+
+	mov.b32 	%r196, %f101;
+	shfl.sync.down.b32 	%r199|%p48, %r196, %r44, %r193, %r194;
+	mov.b32 	%f83, %r199;
+	add.f32 	%f101, %f101, %f83;
+	shr.u32 	%r45, %r25, 21;
+	setp.eq.s32 	%p49, %r45, 0;
+	@%p49 bra 	$L__BB8_43;
+
+	mov.b32 	%r200, %f101;
+	mov.u32 	%r201, 31;
+	mov.u32 	%r202, -1;
+	shfl.sync.down.b32 	%r203|%p50, %r200, %r45, %r201, %r202;
+	mov.b32 	%f84, %r203;
+	add.f32 	%f101, %f101, %f84;
+	shr.u32 	%r46, %r25, 22;
+	setp.eq.s32 	%p51, %r46, 0;
+	@%p51 bra 	$L__BB8_43;
+
+	mov.b32 	%r204, %f101;
+	shfl.sync.down.b32 	%r207|%p52, %r204, %r46, %r201, %r202;
+	mov.b32 	%f85, %r207;
+	add.f32 	%f101, %f101, %f85;
+	shr.u32 	%r47, %r25, 23;
+	setp.eq.s32 	%p53, %r47, 0;
+	@%p53 bra 	$L__BB8_43;
+
+	mov.b32 	%r208, %f101;
+	mov.u32 	%r209, 31;
+	mov.u32 	%r210, -1;
+	shfl.sync.down.b32 	%r211|%p54, %r208, %r47, %r209, %r210;
+	mov.b32 	%f86, %r211;
+	add.f32 	%f101, %f101, %f86;
+	shr.u32 	%r48, %r25, 24;
+	setp.eq.s32 	%p55, %r48, 0;
+	@%p55 bra 	$L__BB8_43;
+
+	mov.b32 	%r212, %f101;
+	shfl.sync.down.b32 	%r215|%p56, %r212, %r48, %r209, %r210;
+	mov.b32 	%f87, %r215;
+	add.f32 	%f101, %f101, %f87;
+	shr.u32 	%r49, %r25, 25;
+	setp.eq.s32 	%p57, %r49, 0;
+	@%p57 bra 	$L__BB8_43;
+
+	mov.b32 	%r216, %f101;
+	mov.u32 	%r217, 31;
+	mov.u32 	%r218, -1;
+	shfl.sync.down.b32 	%r219|%p58, %r216, %r49, %r217, %r218;
+	mov.b32 	%f88, %r219;
+	add.f32 	%f101, %f101, %f88;
+	shr.u32 	%r50, %r25, 26;
+	setp.eq.s32 	%p59, %r50, 0;
+	@%p59 bra 	$L__BB8_43;
+
+	mov.b32 	%r220, %f101;
+	shfl.sync.down.b32 	%r223|%p60, %r220, %r50, %r217, %r218;
+	mov.b32 	%f89, %r223;
+	add.f32 	%f101, %f101, %f89;
+	shr.u32 	%r51, %r25, 27;
+	setp.eq.s32 	%p61, %r51, 0;
+	@%p61 bra 	$L__BB8_43;
+
+	mov.b32 	%r224, %f101;
+	mov.u32 	%r225, 31;
+	mov.u32 	%r226, -1;
+	shfl.sync.down.b32 	%r227|%p62, %r224, %r51, %r225, %r226;
+	mov.b32 	%f90, %r227;
+	add.f32 	%f101, %f101, %f90;
+	shr.u32 	%r52, %r25, 28;
+	setp.eq.s32 	%p63, %r52, 0;
+	@%p63 bra 	$L__BB8_43;
+
+	mov.b32 	%r228, %f101;
+	shfl.sync.down.b32 	%r231|%p64, %r228, %r52, %r225, %r226;
+	mov.b32 	%f91, %r231;
+	add.f32 	%f101, %f101, %f91;
+	shr.u32 	%r53, %r25, 29;
+	setp.eq.s32 	%p65, %r53, 0;
+	@%p65 bra 	$L__BB8_43;
+
+	mov.b32 	%r232, %f101;
+	mov.u32 	%r233, 31;
+	mov.u32 	%r234, -1;
+	shfl.sync.down.b32 	%r235|%p66, %r232, %r53, %r233, %r234;
+	mov.b32 	%f92, %r235;
+	add.f32 	%f101, %f101, %f92;
+	shr.u32 	%r54, %r25, 30;
+	setp.eq.s32 	%p67, %r54, 0;
+	@%p67 bra 	$L__BB8_43;
+
+	mov.b32 	%r236, %f101;
+	shfl.sync.down.b32 	%r239|%p68, %r236, %r54, %r233, %r234;
+	mov.b32 	%f93, %r239;
+	add.f32 	%f101, %f101, %f93;
+	shr.u32 	%r55, %r25, 31;
+	setp.eq.s32 	%p69, %r55, 0;
+	@%p69 bra 	$L__BB8_43;
+
+	mov.b32 	%r240, %f101;
+	mov.u32 	%r241, 31;
+	mov.u32 	%r242, -1;
+	shfl.sync.down.b32 	%r243|%p70, %r240, %r55, %r241, %r242;
+	mov.b32 	%f94, %r243;
+	add.f32 	%f101, %f101, %f94;
+
+$L__BB8_43:
+	setp.ne.s32 	%p71, %r5, 0;
+	@%p71 bra 	$L__BB8_45;
+
+	mul.f32 	%f95, %f1, %f101;
+	// begin inline asm
+	{  cvt.rn.f16.f32 %rs7, %f95;}
+
+	// end inline asm
+	cvta.to.global.u64 	%rd49, %rd13;
+	shl.b64 	%rd50, %rd2, 1;
+	add.s64 	%rd51, %rd49, %rd50;
+	st.global.u16 	[%rd51], %rs7;
+
+$L__BB8_45:
+	ret;
+
+}
+	// .globl	i2_s_gemv_f32in_ragged
+.visible .entry i2_s_gemv_f32in_ragged(
+	.param .u64 i2_s_gemv_f32in_ragged_param_0,
+	.param .u64 i2_s_gemv_f32in_ragged_param_1,
+	.param .u64 i2_s_gemv_f32in_ragged_param_2,
+	.param .u32 i2_s_gemv_f32in_ragged_param_3,
+	.param .u32 i2_s_gemv_f32in_ragged_param_4
+)
+.maxntid 256, 1, 1
+{
+	.reg .pred 	%p<72>;
+	.reg .b16 	%rs<6>;
+	.reg .f32 	%f<102>;
+	.reg .b32 	%r<252>;
+	.reg .b64 	%rd<54>;
+	// demoted variable
+	.shared .align 4 .b8 _ZZ22i2_s_gemv_f32in_raggedE2xs[27648];
+
+	ld.param.u64 	%rd11, [i2_s_gemv_f32in_ragged_param_0];
+	ld.param.u64 	%rd12, [i2_s_gemv_f32in_ragged_param_1];
+	ld.param.u64 	%rd13, [i2_s_gemv_f32in_ragged_param_2];
+	ld.param.u32 	%r56, [i2_s_gemv_f32in_ragged_param_3];
+	ld.param.u32 	%r57, [i2_s_gemv_f32in_ragged_param_4];
+	mov.u32 	%r1, %tid.x;
+	setp.ge.s32 	%p1, %r1, %r57;
+	@%p1 bra 	$L__BB9_3;
+
+	mov.u32 	%r2, %ntid.x;
+	cvta.to.global.u64 	%rd1, %rd12;
+	mov.u32 	%r244, %r1;
+
+$L__BB9_2:
+	mul.wide.s32 	%rd14, %r244, 4;
+	add.s64 	%rd15, %rd1, %rd14;
+	ld.global.nc.f32 	%f41, [%rd15];
+	shl.b32 	%r58, %r244, 2;
+	mov.u32 	%r59, _ZZ22i2_s_gemv_f32in_raggedE2xs;
+	add.s32 	%r60, %r59, %r58;
+	st.shared.f32 	[%r60], %f41;
+	add.s32 	%r244, %r244, %r2;
+	setp.lt.s32 	%p2, %r244, %r57;
+	@%p2 bra 	$L__BB9_2;
+
+$L__BB9_3:
+	bar.sync 	0;
+	and.b32  	%r5, %r1, 31;
+	mov.u32 	%r61, %ctaid.x;
+	shl.b32 	%r62, %r61, 3;
+	shr.u32 	%r63, %r1, 5;
+	add.s32 	%r6, %r62, %r63;
+	setp.ge.s32 	%p3, %r6, %r56;
+	@%p3 bra 	$L__BB9_45;
+
+	shr.s32 	%r64, %r57, 31;
+	shr.u32 	%r65, %r64, 30;
+	add.s32 	%r66, %r57, %r65;
+	shr.s32 	%r67, %r66, 2;
+	mul.wide.s32 	%rd16, %r67, %r56;
+	cvta.to.global.u64 	%rd17, %rd11;
+	add.s64 	%rd18, %rd17, %rd16;
+	ld.global.nc.f32 	%f1, [%rd18];
+	cvt.s64.s32 	%rd2, %r6;
+	setp.ge.s32 	%p4, %r5, %r57;
+	mov.f32 	%f101, 0f00000000;
+	@%p4 bra 	$L__BB9_11;
+
+	not.b32 	%r68, %r5;
+	add.s32 	%r7, %r68, %r57;
+	shr.u32 	%r69, %r7, 5;
+	add.s32 	%r70, %r69, 1;
+	and.b32  	%r247, %r70, 3;
+	setp.eq.s32 	%p5, %r247, 0;
+	mov.f32 	%f101, 0f00000000;
+	mov.u32 	%r248, %r5;
+	@%p5 bra 	$L__BB9_8;
+
+	shl.b32 	%r71, %r5, 2;
+	mov.u32 	%r72, _ZZ22i2_s_gemv_f32in_raggedE2xs;
+	add.s32 	%r245, %r72, %r71;
+	cvt.s64.s32 	%rd19, %r57;
+	mul.lo.s64 	%rd20, %rd19, %rd2;
+	mov.u32 	%r73, %tid.x;
+	cvt.u64.u32 	%rd21, %r73;
+	and.b64  	%rd22, %rd21, 31;
+	add.s64 	%rd52, %rd20, %rd22;
+	mov.f32 	%f101, 0f00000000;
+	mov.u32 	%r248, %r5;
+
+$L__BB9_7:
+	.pragma "nounroll";
+	cvt.u32.u64 	%r74, %rd52;
+	and.b32  	%r75, %r74, 96;
+	shr.u32 	%r76, %r75, 4;
+	shr.s64 	%rd23, %rd52, 7;
+	and.b64  	%rd24, %rd52, 31;
+	bfi.b64 	%rd25, %rd23, %rd24, 5, 59;
+	add.s64 	%rd26, %rd17, %rd25;
+	mov.u32 	%r77, 6;
+	sub.s32 	%r78, %r77, %r76;
+	ld.global.nc.u8 	%rs1, [%rd26];
+	cvt.u32.u16 	%r79, %rs1;
+	and.b32  	%r80, %r79, 255;
+	shr.u32 	%r81, %r80, %r78;
+	and.b32  	%r82, %r81, 3;
+	cvt.rn.f32.s32 	%f46, %r82;
+	add.f32 	%f47, %f46, 0fBF800000;
+	ld.shared.f32 	%f48, [%r245];
+	fma.rn.f32 	%f101, %f48, %f47, %f101;
+	add.s32 	%r248, %r248, 32;
+	add.s32 	%r245, %r245, 128;
+	add.s64 	%rd52, %rd52, 32;
+	add.s32 	%r247, %r247, -1;
+	setp.ne.s32 	%p6, %r247, 0;
+	@%p6 bra 	$L__BB9_7;
+
+$L__BB9_8:
+	setp.lt.u32 	%p7, %r7, 96;
+	@%p7 bra 	$L__BB9_11;
+
+	cvt.s64.s32 	%rd27, %r57;
+	mul.lo.s64 	%rd28, %rd27, %rd2;
+	cvt.u64.u32 	%rd29, %r248;
+	add.s64 	%rd53, %rd28, %rd29;
+	mad.lo.s32 	%r83, %r57, %r6, %r248;
+	add.s32 	%r250, %r83, 96;
+	shl.b32 	%r84, %r248, 2;
+	mov.u32 	%r85, _ZZ22i2_s_gemv_f32in_raggedE2xs;
+	add.s32 	%r86, %r85, %r84;
+	add.s32 	%r249, %r86, 256;
+
+$L__BB9_10:
+	add.s32 	%r87, %r250, -96;
+	and.b32  	%r88, %r87, 96;
+	shr.u32 	%r89, %r88, 4;
+	shr.s64 	%rd30, %rd53, 7;
+	and.b64  	%rd31, %rd53, 31;
+	bfi.b64 	%rd32, %rd30, %rd31, 5, 59;
+	add.s64 	%rd33, %rd17, %rd32;
+	mov.u32 	%r90, 6;
+	sub.s32 	%r91, %r90, %r89;
+	ld.global.nc.u8 	%rs2, [%rd33];
+	cvt.u32.u16 	%r92, %rs2;
+	and.b32  	%r93, %r92, 255;
+	shr.u32 	%r94, %r93, %r91;
+	and.b32  	%r95, %r94, 3;
+	cvt.rn.f32.s32 	%f49, %r95;
+	add.f32 	%f50, %f49, 0fBF800000;
+	ld.shared.f32 	%f51, [%r249+-256];
+	fma.rn.f32 	%f52, %f51, %f50, %f101;
+	add.s64 	%rd34, %rd53, 32;
+	shr.s64 	%rd35, %rd34, 7;
+	add.s32 	%r96, %r250, -64;
+	and.b32  	%r97, %r96, 96;
+	and.b64  	%rd36, %rd34, 31;
+	shr.u32 	%r98, %r97, 4;
+	bfi.b64 	%rd37, %rd35, %rd36, 5, 59;
+	add.s64 	%rd38, %rd17, %rd37;
+	sub.s32 	%r99, %r90, %r98;
+	ld.global.nc.u8 	%rs3, [%rd38];
+	cvt.u32.u16 	%r100, %rs3;
+	and.b32  	%r101, %r100, 255;
+	shr.u32 	%r102, %r101, %r99;
+	and.b32  	%r103, %r102, 3;
+	cvt.rn.f32.s32 	%f53, %r103;
+	add.f32 	%f54, %f53, 0fBF800000;
+	ld.shared.f32 	%f55, [%r249+-128];
+	fma.rn.f32 	%f56, %f55, %f54, %f52;
+	add.s64 	%rd39, %rd53, 64;
+	shr.s64 	%rd40, %rd39, 7;
+	add.s32 	%r104, %r250, -32;
+	and.b32  	%r105, %r104, 96;
+	and.b64  	%rd41, %rd39, 31;
+	shr.u32 	%r106, %r105, 4;
+	bfi.b64 	%rd42, %rd40, %rd41, 5, 59;
+	add.s64 	%rd43, %rd17, %rd42;
+	sub.s32 	%r107, %r90, %r106;
+	ld.global.nc.u8 	%rs4, [%rd43];
+	cvt.u32.u16 	%r108, %rs4;
+	and.b32  	%r109, %r108, 255;
+	shr.u32 	%r110, %r109, %r107;
+	and.b32  	%r111, %r110, 3;
+	cvt.rn.f32.s32 	%f57, %r111;
+	add.f32 	%f58, %f57, 0fBF800000;
+	ld.shared.f32 	%f59, [%r249];
+	fma.rn.f32 	%f60, %f59, %f58, %f56;
+	add.s64 	%rd44, %rd53, 96;
+	shr.s64 	%rd45, %rd44, 7;
+	and.b64  	%rd46, %rd44, 31;
+	and.b32  	%r112, %r250, 96;
+	shr.u32 	%r113, %r112, 4;
+	bfi.b64 	%rd47, %rd45, %rd46, 5, 59;
+	add.s64 	%rd48, %rd17, %rd47;
+	sub.s32 	%r114, %r90, %r113;
+	ld.global.nc.u8 	%rs5, [%rd48];
+	cvt.u32.u16 	%r115, %rs5;
+	and.b32  	%r116, %r115, 255;
+	shr.u32 	%r117, %r116, %r114;
+	and.b32  	%r118, %r117, 3;
+	cvt.rn.f32.s32 	%f61, %r118;
+	add.f32 	%f62, %f61, 0fBF800000;
+	ld.shared.f32 	%f63, [%r249+128];
+	fma.rn.f32 	%f101, %f63, %f62, %f60;
+	add.s64 	%rd53, %rd53, 128;
+	add.s32 	%r250, %r250, 128;
+	add.s32 	%r249, %r249, 512;
+	add.s32 	%r248, %r248, 128;
+	setp.lt.s32 	%p8, %r248, %r57;
+	@%p8 bra 	$L__BB9_10;
+
+$L__BB9_11:
+	mov.u32 	%r25, WARP_SZ;
+	setp.lt.s32 	%p9, %r25, 2;
+	@%p9 bra 	$L__BB9_43;
+
+	shr.u32 	%r119, %r25, 1;
+	mov.b32 	%r120, %f101;
+	mov.u32 	%r121, 31;
+	mov.u32 	%r122, -1;
+	shfl.sync.down.b32 	%r123|%p10, %r120, %r119, %r121, %r122;
+	mov.b32 	%f64, %r123;
+	add.f32 	%f101, %f101, %f64;
+	shr.u32 	%r26, %r25, 2;
+	setp.eq.s32 	%p11, %r26, 0;
+	@%p11 bra 	$L__BB9_43;
+
+	mov.b32 	%r124, %f101;
+	shfl.sync.down.b32 	%r127|%p12, %r124, %r26, %r121, %r122;
+	mov.b32 	%f65, %r127;
+	add.f32 	%f101, %f101, %f65;
+	shr.u32 	%r27, %r25, 3;
+	setp.eq.s32 	%p13, %r27, 0;
+	@%p13 bra 	$L__BB9_43;
+
+	mov.b32 	%r128, %f101;
+	mov.u32 	%r129, 31;
+	mov.u32 	%r130, -1;
+	shfl.sync.down.b32 	%r131|%p14, %r128, %r27, %r129, %r130;
+	mov.b32 	%f66, %r131;
+	add.f32 	%f101, %f101, %f66;
+	shr.u32 	%r28, %r25, 4;
+	setp.eq.s32 	%p15, %r28, 0;
+	@%p15 bra 	$L__BB9_43;
+
+	mov.b32 	%r132, %f101;
+	shfl.sync.down.b32 	%r135|%p16, %r132, %r28, %r129, %r130;
+	mov.b32 	%f67, %r135;
+	add.f32 	%f101, %f101, %f67;
+	shr.u32 	%r29, %r25, 5;
+	setp.eq.s32 	%p17, %r29, 0;
+	@%p17 bra 	$L__BB9_43;
+
+	mov.b32 	%r136, %f101;
+	mov.u32 	%r137, 31;
+	mov.u32 	%r138, -1;
+	shfl.sync.down.b32 	%r139|%p18, %r136, %r29, %r137, %r138;
+	mov.b32 	%f68, %r139;
+	add.f32 	%f101, %f101, %f68;
+	shr.u32 	%r30, %r25, 6;
+	setp.eq.s32 	%p19, %r30, 0;
+	@%p19 bra 	$L__BB9_43;
+
+	mov.b32 	%r140, %f101;
+	shfl.sync.down.b32 	%r143|%p20, %r140, %r30, %r137, %r138;
+	mov.b32 	%f69, %r143;
+	add.f32 	%f101, %f101, %f69;
+	shr.u32 	%r31, %r25, 7;
+	setp.eq.s32 	%p21, %r31, 0;
+	@%p21 bra 	$L__BB9_43;
+
+	mov.b32 	%r144, %f101;
+	mov.u32 	%r145, 31;
+	mov.u32 	%r146, -1;
+	shfl.sync.down.b32 	%r147|%p22, %r144, %r31, %r145, %r146;
+	mov.b32 	%f70, %r147;
+	add.f32 	%f101, %f101, %f70;
+	shr.u32 	%r32, %r25, 8;
+	setp.eq.s32 	%p23, %r32, 0;
+	@%p23 bra 	$L__BB9_43;
+
+	mov.b32 	%r148, %f101;
+	shfl.sync.down.b32 	%r151|%p24, %r148, %r32, %r145, %r146;
+	mov.b32 	%f71, %r151;
+	add.f32 	%f101, %f101, %f71;
+	shr.u32 	%r33, %r25, 9;
+	setp.eq.s32 	%p25, %r33, 0;
+	@%p25 bra 	$L__BB9_43;
+
+	mov.b32 	%r152, %f101;
+	mov.u32 	%r153, 31;
+	mov.u32 	%r154, -1;
+	shfl.sync.down.b32 	%r155|%p26, %r152, %r33, %r153, %r154;
+	mov.b32 	%f72, %r155;
+	add.f32 	%f101, %f101, %f72;
+	shr.u32 	%r34, %r25, 10;
+	setp.eq.s32 	%p27, %r34, 0;
+	@%p27 bra 	$L__BB9_43;
+
+	mov.b32 	%r156, %f101;
+	shfl.sync.down.b32 	%r159|%p28, %r156, %r34, %r153, %r154;
+	mov.b32 	%f73, %r159;
+	add.f32 	%f101, %f101, %f73;
+	shr.u32 	%r35, %r25, 11;
+	setp.eq.s32 	%p29, %r35, 0;
+	@%p29 bra 	$L__BB9_43;
+
+	mov.b32 	%r160, %f101;
+	mov.u32 	%r161, 31;
+	mov.u32 	%r162, -1;
+	shfl.sync.down.b32 	%r163|%p30, %r160, %r35, %r161, %r162;
+	mov.b32 	%f74, %r163;
+	add.f32 	%f101, %f101, %f74;
+	shr.u32 	%r36, %r25, 12;
+	setp.eq.s32 	%p31, %r36, 0;
+	@%p31 bra 	$L__BB9_43;
+
+	mov.b32 	%r164, %f101;
+	shfl.sync.down.b32 	%r167|%p32, %r164, %r36, %r161, %r162;
+	mov.b32 	%f75, %r167;
+	add.f32 	%f101, %f101, %f75;
+	shr.u32 	%r37, %r25, 13;
+	setp.eq.s32 	%p33, %r37, 0;
+	@%p33 bra 	$L__BB9_43;
+
+	mov.b32 	%r168, %f101;
+	mov.u32 	%r169, 31;
+	mov.u32 	%r170, -1;
+	shfl.sync.down.b32 	%r171|%p34, %r168, %r37, %r169, %r170;
+	mov.b32 	%f76, %r171;
+	add.f32 	%f101, %f101, %f76;
+	shr.u32 	%r38, %r25, 14;
+	setp.eq.s32 	%p35, %r38, 0;
+	@%p35 bra 	$L__BB9_43;
+
+	mov.b32 	%r172, %f101;
+	shfl.sync.down.b32 	%r175|%p36, %r172, %r38, %r169, %r170;
+	mov.b32 	%f77, %r175;
+	add.f32 	%f101, %f101, %f77;
+	shr.u32 	%r39, %r25, 15;
+	setp.eq.s32 	%p37, %r39, 0;
+	@%p37 bra 	$L__BB9_43;
+
+	mov.b32 	%r176, %f101;
+	mov.u32 	%r177, 31;
+	mov.u32 	%r178, -1;
+	shfl.sync.down.b32 	%r179|%p38, %r176, %r39, %r177, %r178;
+	mov.b32 	%f78, %r179;
+	add.f32 	%f101, %f101, %f78;
+	shr.u32 	%r40, %r25, 16;
+	setp.eq.s32 	%p39, %r40, 0;
+	@%p39 bra 	$L__BB9_43;
+
+	mov.b32 	%r180, %f101;
+	shfl.sync.down.b32 	%r183|%p40, %r180, %r40, %r177, %r178;
+	mov.b32 	%f79, %r183;
+	add.f32 	%f101, %f101, %f79;
+	shr.u32 	%r41, %r25, 17;
+	setp.eq.s32 	%p41, %r41, 0;
+	@%p41 bra 	$L__BB9_43;
+
+	mov.b32 	%r184, %f101;
+	mov.u32 	%r185, 31;
+	mov.u32 	%r186, -1;
+	shfl.sync.down.b32 	%r187|%p42, %r184, %r41, %r185, %r186;
+	mov.b32 	%f80, %r187;
+	add.f32 	%f101, %f101, %f80;
+	shr.u32 	%r42, %r25, 18;
+	setp.eq.s32 	%p43, %r42, 0;
+	@%p43 bra 	$L__BB9_43;
+
+	mov.b32 	%r188, %f101;
+	shfl.sync.down.b32 	%r191|%p44, %r188, %r42, %r185, %r186;
+	mov.b32 	%f81, %r191;
+	add.f32 	%f101, %f101, %f81;
+	shr.u32 	%r43, %r25, 19;
+	setp.eq.s32 	%p45, %r43, 0;
+	@%p45 bra 	$L__BB9_43;
+
+	mov.b32 	%r192, %f101;
+	mov.u32 	%r193, 31;
+	mov.u32 	%r194, -1;
+	shfl.sync.down.b32 	%r195|%p46, %r192, %r43, %r193, %r194;
+	mov.b32 	%f82, %r195;
+	add.f32 	%f101, %f101, %f82;
+	shr.u32 	%r44, %r25, 20;
+	setp.eq.s32 	%p47, %r44, 0;
+	@%p47 bra 	$L__BB9_43;
+
+	mov.b32 	%r196, %f101;
+	shfl.sync.down.b32 	%r199|%p48, %r196, %r44, %r193, %r194;
+	mov.b32 	%f83, %r199;
+	add.f32 	%f101, %f101, %f83;
+	shr.u32 	%r45, %r25, 21;
+	setp.eq.s32 	%p49, %r45, 0;
+	@%p49 bra 	$L__BB9_43;
+
+	mov.b32 	%r200, %f101;
+	mov.u32 	%r201, 31;
+	mov.u32 	%r202, -1;
+	shfl.sync.down.b32 	%r203|%p50, %r200, %r45, %r201, %r202;
+	mov.b32 	%f84, %r203;
+	add.f32 	%f101, %f101, %f84;
+	shr.u32 	%r46, %r25, 22;
+	setp.eq.s32 	%p51, %r46, 0;
+	@%p51 bra 	$L__BB9_43;
+
+	mov.b32 	%r204, %f101;
+	shfl.sync.down.b32 	%r207|%p52, %r204, %r46, %r201, %r202;
+	mov.b32 	%f85, %r207;
+	add.f32 	%f101, %f101, %f85;
+	shr.u32 	%r47, %r25, 23;
+	setp.eq.s32 	%p53, %r47, 0;
+	@%p53 bra 	$L__BB9_43;
+
+	mov.b32 	%r208, %f101;
+	mov.u32 	%r209, 31;
+	mov.u32 	%r210, -1;
+	shfl.sync.down.b32 	%r211|%p54, %r208, %r47, %r209, %r210;
+	mov.b32 	%f86, %r211;
+	add.f32 	%f101, %f101, %f86;
+	shr.u32 	%r48, %r25, 24;
+	setp.eq.s32 	%p55, %r48, 0;
+	@%p55 bra 	$L__BB9_43;
+
+	mov.b32 	%r212, %f101;
+	shfl.sync.down.b32 	%r215|%p56, %r212, %r48, %r209, %r210;
+	mov.b32 	%f87, %r215;
+	add.f32 	%f101, %f101, %f87;
+	shr.u32 	%r49, %r25, 25;
+	setp.eq.s32 	%p57, %r49, 0;
+	@%p57 bra 	$L__BB9_43;
+
+	mov.b32 	%r216, %f101;
+	mov.u32 	%r217, 31;
+	mov.u32 	%r218, -1;
+	shfl.sync.down.b32 	%r219|%p58, %r216, %r49, %r217, %r218;
+	mov.b32 	%f88, %r219;
+	add.f32 	%f101, %f101, %f88;
+	shr.u32 	%r50, %r25, 26;
+	setp.eq.s32 	%p59, %r50, 0;
+	@%p59 bra 	$L__BB9_43;
+
+	mov.b32 	%r220, %f101;
+	shfl.sync.down.b32 	%r223|%p60, %r220, %r50, %r217, %r218;
+	mov.b32 	%f89, %r223;
+	add.f32 	%f101, %f101, %f89;
+	shr.u32 	%r51, %r25, 27;
+	setp.eq.s32 	%p61, %r51, 0;
+	@%p61 bra 	$L__BB9_43;
+
+	mov.b32 	%r224, %f101;
+	mov.u32 	%r225, 31;
+	mov.u32 	%r226, -1;
+	shfl.sync.down.b32 	%r227|%p62, %r224, %r51, %r225, %r226;
+	mov.b32 	%f90, %r227;
+	add.f32 	%f101, %f101, %f90;
+	shr.u32 	%r52, %r25, 28;
+	setp.eq.s32 	%p63, %r52, 0;
+	@%p63 bra 	$L__BB9_43;
+
+	mov.b32 	%r228, %f101;
+	shfl.sync.down.b32 	%r231|%p64, %r228, %r52, %r225, %r226;
+	mov.b32 	%f91, %r231;
+	add.f32 	%f101, %f101, %f91;
+	shr.u32 	%r53, %r25, 29;
+	setp.eq.s32 	%p65, %r53, 0;
+	@%p65 bra 	$L__BB9_43;
+
+	mov.b32 	%r232, %f101;
+	mov.u32 	%r233, 31;
+	mov.u32 	%r234, -1;
+	shfl.sync.down.b32 	%r235|%p66, %r232, %r53, %r233, %r234;
+	mov.b32 	%f92, %r235;
+	add.f32 	%f101, %f101, %f92;
+	shr.u32 	%r54, %r25, 30;
+	setp.eq.s32 	%p67, %r54, 0;
+	@%p67 bra 	$L__BB9_43;
+
+	mov.b32 	%r236, %f101;
+	shfl.sync.down.b32 	%r239|%p68, %r236, %r54, %r233, %r234;
+	mov.b32 	%f93, %r239;
+	add.f32 	%f101, %f101, %f93;
+	shr.u32 	%r55, %r25, 31;
+	setp.eq.s32 	%p69, %r55, 0;
+	@%p69 bra 	$L__BB9_43;
+
+	mov.b32 	%r240, %f101;
+	mov.u32 	%r241, 31;
+	mov.u32 	%r242, -1;
+	shfl.sync.down.b32 	%r243|%p70, %r240, %r55, %r241, %r242;
+	mov.b32 	%f94, %r243;
+	add.f32 	%f101, %f101, %f94;
+
+$L__BB9_43:
+	setp.ne.s32 	%p71, %r5, 0;
+	@%p71 bra 	$L__BB9_45;
+
+	mul.f32 	%f95, %f1, %f101;
+	cvta.to.global.u64 	%rd49, %rd13;
+	shl.b64 	%rd50, %rd2, 2;
+	add.s64 	%rd51, %rd49, %rd50;
+	st.global.f32 	[%rd51], %f95;
+
+$L__BB9_45:
 	ret;
 
 }

--- a/src/DotLLM.Cpu/Kernels/MatMul.I2S.cs
+++ b/src/DotLLM.Cpu/Kernels/MatMul.I2S.cs
@@ -45,6 +45,26 @@ namespace DotLLM.Cpu.Kernels;
 /// <para>Per-block dot scaling: for a Q8_0 activation block <c>b</c> with float scale <c>d_b</c>,
 /// the int32 accumulator <c>Σ w·q</c> is multiplied by <c>d_b</c> and float-accumulated across
 /// blocks; the final sum is multiplied by the per-tensor weight scale.</para>
+///
+/// <para><b>Ragged K (issue #206).</b> Most published I2_S checkpoints have <c>k</c> an exact
+/// multiple of 128 (e.g. BitNet-2B-4T: 2560/6912), which is what the SIMD fast paths above
+/// assume. At least one real checkpoint family (1bitLLM-style <c>bitnet_b1_58-large</c>/<c>-xl</c>:
+/// hidden=2048, intermediate=5460, and <c>5460 % 128 == 84</c>) genuinely has a non-128-aligned
+/// row length on <c>ffn_down</c>. Empirically verified against the real GGUF (tensor byte
+/// extents match <c>m·k/4 + 4</c>, rounded up to the file's 32-byte tensor alignment, with zero
+/// extra per-row padding) and cross-checked against the upstream bitnet.cpp writer
+/// (<c>ggml-bitnet-mad.cpp</c>'s <c>quantize_i2_s</c>): the 128-element block interleave is
+/// computed over the <b>flattened <c>m·k</c> element stream</b>, not reset at each row boundary.
+/// Concretely, block index and in-block bit position for flattened element <c>i</c> are
+/// <c>i/128</c> and <c>i%128</c> — so whenever <c>k % 128 != 0</c>, a row's first element does
+/// NOT generally start on a fresh block boundary (only every <c>128/gcd(k,128)</c>-th row does).
+/// The 128-aligned fast paths above are unaffected by this — when <c>k % 128 == 0</c> every row
+/// boundary coincides with a block boundary, so per-row block resets and the flattened-stream
+/// addressing are bit-identical (which is why the fast paths have worked for every 128-aligned
+/// model to date). Ragged rows are decoded via <see cref="I2SRaggedCode"/> /
+/// <see cref="UnpackRowRagged"/>, a scalar correctness-first path that computes the flattened
+/// block/bit address per element directly; it is reached only when <c>k % 128 != 0</c> and never
+/// perturbs the aligned SIMD paths.</para>
 /// </summary>
 public static unsafe partial class MatMul
 {
@@ -109,10 +129,14 @@ public static unsafe partial class MatMul
     public static void GemvI2_S(byte* weights, float* x, float* result, int m, int k,
                                 ComputeThreadPool? threadPool)
     {
-        if (k % I2SBlockSize != 0)
-            throw new ArgumentException($"k must be a multiple of {I2SBlockSize}, got {k}", nameof(k));
-
         float scale = Unsafe.ReadUnaligned<float>(weights + (long)m * k / 4);
+
+        if (k % I2SBlockSize != 0)
+        {
+            GemvI2_SRaggedCore(weights, x, result, m, k, scale, threadPool);
+            return;
+        }
+
         GemvI2_SCore(weights, x, result, m, k, scale, threadPool);
     }
 
@@ -129,7 +153,10 @@ public static unsafe partial class MatMul
                                 float scale, ComputeThreadPool? threadPool)
     {
         if (k % I2SBlockSize != 0)
-            throw new ArgumentException($"k must be a multiple of {I2SBlockSize}, got {k}", nameof(k));
+        {
+            GemvI2_SRaggedCore(weights, x, result, m, k, scale, threadPool);
+            return;
+        }
         GemvI2_SCore(weights, x, result, m, k, scale, threadPool);
     }
 
@@ -207,10 +234,14 @@ public static unsafe partial class MatMul
             return;
         }
 
-        if (k % I2SBlockSize != 0)
-            throw new ArgumentException($"k must be a multiple of {I2SBlockSize}, got {k}", nameof(k));
-
         float scale = Unsafe.ReadUnaligned<float>(weights + (long)m * k / 4);
+
+        if (k % I2SBlockSize != 0)
+        {
+            GemmI2_SRaggedCore(weights, b, c, m, k, n, scale, threadPool);
+            return;
+        }
+
         GemmI2_SCore(weights, b, c, m, k, n, scale, threadPool);
     }
 
@@ -234,7 +265,10 @@ public static unsafe partial class MatMul
         }
 
         if (k % I2SBlockSize != 0)
-            throw new ArgumentException($"k must be a multiple of {I2SBlockSize}, got {k}", nameof(k));
+        {
+            GemmI2_SRaggedCore(weights, b, c, m, k, n, scale, threadPool);
+            return;
+        }
 
         GemmI2_SCore(weights, b, c, m, k, n, scale, threadPool);
     }
@@ -283,6 +317,146 @@ public static unsafe partial class MatMul
             for (int r = startRow; r < startRow + rowCount; r++)
             {
                 UnpackRow(weights + (long)r * rowBytes, rowSpan, k);
+                for (int t = 0; t < n; t++)
+                {
+                    var xSpan = new ReadOnlySpan<float>(b + (long)t * k, k);
+                    c[(long)t * m + r] = TensorPrimitives.Dot((ReadOnlySpan<float>)rowSpan, xSpan) * scale;
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(rowBuf);
+        }
+    }
+
+    // ─────────────────────────── Ragged K (k % 128 != 0) — issue #206 ───────────────────────────
+    //
+    // Correctness-first scalar path. Reached ONLY when k % I2SBlockSize != 0 (see the class-level
+    // remarks for why the 128-aligned fast paths above cannot simply be reused with a "tail
+    // cleanup" — the on-disk block interleave is computed over the flattened m*k stream, so most
+    // ragged rows don't even start on a block boundary). Never invoked for aligned tensors, so it
+    // cannot regress the benchmarked common-case performance.
+
+    /// <summary>
+    /// Decodes the raw 2-bit ternary code (0, 1, 2 — caller subtracts 1 for {-1,0,+1}) at
+    /// flattened element index <paramref name="flatIndex"/> of a ragged I2_S tensor, using the
+    /// tensor-global (not per-row) 128-element block interleave. Block <c>b = flatIndex/128</c>
+    /// occupies packed bytes <c>[b·32, b·32+32)</c>; within a block, in-block position
+    /// <c>p = flatIndex%128</c> maps to byte <c>b·32 + p%32</c> and 2-bit field
+    /// <c>(p/32)</c> at bit offset <c>6 − 2·(p/32)</c> (same bit convention as the aligned
+    /// <see cref="UnpackRow"/>/<see cref="UnpackRowI8"/>, just addressed relative to the whole
+    /// tensor rather than one row).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int I2SRaggedCode(byte* tensorBase, long flatIndex)
+    {
+        long block = flatIndex >> 7;           // flatIndex / 128
+        int inBlock = (int)(flatIndex & 127);   // flatIndex % 128
+        int groupPos = inBlock & 31;            // byte within the block's 32 bytes
+        int groupIdx = inBlock >> 5;            // which of the 4 interleaved slots (0..3)
+        byte packed = tensorBase[block * 32 + groupPos];
+        int shift = 6 - 2 * groupIdx;
+        return (packed >> shift) & 0x3;
+    }
+
+    /// <summary>
+    /// Unpacks logical row <paramref name="row"/> (arbitrary <paramref name="k"/>, need not be
+    /// 128-aligned) of a ragged I2_S tensor into float {-1,0,+1} via <see cref="I2SRaggedCode"/>.
+    /// <paramref name="tensorBase"/> is the tensor's packed-payload base (element 0 of row 0) —
+    /// the SAME pointer the aligned paths call "weights".
+    /// </summary>
+    [SkipLocalsInit]
+    private static void UnpackRowRagged(byte* tensorBase, long row, int k, Span<float> dest)
+    {
+        long rowStart = row * (long)k;
+        for (int col = 0; col < k; col++)
+            dest[col] = I2SRaggedCode(tensorBase, rowStart + col) - 1;
+    }
+
+    [SkipLocalsInit]
+    private static void GemvI2_SRaggedCore(byte* weights, float* x, float* result, int m, int k,
+                                           float scale, ComputeThreadPool? threadPool)
+    {
+        if (threadPool is null || m < ParallelMinRows)
+        {
+            GemvI2_SRaggedRows(weights, x, result, 0, m, k, scale);
+            return;
+        }
+
+        var ctx = new GemvI2SCtx { Weights = weights, X = x, Result = result, M = m, K = k, Scale = scale };
+        threadPool.Dispatch((nint)(&ctx), &GemvI2_SRaggedWorker);
+    }
+
+    [SkipLocalsInit]
+    private static void GemvI2_SRaggedWorker(nint ctxPtr, int threadIdx, int threadCount)
+    {
+        ref var ctx = ref Unsafe.AsRef<GemvI2SCtx>((void*)ctxPtr);
+        PartitionRows(ctx.M, threadIdx, threadCount, out int start, out int count);
+        if (count == 0) return;
+        GemvI2_SRaggedRows(ctx.Weights, ctx.X, ctx.Result, start, count, ctx.K, ctx.Scale);
+    }
+
+    /// <summary>Ragged twin of <see cref="GemvI2_SRows"/> — unpacks each row via the
+    /// tensor-global addressing (<see cref="UnpackRowRagged"/>) instead of the per-row-reset
+    /// fast unpack, since row boundaries don't generally align with block boundaries here.</summary>
+    [SkipLocalsInit]
+    private static void GemvI2_SRaggedRows(byte* weights, float* x, float* result,
+                                           int startRow, int rowCount, int k, float scale)
+    {
+        var xSpan = new ReadOnlySpan<float>(x, k);
+
+        float[] rowBuf = ArrayPool<float>.Shared.Rent(k);
+        try
+        {
+            var rowSpan = rowBuf.AsSpan(0, k);
+            for (int r = startRow; r < startRow + rowCount; r++)
+            {
+                UnpackRowRagged(weights, r, k, rowSpan);
+                result[r] = TensorPrimitives.Dot((ReadOnlySpan<float>)rowSpan, xSpan) * scale;
+            }
+        }
+        finally
+        {
+            ArrayPool<float>.Shared.Return(rowBuf);
+        }
+    }
+
+    [SkipLocalsInit]
+    private static void GemmI2_SRaggedCore(byte* weights, float* b, float* c, int m, int k, int n,
+                                           float scale, ComputeThreadPool? threadPool)
+    {
+        if (threadPool is null || m < ParallelMinRows)
+        {
+            GemmI2_SRaggedRows(weights, b, c, m, 0, m, k, n, scale);
+            return;
+        }
+
+        var ctx = new GemmI2SCtx { Weights = weights, B = b, C = c, M = m, K = k, N = n, Scale = scale };
+        threadPool.Dispatch((nint)(&ctx), &GemmI2_SRaggedWorker);
+    }
+
+    [SkipLocalsInit]
+    private static void GemmI2_SRaggedWorker(nint ctxPtr, int threadIdx, int threadCount)
+    {
+        ref var ctx = ref Unsafe.AsRef<GemmI2SCtx>((void*)ctxPtr);
+        PartitionRows(ctx.M, threadIdx, threadCount, out int start, out int count);
+        if (count == 0) return;
+        GemmI2_SRaggedRows(ctx.Weights, ctx.B, ctx.C, ctx.M, start, count, ctx.K, ctx.N, ctx.Scale);
+    }
+
+    /// <summary>Ragged twin of <see cref="GemmI2_SRows"/>.</summary>
+    [SkipLocalsInit]
+    private static void GemmI2_SRaggedRows(byte* weights, float* b, float* c, int m,
+                                           int startRow, int rowCount, int k, int n, float scale)
+    {
+        float[] rowBuf = ArrayPool<float>.Shared.Rent(k);
+        try
+        {
+            var rowSpan = rowBuf.AsSpan(0, k);
+            for (int r = startRow; r < startRow + rowCount; r++)
+            {
+                UnpackRowRagged(weights, r, k, rowSpan);
                 for (int t = 0; t < n; t++)
                 {
                     var xSpan = new ReadOnlySpan<float>(b + (long)t * k, k);
@@ -680,14 +854,17 @@ public static unsafe partial class MatMul
     /// <param name="n">Number of input rows (token·slot assignments).</param>
     /// <param name="rowExpertIds">Length-<paramref name="n"/> expert id assigned to each input row.</param>
     /// <param name="threadPool">Optional thread pool — forwarded to the per-expert GEMM.</param>
+    /// <remarks>
+    /// <paramref name="k"/> need not be a multiple of 128 (issue #206) — the per-expert batched
+    /// GEMM below (<see cref="GemmI2_S(byte*, float*, float*, int, int, int, float, ComputeThreadPool?)"/>)
+    /// already dispatches to the ragged-safe path when <c>k % 128 != 0</c>, so no guard is needed here.
+    /// </remarks>
     [SkipLocalsInit]
     public static void MoeIndexedMatmulI2_S(
         byte* expertWeights, long expertRowBytes, ReadOnlySpan<float> expertScales,
         float* b, float* c, int m, int k, int n,
         ReadOnlySpan<int> rowExpertIds, ComputeThreadPool? threadPool)
     {
-        if (k % I2SBlockSize != 0)
-            throw new ArgumentException($"k must be a multiple of {I2SBlockSize}, got {k}", nameof(k));
         if (rowExpertIds.Length < n)
             throw new ArgumentException("rowExpertIds too small", nameof(rowExpertIds));
         if (n == 0) return;

--- a/src/DotLLM.Cuda/CudaKernels.cs
+++ b/src/DotLLM.Cuda/CudaKernels.cs
@@ -192,6 +192,10 @@ public sealed unsafe class CudaKernels : IDisposable
     private readonly nint _i2sGemvA8DeviceScaleFunc;
     private readonly nint _quantizeF16ToI8AbsMaxFunc;
     private readonly nint _dequantI2sF16Func;
+    // Ragged K (k % 128 != 0) — issue #206.
+    private readonly nint _i2sGemvF16InRaggedFunc;
+    private readonly nint _i2sGemvF32InRaggedFunc;
+    private readonly nint _dequantI2sF16RaggedFunc;
     private readonly nint _pq2_0GemvF32InFunc;
     private readonly nint _pq2_0GemvF16InFunc;
     private readonly nint _pq2_0Gemv2F16InFunc;
@@ -614,6 +618,10 @@ public sealed unsafe class CudaKernels : IDisposable
         _i2sGemvA8DeviceScaleFunc = _i2sGemvModule.GetFunction("i2_s_gemv_a8_device_scale");
         _quantizeF16ToI8AbsMaxFunc = _i2sGemvModule.GetFunction("quantize_f16_to_i8_absmax");
         _dequantI2sF16Func = _dequantI2sModule.GetFunction("dequant_i2_s_f16");
+        // Ragged K (k % 128 != 0) — issue #206.
+        _i2sGemvF16InRaggedFunc = _i2sGemvModule.GetFunction("i2_s_gemv_f16in_ragged");
+        _i2sGemvF32InRaggedFunc = _i2sGemvModule.GetFunction("i2_s_gemv_f32in_ragged");
+        _dequantI2sF16RaggedFunc = _dequantI2sModule.GetFunction("dequant_i2_s_f16_ragged");
         _pq2_0GemvF32InFunc = _pq2_0GemvModule.GetFunction("pq2_0_gemv_f32in");
         _pq2_0GemvF16InFunc = _pq2_0GemvModule.GetFunction("pq2_0_gemv_f16in");
         _pq2_0Gemv2F16InFunc = _pq2_0GemvModule.GetFunction("pq2_0_gemv2_f16in");
@@ -1269,6 +1277,38 @@ public sealed unsafe class CudaKernels : IDisposable
                 0, stream, (nint)args, 0).ThrowOnError();
     }
 
+    // Ragged K (k % 128 != 0) — issue #206. i2_s_gemv_{f16,f32}in_ragged use ONE warp per row
+    // (8 rows/block, fixed — not I2sRowsPerBlock, which encodes the aligned kernel's
+    // ROWS_PER_WARP=2 tuning) since they don't share the aligned kernels' uint4/shared-block
+    // launch contract. See i2_s_gemv.cu's issue #206 comment for why a ragged row cannot reuse the
+    // aligned addressing even for a "tail cleanup".
+    private const int I2sRaggedRowsPerBlock = 8;
+
+    /// <summary>
+    /// Ragged-K (<c>k % 128 != 0</c>) twin of <see cref="LaunchI2_SGemvF16In"/>. Scalar
+    /// correctness-first fallback — see <c>i2_s_gemv_f16in_ragged</c> in i2_s_gemv.cu.
+    /// </summary>
+    public void LaunchI2_SGemvF16InRagged(nint quantWeight, nint xF16, nint yF16, int n, int k, nint stream)
+    {
+        nint wArg = quantWeight, xArg = xF16, yArg = yF16;
+        int nArg = n, kArg = k;
+        void** args = stackalloc void*[] {&wArg, &xArg, &yArg, &nArg, &kArg};
+        CudaDriverApi.cuLaunchKernel(_i2sGemvF16InRaggedFunc,
+                (uint)((n + I2sRaggedRowsPerBlock - 1) / I2sRaggedRowsPerBlock), 1, 1, BlockSize, 1, 1,
+                0, stream, (nint)args, 0).ThrowOnError();
+    }
+
+    /// <summary>Ragged-K (<c>k % 128 != 0</c>) twin of <see cref="LaunchI2_SGemvF32In"/>.</summary>
+    public void LaunchI2_SGemvF32InRagged(nint quantWeight, nint xF32, nint yF32, int n, int k, nint stream)
+    {
+        nint wArg = quantWeight, xArg = xF32, yArg = yF32;
+        int nArg = n, kArg = k;
+        void** args = stackalloc void*[] {&wArg, &xArg, &yArg, &nArg, &kArg};
+        CudaDriverApi.cuLaunchKernel(_i2sGemvF32InRaggedFunc,
+                (uint)((n + I2sRaggedRowsPerBlock - 1) / I2sRaggedRowsPerBlock), 1, 1, BlockSize, 1, 1,
+                0, stream, (nint)args, 0).ThrowOnError();
+    }
+
     /// <summary>
     /// I2_S ternary GEMV (W2A8, <c>__dp4a</c>): <c>y_f32[n] = scale · invActScale · int8dot(W[n,k], xq[k])</c>.
     /// Activations <paramref name="xqInt8"/> must be quantized per token (symmetric absmax,
@@ -1333,6 +1373,28 @@ public sealed unsafe class CudaKernels : IDisposable
         if (gridDim == 0) gridDim = 1;
 
         CudaDriverApi.cuLaunchKernel(_dequantI2sF16Func,
+                gridDim, 1, 1, BlockSize, 1, 1,
+                0, stream, (nint)args, 0).ThrowOnError();
+    }
+
+    /// <summary>
+    /// Ragged-K (<c>k % 128 != 0</c>) twin of <see cref="LaunchDequantI2_SToF16"/>. The aligned
+    /// kernel's <c>blocks_per_row = k/128</c> integer division silently drops each row's tail
+    /// elements for a ragged k, so this dispatches a one-thread-per-output-element grid-stride
+    /// kernel (<c>dequant_i2_s_f16_ragged</c>) that derives each element's block/bit address
+    /// directly from its flattened index instead. See issue #206.
+    /// </summary>
+    public void LaunchDequantI2_SToF16Ragged(nint src, nint dst, int n, int k, nint stream)
+    {
+        nint srcArg = src, dstArg = dst;
+        int nArg = n, kArg = k;
+        void** args = stackalloc void*[] {&srcArg, &dstArg, &nArg, &kArg};
+
+        long totalElems = (long)n * k;
+        uint gridDim = (uint)Math.Min((totalElems + BlockSize - 1) / BlockSize, MaxDequantGridSize);
+        if (gridDim == 0) gridDim = 1;
+
+        CudaDriverApi.cuLaunchKernel(_dequantI2sF16RaggedFunc,
                 gridDim, 1, 1, BlockSize, 1, 1,
                 0, stream, (nint)args, 0).ThrowOnError();
     }

--- a/src/DotLLM.Cuda/CudaTransformerModel.cs
+++ b/src/DotLLM.Cuda/CudaTransformerModel.cs
@@ -2554,7 +2554,11 @@ public sealed unsafe class CudaTransformerModel : IModel
             if (w == 0)
             {
                 // Quantized: dequant into scratch, then GEMM
-                if (qt == QuantizationType.I2_S)
+                if (qt == QuantizationType.I2_S && inputDim % I2SBlockSize128 != 0)
+                    // Ragged K (issue #206): the aligned dequant kernel's blocks_per_row=k/128
+                    // integer division would silently drop each row's tail elements.
+                    _kernels.LaunchDequantI2_SToF16Ragged(quantWeight, _state.DequantScratch, outputDim, inputDim, s);
+                else if (qt == QuantizationType.I2_S)
                     _kernels.LaunchDequantI2_SToF16(quantWeight, _state.DequantScratch, outputDim, inputDim, s);
                 else if (qt == QuantizationType.PQ2_0)
                     _kernels.LaunchDequantPQ2_0ToF16(quantWeight, _state.DequantScratch, outputDim, inputDim, s);
@@ -2571,6 +2575,12 @@ public sealed unsafe class CudaTransformerModel : IModel
             _kernels.LaunchI2_SGemvA8DeviceScale(
                 quantWeight, _state.A8Input, _state.A8OutputF32, outputDim, inputDim, _state.A8InvScale, s);
             _kernels.LaunchConvertF32ToF16(_state.A8OutputF32, output, outputDim, s);
+        }
+        else if (quantWeight != 0 && qt == QuantizationType.I2_S && inputDim % I2SBlockSize128 != 0)
+        {
+            // Ragged K (issue #206): the aligned GEMV kernel's uint4/block addressing assumes
+            // k % 128 == 0 and would read misaligned/wrong data (CUDA error 716) otherwise.
+            _kernels.LaunchI2_SGemvF16InRagged(quantWeight, input, output, outputDim, inputDim, s);
         }
         else if (quantWeight != 0 && qt == QuantizationType.I2_S) // Decode: I2_S ternary GEMV
         {
@@ -2659,6 +2669,14 @@ public sealed unsafe class CudaTransformerModel : IModel
         }
     }
 
+    // The fused multi-tensor GEMV kernels (i2_s_gemv2/3_f16in) and the W2A8 int8-activation
+    // kernel share the SAME 128-aligned uint4/block addressing as the single-tensor fast path
+    // (i2_s_gemv_f16in) — none of them are ragged-safe (see MatMul.I2S.cs's class remarks / issue
+    // #206 for why a ragged row doesn't even start on a block boundary in general). Gating every
+    // fusion/A8 predicate on `inputDim % I2SBlockSize128 == 0` routes ragged projections through
+    // the single-tensor Project() fallback, which dispatches to the ragged-safe kernel instead.
+    private const int I2SBlockSize128 = 128;
+
     private static bool CanFuseI2SDecode(
         int seqLen,
         QuantizationType qt0, QuantizationType qt1,
@@ -2666,7 +2684,8 @@ public sealed unsafe class CudaTransformerModel : IModel
         => seqLen == 1
            && qt0 == QuantizationType.I2_S
            && qt1 == QuantizationType.I2_S
-           && inputDim0 == inputDim1;
+           && inputDim0 == inputDim1
+           && inputDim0 % I2SBlockSize128 == 0;
 
     private static bool CanFuseI2SDecode(
         int seqLen,
@@ -2677,7 +2696,8 @@ public sealed unsafe class CudaTransformerModel : IModel
            && qt1 == QuantizationType.I2_S
            && qt2 == QuantizationType.I2_S
            && inputDim0 == inputDim1
-           && inputDim0 == inputDim2;
+           && inputDim0 == inputDim2
+           && inputDim0 % I2SBlockSize128 == 0;
 
     private static bool CanFuseI2SNormDecode(
         int seqLen,
@@ -2688,7 +2708,8 @@ public sealed unsafe class CudaTransformerModel : IModel
         => seqLen == 1
            && normWeight != 0
            && qt == QuantizationType.I2_S
-           && inputDim == normDim;
+           && inputDim == normDim
+           && inputDim % I2SBlockSize128 == 0;
 
     private bool CanUseI2SA8Project(QuantizationType qt, int seqLen, int outputDim, int inputDim)
         => s_i2sA8Decode
@@ -2697,7 +2718,8 @@ public sealed unsafe class CudaTransformerModel : IModel
            && Config.Architecture == Architecture.BitNet
            && outputDim != Config.VocabSize
            && inputDim <= Math.Max(Config.HiddenSize, Config.IntermediateSize)
-           && outputDim <= Math.Max(Config.HiddenSize, Config.IntermediateSize);
+           && outputDim <= Math.Max(Config.HiddenSize, Config.IntermediateSize)
+           && inputDim % I2SBlockSize128 == 0;
 
     /// <summary>
     /// Creates a <see cref="CudaKvCache"/> for this model.

--- a/src/DotLLM.Cuda/HybridTransformerModel.cs
+++ b/src/DotLLM.Cuda/HybridTransformerModel.cs
@@ -997,7 +997,12 @@ public sealed unsafe class HybridTransformerModel : IModel
             nint w = fp16Weight;
             if (w == 0)
             {
-                if (qt == QuantizationType.I2_S)
+                // Ragged K (issue #206) — see CudaTransformerModel.Project for the full rationale:
+                // the aligned dequant/GEMV kernels assume k % 128 == 0 and silently drop tail
+                // elements (dequant) or read misaligned memory (GEMV) otherwise.
+                if (qt == QuantizationType.I2_S && inputDim % 128 != 0)
+                    _kernels.LaunchDequantI2_SToF16Ragged(quantWeight, _gpuState.DequantScratch, outputDim, inputDim, s);
+                else if (qt == QuantizationType.I2_S)
                     _kernels.LaunchDequantI2_SToF16(quantWeight, _gpuState.DequantScratch, outputDim, inputDim, s);
                 else
                     _kernels.LaunchDequantToF16(quantWeight, qt, _gpuState.DequantScratch,
@@ -1005,6 +1010,10 @@ public sealed unsafe class HybridTransformerModel : IModel
                 w = _gpuState.DequantScratch;
             }
             CudaGemm.LinearF16(_cublas.Handle, input, w, output, seqLen, inputDim, outputDim, s);
+        }
+        else if (quantWeight != 0 && qt == QuantizationType.I2_S && inputDim % 128 != 0)
+        {
+            _kernels.LaunchI2_SGemvF16InRagged(quantWeight, input, output, outputDim, inputDim, s);
         }
         else if (quantWeight != 0 && qt == QuantizationType.I2_S)
         {

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2STests.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/I2STests.cs
@@ -201,6 +201,201 @@ public sealed unsafe class I2STests
         finally { NativeMemory.Free(w); }
     }
 
+    // ──────────────────── Ragged K (k % 128 != 0) — issue #206 ────────────────────
+    //
+    // Most published I2_S checkpoints have k an exact multiple of 128 (e.g. BitNet-2B-4T:
+    // 2560/6912), which is what MatMul.I2S.cs's dedicated 128-block-interleave layout above
+    // assumes. At least one real checkpoint (1bitLLM-style bitnet_b1_58-large/-xl: hidden=2048,
+    // intermediate=5460, 5460 % 128 == 84) genuinely has a ragged row length on ffn_down. Before
+    // this fix, GemvI2_S/GemmI2_S threw ArgumentException for any k % 128 != 0.
+    //
+    // PackI2S (below) already packs via the flattened-index formula `block = e/128, j = e%128`
+    // (matching the real on-disk layout — the block interleave is computed over the tensor's
+    // flattened m*k stream, NOT reset per row; see MatMul.I2S.cs's class remarks), so it's the
+    // correct reference packer for ragged k too — no changes needed there. Test tensor totals
+    // (m*k) are chosen as exact multiples of 128 so PackI2S's zero-alloc buffer sizing
+    // (n/4 + 4 bytes) stays exact, matching how every real BitNet GGUF is shaped in practice.
+
+    [Fact]
+    public void GemvI2S_RaggedK_SmallSynthetic_MatchesDotOfDequantizedRows()
+    {
+        var rng = new Random(206);
+        const int m = 16;   // 16 rows exercises multiple distinct row-start bit-phases
+        const int k = 200;  // NOT a multiple of 128 (200 % 128 == 72) — m*k = 3200 = 25*128
+        sbyte[] ternary = new sbyte[m * k];
+        for (int i = 0; i < ternary.Length; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        const float scale = 0.05f;
+
+        float[] x = new float[k];
+        for (int i = 0; i < k; i++) x[i] = rng.NextSingle() * 2f - 1f;
+
+        byte* w = PackI2S(ternary, scale);
+        try
+        {
+            float[] y = new float[m];
+            fixed (float* xp = x)
+            fixed (float* yp = y)
+                MatMul.GemvI2_S(w, xp, yp, m, k, null);
+
+            for (int r = 0; r < m; r++)
+            {
+                float acc = 0f;
+                for (int c = 0; c < k; c++) acc += ternary[r * k + c] * scale * x[c];
+                Assert.Equal(acc, y[r], 1e-3f);
+            }
+        }
+        finally { NativeMemory.Free(w); }
+    }
+
+    /// <summary>Same shape as the "explicit scale" overload used by the indexed-MoE path.</summary>
+    [Fact]
+    public void GemvI2S_RaggedK_ExplicitScaleOverload_MatchesDotOfDequantizedRows()
+    {
+        var rng = new Random(207);
+        const int m = 16;
+        const int k = 200;
+        sbyte[] ternary = new sbyte[m * k];
+        for (int i = 0; i < ternary.Length; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        const float scale = 0.05f;
+
+        float[] x = new float[k];
+        for (int i = 0; i < k; i++) x[i] = rng.NextSingle() * 2f - 1f;
+
+        // Pack WITHOUT the tail scale (explicit-scale overload reads the packed payload only).
+        byte* w = (byte*)NativeMemory.AllocZeroed((nuint)(m * k / 4));
+        for (int e = 0; e < ternary.Length; e++)
+        {
+            int block = e / 128, j = e % 128;
+            int groupIdx = j / 32, groupPos = j % 32;
+            int code = ternary[e] + 1;
+            w[block * 32 + groupPos] |= (byte)(code << (6 - 2 * groupIdx));
+        }
+        try
+        {
+            float[] y = new float[m];
+            fixed (float* xp = x)
+            fixed (float* yp = y)
+                MatMul.GemvI2_S(w, xp, yp, m, k, scale, null);
+
+            for (int r = 0; r < m; r++)
+            {
+                float acc = 0f;
+                for (int c = 0; c < k; c++) acc += ternary[r * k + c] * scale * x[c];
+                Assert.Equal(acc, y[r], 1e-3f);
+            }
+        }
+        finally { NativeMemory.Free(w); }
+    }
+
+    [Fact]
+    public void GemmI2S_RaggedK_SmallSynthetic_MatchesDotOfDequantizedRows()
+    {
+        var rng = new Random(208);
+        const int m = 16;
+        const int k = 200;
+        const int n = 3; // tokens
+        sbyte[] ternary = new sbyte[m * k];
+        for (int i = 0; i < ternary.Length; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        const float scale = 0.021f;
+
+        float[] b = new float[n * k];
+        for (int i = 0; i < b.Length; i++) b[i] = rng.NextSingle() * 2f - 1f;
+
+        byte* w = PackI2S(ternary, scale);
+        try
+        {
+            float[] c = new float[n * m];
+            fixed (float* bp = b)
+            fixed (float* cp = c)
+                MatMul.GemmI2_S(w, bp, cp, m, k, n, null);
+
+            for (int t = 0; t < n; t++)
+            for (int r = 0; r < m; r++)
+            {
+                float acc = 0f;
+                for (int col = 0; col < k; col++)
+                    acc += ternary[r * k + col] * scale * b[t * k + col];
+                Assert.Equal(acc, c[t * m + r], 1e-3f);
+            }
+        }
+        finally { NativeMemory.Free(w); }
+    }
+
+    /// <summary>
+    /// The real bitnet_b1_58-xl shape (hidden=2048, intermediate=5460 → ffn_down k=5460).
+    /// m=32 is chosen deliberately: for k=5460, gcd(5460,128)=4, so consecutive row starts cycle
+    /// through 128/4=32 distinct bit-phases before repeating (row r starts at flattened bit
+    /// r·5460, and r·5460 mod 128 only returns to 0 every 32 rows) — using exactly 32 rows
+    /// exercises every one of those phases once, the strongest test this shape admits for
+    /// "does the ragged decoder handle a row that doesn't start on a block boundary".
+    /// </summary>
+    [Fact]
+    public void GemvI2S_RaggedK_RealBitNetXlFfnDownShape_MatchesDotOfDequantizedRows()
+    {
+        var rng = new Random(209);
+        const int m = 32;
+        const int k = 5460;
+        Assert.Equal(84, k % 128); // sanity: pin the real checkpoint's raggedness
+        Assert.Equal(0, (m * k) % 128); // sanity: PackI2S's exact-byte-sizing precondition
+
+        sbyte[] ternary = new sbyte[m * k];
+        for (int i = 0; i < ternary.Length; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        const float scale = 0.037f;
+
+        float[] x = new float[k];
+        for (int i = 0; i < k; i++) x[i] = rng.NextSingle() * 2f - 1f;
+
+        byte* w = PackI2S(ternary, scale);
+        try
+        {
+            float[] y = new float[m];
+            fixed (float* xp = x)
+            fixed (float* yp = y)
+                MatMul.GemvI2_S(w, xp, yp, m, k, null);
+
+            for (int r = 0; r < m; r++)
+            {
+                float acc = 0f;
+                for (int c = 0; c < k; c++) acc += ternary[r * k + c] * scale * x[c];
+                Assert.Equal(acc, y[r], 1e-2f);
+            }
+        }
+        finally { NativeMemory.Free(w); }
+    }
+
+    /// <summary>Same shape via the thread-pool-parallel dispatch path (GemvI2_SRaggedWorker).</summary>
+    [Fact]
+    public void GemvI2S_RaggedK_WithThreadPool_MatchesDotOfDequantizedRows()
+    {
+        var rng = new Random(210);
+        const int m = 64; // above ParallelMinRows so the pool path actually engages
+        const int k = 200;
+        sbyte[] ternary = new sbyte[m * k];
+        for (int i = 0; i < ternary.Length; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        const float scale = 0.05f;
+
+        float[] x = new float[k];
+        for (int i = 0; i < k; i++) x[i] = rng.NextSingle() * 2f - 1f;
+
+        byte* w = PackI2S(ternary, scale);
+        using var pool = new DotLLM.Cpu.Threading.ComputeThreadPool(4);
+        try
+        {
+            float[] y = new float[m];
+            fixed (float* xp = x)
+            fixed (float* yp = y)
+                MatMul.GemvI2_S(w, xp, yp, m, k, pool);
+
+            for (int r = 0; r < m; r++)
+            {
+                float acc = 0f;
+                for (int c = 0; c < k; c++) acc += ternary[r * k + c] * scale * x[c];
+                Assert.Equal(acc, y[r], 1e-3f);
+            }
+        }
+        finally { NativeMemory.Free(w); }
+    }
+
     private static void AssertWithinQuantTolerance(float expected, float actual)
     {
         // Absolute floor for near-zero sums; relative band for larger magnitudes.

--- a/tests/DotLLM.Tests.Unit/Cpu/Kernels/MoeIndexedMatmulI2STests.cs
+++ b/tests/DotLLM.Tests.Unit/Cpu/Kernels/MoeIndexedMatmulI2STests.cs
@@ -203,4 +203,77 @@ public sealed unsafe class MoeIndexedMatmulI2STests
             NativeMemory.Free(banks);
         }
     }
+
+    /// <summary>
+    /// Ragged K (issue #206): the indexed path used to guard <c>k % 128 == 0</c> explicitly, but
+    /// it always delegates to <see cref="MatMul.GemmI2_S(byte*, float*, float*, int, int, int, float, DotLLM.Cpu.Threading.ComputeThreadPool?)"/>
+    /// per touched expert, which is now ragged-safe — so the guard was simply removed. Proves the
+    /// indexed path still matches the dense reference when k is not a multiple of 128.
+    ///
+    /// <para>m is chosen so <c>m*k</c> (the total per-expert element count) is itself an exact
+    /// multiple of 128 (gcd(200,128)=8, so m must be a multiple of 16) — matching how every real
+    /// I2_S GGUF tensor is shaped (the flattened-block packing never leaves an unwritten partial
+    /// tail at the very end of the tensor; a total that isn't 128-aligned would need its own
+    /// "implicit zero tail" handling, out of this issue's scope since no real checkpoint needs
+    /// it — see PackI2S's byte-sizing note in I2STests.cs for why this matters for the test
+    /// packer specifically).</para>
+    /// </summary>
+    [Fact]
+    public void RaggedK_MatchesDenseI2SGemm()
+    {
+        var rng = new Random(206);
+        const int m = 16;   // m*k = 3200 = 25*128 (exact — see remarks above)
+        const int k = 200;   // NOT a multiple of 128 (200 % 128 == 72)
+        const int n = 9;
+        const int numExperts = 3;
+        const float scale = 0.031f;
+
+        sbyte[] ternary = new sbyte[m * k];
+        for (int i = 0; i < ternary.Length; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        float[] bAct = new float[n * k];
+        for (int i = 0; i < bAct.Length; i++) bAct[i] = rng.NextSingle() * 2f - 1f;
+
+        byte* dense = PackI2SWithTailScale(ternary, scale);
+        float[] cDense = new float[n * m];
+
+        long payloadBytes = (long)m * k / 4;
+        byte* banks = (byte*)NativeMemory.AllocZeroed((nuint)(payloadBytes * numExperts));
+        float[] expertScales = new float[numExperts];
+        int[] rowExpertIds = new int[n];
+        float[] cIndexed = new float[n * m];
+
+        try
+        {
+            for (int e = 0; e < numExperts; e++)
+            {
+                PackI2SPayloadOnly(ternary, banks + e * payloadBytes);
+                expertScales[e] = scale;
+            }
+            for (int t = 0; t < n; t++) rowExpertIds[t] = t % numExperts;
+
+            fixed (float* bp = bAct)
+            fixed (float* cdp = cDense)
+            fixed (float* cip = cIndexed)
+            fixed (float* scalesPtr = expertScales)
+            fixed (int* rowPtr = rowExpertIds)
+            {
+                MatMul.GemmI2_S(dense, bp, cdp, m, k, n, threadPool: null);
+
+                MatMul.MoeIndexedMatmulI2_S(
+                    banks, payloadBytes,
+                    new ReadOnlySpan<float>(scalesPtr, numExperts),
+                    bp, cip, m, k, n,
+                    new ReadOnlySpan<int>(rowPtr, n),
+                    threadPool: null);
+            }
+
+            for (int i = 0; i < n * m; i++)
+                AssertWithinTolerance(cDense[i], cIndexed[i]);
+        }
+        finally
+        {
+            NativeMemory.Free(dense);
+            NativeMemory.Free(banks);
+        }
+    }
 }

--- a/tests/DotLLM.Tests.Unit/Cuda/CudaI2SGemvTest.cs
+++ b/tests/DotLLM.Tests.Unit/Cuda/CudaI2SGemvTest.cs
@@ -406,6 +406,171 @@ public class CudaI2SGemvTest
         Assert.True(meanDiff <= 1e-5f, $"mean abs diff {meanDiff} exceeds 1e-5");
     }
 
+    // ──────────────────── Ragged K (k % 128 != 0) — issue #206 ────────────────────
+    //
+    // The aligned kernels above assume k % 128 == 0 (uint4/shared-block addressing) and crash
+    // with "CUDA error 716: misaligned address" otherwise. i2_s_gemv_f32in_ragged /
+    // dequant_i2_s_f16_ragged are the correctness-first fallbacks reached when k is not
+    // 128-aligned (e.g. bitnet_b1_58-xl's ffn_down: hidden=2048, intermediate=5460).
+
+    [SkippableTheory]
+    [InlineData(16, 200)]   // small synthetic ragged k (200 % 128 == 72)
+    [InlineData(32, 5460)]  // real bitnet_b1_58-xl ffn_down shape; m=32 covers all 32 distinct
+                             // row-start bit-phases for k=5460 (gcd(5460,128)=4 -> period 32)
+    public void I2SGemvF32InRagged_MatchesCpuFloatReference(int n, int k)
+    {
+        Skip.IfNot(IsCudaDriverPresent(), "No CUDA GPU available");
+        RunRagged(n, k);
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private unsafe void RunRagged(int n, int k)
+    {
+        Assert.NotEqual(0, k % 128); // sanity: this test exists specifically for ragged k
+        Assert.Equal(0, ((long)n * k) % 128); // PackRagged's exact-byte-sizing precondition
+
+        var rng = new Random(1234);
+        long total = (long)n * k;
+        long packedLen = total / 4 + 4;
+
+        sbyte[] ternary = new sbyte[total];
+        for (long i = 0; i < ternary.LongLength; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        float scale = 0.02f + (float)rng.NextDouble() * 0.03f;
+        byte[] packed = PackRagged(ternary, n, k, scale);
+
+        float[] x = new float[k];
+        for (int i = 0; i < k; i++) x[i] = (float)(rng.NextDouble() * 2 - 1) * 0.5f;
+
+        // CPU reference (now ragged-safe — MatMul.GemvI2_S dispatches to the ragged path itself).
+        float[] cpu = new float[n];
+        fixed (byte* w = packed)
+        fixed (float* px = x, py = cpu)
+            MatMul.GemvI2_S(w, px, py, n, k, null);
+
+        // GPU (ragged kernel).
+        float[] gpu;
+        {
+            using var ctx = CudaContext.Create(0);
+            using var stream = CudaStream.Create();
+            string? ptxDir = FindPtxDir();
+            Skip.If(ptxDir == null, "PTX files not found");
+            using var kernels = new CudaKernels(ptxDir!);
+            nint s = stream.Handle;
+
+            CudaDriverApi.cuMemAlloc_v2(out nint devW, (nuint)packedLen).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out nint devX, (nuint)((long)k * sizeof(float))).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out nint devY, (nuint)((long)n * sizeof(float))).ThrowOnError();
+            try
+            {
+                fixed (byte* w = packed)
+                    CudaDriverApi.cuMemcpyHtoD_v2(devW, (nint)w, (nuint)packedLen).ThrowOnError();
+                fixed (float* px = x)
+                    CudaDriverApi.cuMemcpyHtoD_v2(devX, (nint)px, (nuint)((long)k * sizeof(float))).ThrowOnError();
+
+                kernels.LaunchI2_SGemvF32InRagged(devW, devX, devY, n, k, s);
+                stream.Synchronize();
+
+                gpu = new float[n];
+                fixed (float* py = gpu)
+                    CudaDriverApi.cuMemcpyDtoH_v2((nint)py, devY, (nuint)((long)n * sizeof(float))).ThrowOnError();
+            }
+            finally
+            {
+                CudaDriverApi.cuMemFree_v2(devW);
+                CudaDriverApi.cuMemFree_v2(devX);
+                CudaDriverApi.cuMemFree_v2(devY);
+            }
+        }
+
+        float maxDiff = 0, sumDiff = 0;
+        for (int i = 0; i < n; i++)
+        {
+            float d = MathF.Abs(cpu[i] - gpu[i]);
+            sumDiff += d;
+            if (d > maxDiff) maxDiff = d;
+        }
+        float meanDiff = sumDiff / n;
+        _out.WriteLine($"I2_S GEMV ragged {n}×{k}: max abs diff={maxDiff:E4}, mean={meanDiff:E4}");
+
+        Assert.True(maxDiff <= 1e-3f, $"max abs diff {maxDiff} exceeds 1e-3 (CPU vs GPU should match to fp32)");
+        Assert.True(meanDiff <= 1e-4f, $"mean abs diff {meanDiff} exceeds 1e-4");
+    }
+
+    [SkippableTheory]
+    [InlineData(16, 200)]
+    [InlineData(32, 5460)]
+    public void DequantI2_SToF16Ragged_MatchesCpuReference(int n, int k)
+    {
+        Skip.IfNot(IsCudaDriverPresent(), "No CUDA GPU available");
+        RunDequantRagged(n, k);
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private unsafe void RunDequantRagged(int n, int k)
+    {
+        Assert.NotEqual(0, k % 128);
+        Assert.Equal(0, ((long)n * k) % 128);
+
+        var rng = new Random(3456);
+        long total = (long)n * k;
+        long packedLen = total / 4 + 4;
+
+        sbyte[] ternary = new sbyte[total];
+        for (long i = 0; i < ternary.LongLength; i++) ternary[i] = (sbyte)(rng.Next(3) - 1);
+        float scale = 0.02f + (float)rng.NextDouble() * 0.03f;
+        byte[] packed = PackRagged(ternary, n, k, scale);
+
+        // CPU reference — DequantizeI2_S already treats elementCount as the flattened total, so
+        // it's already ragged-correct as long as the TOTAL element count is 128-aligned (which we
+        // assert above); no CPU-side change was needed for this path.
+        float[] cpu = new float[total];
+        fixed (byte* w = packed)
+            Dequantize.ToFloat32((nint)w, total, DotLLM.Core.Configuration.QuantizationType.I2_S, cpu);
+
+        Half[] gpu;
+        {
+            using var ctx = CudaContext.Create(0);
+            using var stream = CudaStream.Create();
+            string? ptxDir = FindPtxDir();
+            Skip.If(ptxDir == null, "PTX files not found");
+            using var kernels = new CudaKernels(ptxDir!);
+            nint s = stream.Handle;
+
+            CudaDriverApi.cuMemAlloc_v2(out nint devW, (nuint)packedLen).ThrowOnError();
+            CudaDriverApi.cuMemAlloc_v2(out nint devDst, (nuint)(total * sizeof(ushort))).ThrowOnError();
+            try
+            {
+                fixed (byte* w = packed)
+                    CudaDriverApi.cuMemcpyHtoD_v2(devW, (nint)w, (nuint)packedLen).ThrowOnError();
+
+                kernels.LaunchDequantI2_SToF16Ragged(devW, devDst, n, k, s);
+                stream.Synchronize();
+
+                gpu = new Half[total];
+                fixed (Half* p = gpu)
+                    CudaDriverApi.cuMemcpyDtoH_v2((nint)p, devDst, (nuint)(total * sizeof(ushort))).ThrowOnError();
+            }
+            finally
+            {
+                CudaDriverApi.cuMemFree_v2(devW);
+                CudaDriverApi.cuMemFree_v2(devDst);
+            }
+        }
+
+        float maxAbsDiff = 0, sumAbsDiff = 0;
+        for (long i = 0; i < cpu.Length; i++)
+        {
+            float d = MathF.Abs(cpu[i] - (float)gpu[i]);
+            sumAbsDiff += d;
+            if (d > maxAbsDiff) maxAbsDiff = d;
+        }
+        float meanAbsDiff = sumAbsDiff / cpu.Length;
+        _out.WriteLine($"I2_S dequant ragged {n}×{k}: max abs diff={maxAbsDiff:E4}, mean={meanAbsDiff:E4}");
+
+        Assert.True(maxAbsDiff <= 5e-4f, $"max abs diff {maxAbsDiff} exceeds 5e-4 (F16 rounding vs CPU float32)");
+        Assert.True(meanAbsDiff <= 1e-4f, $"mean abs diff {meanAbsDiff} exceeds 1e-4");
+    }
+
     /// <summary>
     /// Microbenchmark: Variant A (W2A16, FP16 activations) vs Variant B (W2A8, dp4a int8 activations)
     /// at the GEMV level on the real BitNet projection shapes. Informational — always passes; run with
@@ -499,6 +664,29 @@ public class CudaI2SGemvTest
             }
         }
         BitConverter.GetBytes(scale).CopyTo(buf, (int)((long)n * rowBytes));
+        return buf;
+    }
+
+    /// <summary>
+    /// Ragged-K packer (issue #206): unlike <see cref="Pack"/> above, block boundaries are NOT
+    /// reset per row — the block interleave is computed over the FLATTENED n*k element stream
+    /// (matching the real on-disk layout / upstream bitnet.cpp writer; see MatMul.I2S.cs's class
+    /// remarks and I2STests.PackI2S, the CPU-side twin of this helper). For aligned k the two
+    /// packers are bit-identical (every row boundary is also a block boundary); they only diverge
+    /// when k % 128 != 0, which is exactly the case this helper exists to test.
+    /// </summary>
+    private static byte[] PackRagged(sbyte[] ternary, int n, int k, float scale)
+    {
+        long total = (long)n * k;
+        byte[] buf = new byte[total / 4 + 4];
+        for (long e = 0; e < total; e++)
+        {
+            long block = e / 128;
+            int j = (int)(e % 128), gi = j / 32, gp = j % 32;
+            int code = ternary[e] + 1;
+            buf[block * 32 + gp] |= (byte)(code << (6 - 2 * gi));
+        }
+        BitConverter.GetBytes(scale).CopyTo(buf, (int)(total / 4));
         return buf;
     }
 


### PR DESCRIPTION
## Summary

- I2_S (BitNet ternary) GEMV/GEMM hard-required `k % 128 == 0`, throwing on CPU and crashing with `CUDA error 716: misaligned address` on CUDA. At least one real checkpoint family (1bitLLM-style `bitnet_b1_58-large`/`-xl`: hidden=2048, intermediate=5460, `5460 % 128 == 84`) has a genuinely non-128-aligned `ffn_down` row length.
- Root cause (verified empirically against the real GGUF's tensor byte offsets, and against the upstream bitnet.cpp writer `ggml-bitnet-mad.cpp`'s `quantize_i2_s`): the 128-element block interleave is computed over the **flattened `m*k` element stream**, not reset at each row boundary. A ragged row therefore does not generally start on a block boundary at all (only every `128/gcd(k,128)`-th row does) — a "tail cleanup after the fast path" would have been wrong for most of a ragged tensor's rows, not just a trailing few elements. This is moot when `k % 128 == 0` (every row boundary is also a block boundary), which is why the aligned fast paths never noticed.
- **CPU** (`MatMul.I2S.cs`): `GemvI2_S`/`GemmI2_S` (both overloads) and `MoeIndexedMatmulI2_S` now dispatch to a new scalar, correctness-first ragged path (`I2SRaggedCode`/`UnpackRowRagged` + `GemvI2_SRaggedCore`/`GemmI2_SRaggedCore`) when `k % 128 != 0`, instead of throwing. The 128-aligned SIMD/W2A8 fast paths are byte-for-byte untouched.
- **CUDA** (`native/kernels/i2_s_gemv.cu`, `dequant_i2_s.cu`): new `i2_s_gemv_{f16,f32}in_ragged` and `dequant_i2_s_f16_ragged` kernels implement the same flattened-stream addressing (one warp per row / one thread per output element — no uint4/shared-block assumptions). `CudaTransformerModel.Project` and `HybridTransformerModel.ProjectGpu` dispatch to these when `inputDim % 128 != 0`; the fused multi-tensor GEMV kernels and the W2A8 int8-activation path (which share the aligned kernels' addressing) are gated off for ragged `inputDim` via `CanFuseI2SDecode`/`CanFuseI2SNormDecode`/`CanUseI2SA8Project`, falling through to the single-tensor ragged dispatch instead.
- Vulkan's I2_S kernel has the same `k % 128 == 0` guard but throws cleanly (no silent crash/corruption) — left out of scope for this issue, worth a fast follow-up issue.

Closes #206

## Test plan

- [x] CPU regression tests added (`I2STests.cs`): small synthetic ragged `k=200`, the explicit-scale overload, GEMM, the real `bitnet_b1_58-xl` `ffn_down` shape (`k=5460`, `m=32` chosen to cycle through all 32 distinct row-start bit-phases for this `k`), and the thread-pool-parallel dispatch path.
- [x] CPU MoE regression test added (`MoeIndexedMatmulI2STests.cs`): ragged `k` routed through the indexed per-expert batched GEMM.
- [x] CUDA regression tests added (`CudaI2SGemvTest.cs`, `[SkippableTheory]`/`Category=GPU`, gated on a live CUDA device): ragged GEMV (`k=200` and the real `k=5460` shape) and ragged dequant, each checked against the CPU reference — **run on the actual RTX 3060, 12/12 passed** (includes pre-existing aligned-K tests, confirming no regression).
- [x] `dotnet test` — dedicated I2_S/BitNet/MoE filter: **69/69 passed**.
- [x] `dotnet test` — full non-GPU suite (`Category!=GPU`): **2166 passed, 25 skipped, 0 failed, 2191 total** (zero regressions across the whole non-GPU surface).
- [x] Reproduced the original crash, then validated the fix against the real broken model (`E:/Development/bitnet-tests/models/bitnet_b1_58-xl/ggml-model-i2_s.gguf`):
  - CPU `-p 8 -n 4 -r 1`: completes, pp 6.57 tok/s, tg 0.77 tok/s.
  - CPU `-p 64 -n 32 -r 3`: completes across all 3 reps, pp ~16.8 tok/s median, tg ~0.74 tok/s median.
  - CUDA `-p 8 -n 4 -r 1`: completes (no misaligned-address crash), pp 67.2 tok/s, tg 153 tok/s.
  - CUDA `-p 64 -n 32 -r 3`: completes across all 3 reps, pp ~599 tok/s median, tg ~157 tok/s median.
  - All runs produced finite (non-NaN/non-Inf) output.
- [x] GPU confirmed idle (`nvidia-smi`, 0% util) before running CUDA tests/benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)