### PR TITLE
ci: add hang-timeout protection to test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     name: Unit Tests
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -51,12 +52,13 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Unit Tests
-        run: dotnet test tests/DotLLM.Tests.Unit/ -c Release --filter "Category!=GPU&Category!=Benchmark"
+        run: dotnet test tests/DotLLM.Tests.Unit/ -c Release --filter "Category!=GPU&Category!=Benchmark" --blame-hang-timeout 5m
 
   integration-tests:
     name: Integration Tests
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -78,4 +80,4 @@ jobs:
           key: dotllm-test-models-v2
 
       - name: Integration Tests
-        run: dotnet test tests/DotLLM.Tests.Integration/ -c Release
+        run: dotnet test tests/DotLLM.Tests.Integration/ -c Release --blame-hang-timeout 5m


### PR DESCRIPTION
## Summary

- Unit Tests hung for 70+ minutes on PR #214's CI run (cancelled manually; a re-run also exceeded 20+ minutes vs the ~2 minute baseline every other recent PR's Unit Tests job has taken — see #209's 1m47s, #211's 2m12s).
- Matches a pre-existing **test-host shutdown hang** three separate agents hit locally this session (issues #206, #207, #212) — occurs at final test-host teardown even after all tests have already passed, unrelated to any specific code change. `--blame-hang-timeout` reliably cut through it locally every time; the CI workflow had no equivalent protection, so a hang there would run until GitHub's default 6-hour job timeout, effectively blocking any PR indefinitely.
- Adds `--blame-hang-timeout 5m` to both `dotnet test` invocations (Unit + Integration), plus a 20-minute job-level `timeout-minutes` backstop on both jobs in case a hang isn't caught by blame's own detection mechanism.

Closes #215

## Test plan

- [x] YAML syntax valid (workflow file parses; no functional change to non-hanging runs — `--blame-hang-timeout` and `timeout-minutes` are no-ops when tests complete normally within the window)
- [ ] Will confirm CI itself runs cleanly on this PR (self-validating — if this PR's own CI is fast and green, the fix works and doesn't regress the normal case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)